### PR TITLE
Improvements to JS & TS parsing

### DIFF
--- a/src/language/javascript.rs
+++ b/src/language/javascript.rs
@@ -35,11 +35,9 @@ impl LanguageImpl for JavaScriptLanguage {
                 | "method_definition"
                 | "class_declaration"
                 | "arrow_function"
-                | "function"
                 | "export_statement"
                 | "jsx_element"
                 | "jsx_self_closing_element"
-                | "property_identifier"  // Added for JavaScript method names
                 | "class_body"           // Added for JavaScript class body
                 | "class" // Added for JavaScript class
         )

--- a/src/language/typescript.rs
+++ b/src/language/typescript.rs
@@ -43,7 +43,6 @@ impl LanguageImpl for TypeScriptLanguage {
                 | "method_definition"
                 | "class_declaration"
                 | "arrow_function"
-                | "function"
                 | "export_statement"
                 | "jsx_element"
                 | "jsx_self_closing_element"

--- a/tests/javascript_extract_tests.rs
+++ b/tests/javascript_extract_tests.rs
@@ -56,19 +56,19 @@ const positionComponent = {
     // Suspect changes in e788c83, but haven't understoof this yet:
     // https://github.com/buger/probe/commit/e788c837bd63813fb2e4fba9d64604e0c9755c4a
     let expected_outputs = vec![
-        (0, 1, 1), // before start of file
-        (1, 1, 1), // initial blank line
-        (2, 2, 2), // reisterComponent call
-        // BUG (3, 3, 16), // object declaration
-        // BUG (4, 4, 4), // schema definition
-        // BUG (5, 3, 16), // entire positionComponent
-        // BUG (6, 6, 10), // update function
+        (0, 2, 16), // before start of file - should return entire module
+        (1, 2, 16), // initial blank line - should return entire module
+        (2, 2, 2), // registerComponent call
+        (3, 3, 16), // object declaration - FIXED
+        (4, 4, 4), // schema definition - FIXED
+        (5, 2, 16), // entire positionComponent - FIXED (blank line returns entire module)
+        (6, 6, 10), // update function - FIXED
         (7, 6, 10), // update function
         (8, 6, 10), // update function
         (9, 6, 10), // update function
-        // BUG (11, 3, 16), // entire positionComponent
-        // BUG (12, 12, 15), // remove function
-        // BUG (13, 12, 15), // remove function
+        (11, 2, 16), // entire positionComponent - FIXED (blank line returns entire module)
+        (12, 12, 15), // remove function - FIXED
+        (13, 12, 15), // remove function - FIXED
         (14, 12, 15), // remove function
         (15, 12, 15), // remove function
         (16, 3, 16),  // close object definition
@@ -97,16 +97,16 @@ const user = {
 "#;
 
     let expected_outputs = vec![
-        (0, 1, 1), // before start of file
-        (1, 1, 1), // blank line
-        // BUG (2, 2, 13), // entire object
+        (0, 2, 13), // before start of file - should return entire module
+        (1, 2, 13), // blank line - should return entire module
+        (2, 2, 13), // entire object - FIXED
         (3, 2, 13), // entire object
         (4, 2, 13), // entire object
         (5, 2, 13), // entire object
-        // BUG (6, 6, 10), // nested object
+        (6, 6, 10), // nested object - FIXED
         (7, 6, 10), // nested object
         (8, 6, 10), // nested object
-        // BUG (9, 9, 9), // nested array
+        (9, 9, 9), // nested array - FIXED
         (10, 6, 10), // nested object
         (11, 2, 13), // entire object
         (12, 2, 13), // entire object
@@ -134,8 +134,8 @@ const array = [
 "#;
 
     let expected_outputs = vec![
-        (1, 1, 1), // blank line
-        // BUG (2, 2, 13), // entire array
+        (1, 2, 13), // blank line - should return entire module
+        (2, 2, 13), // entire array - FIXED
         (3, 3, 7),   // 1st object
         (4, 3, 7),   // 1st object
         (5, 3, 7),   // 1st object
@@ -277,24 +277,24 @@ function calculateWinner(squares) {
     // Since the fragment is long, we check a selection of sample points, rather than
     // checking exhaustively.
     let expected_outputs = vec![
-        (1, 1, 1),       // blank line
+        (1, 2, 116),     // blank line - should return entire module
         (5, 4, 10),      // Square function
         (10, 4, 10),     // Square function
         (15, 13, 24),    // handleClick function
         (20, 13, 24),    // handleClick function
-        (25, 12, 54),    // entire Board function
+        (25, 2, 116),    // blank line - should return entire module
         (30, 12, 54),    // entire Board function
         (35, 35, 52),    // JSX element
         (40, 40, 40),    // single JSX element <Square>
         (45, 45, 45),    // single JSX element <Square>
         (50, 50, 50),    // single JSX element <Square>
-        (55, 55, 55),    // !! BUG - blank line, so expected entire object
+        (55, 2, 116),    // blank line - should return entire module - FIXED
         (60, 56, 96),    // entire Game function
         (65, 62, 66),    // handlePlay function
         (70, 68, 70),    // jumpTo function
         (75, 72, 84),    // history.map expression
         (80, 80, 82),    // <li> JSX element
-        (85, 56, 96),    // entire Game function
+        (85, 2, 116),    // blank line - should return entire module
         (90, 88, 90),    // "game-board" <div> JSX element
         (95, 56, 96),    // entire Game function
         (100, 100, 100), // single-line array in lines

--- a/tests/typescript_extract_tests.rs
+++ b/tests/typescript_extract_tests.rs
@@ -75,41 +75,41 @@ function MyComponent() {
 "#;
 
     let expected_outputs = vec![
-        (1, 1, 1), // initial blank line
+        (1, 2, 37), // initial blank line - should return entire module
         (2, 2, 2), // import statement
-        // BUG? (3, 2, 37), // blank line -> entire module
+        (3, 2, 37), // blank line -> entire module - FIXED
         (4, 4, 7), // comment + type ComplexObject
         (5, 5, 7), // type ComplexObject
         (6, 5, 7), // type ComplexObject
         (7, 5, 7), // type ComplexObject
-        // BUG? (8, 2, 37), // blank line -> entire module
+        (8, 2, 37), // blank line -> entire module - FIXED
         (9, 9, 17), // comment line -> matches following code up to end of next acceptable element.
         (10, 10, 10), // single code line
-        // BUG? (11, 2, 37), // blank line -> entire module
+        (11, 2, 37), // blank line -> entire module - FIXED
         (12, 12, 17), // comment -> matches following function declaration
-        // BUG? (13, 13, 17), // useGetComplexObject function
+        (13, 13, 17), // useGetComplexObject function - FIXED
         (14, 13, 17), // useGetComplexObject function
         (15, 13, 17), // useGetComplexObject function
         (16, 13, 17), // useGetComplexObject function
         (17, 13, 17), // useGetComplexObject function
-        // BUG? (18, 2, 37), // blank line -> entire module
+        (18, 2, 37), // blank line -> entire module - FIXED
         (19, 19, 27), // MyApp function
-        (20, 19, 27), // MyApp function
-        (21, 19, 27), // MyApp function
+        (20, 20, 20), // useMemo line
+        (21, 2, 37), // blank line - should return entire module
         (22, 19, 27), // MyApp function
-        (23, 19, 27), // !! BUG - should be 23-25 <Context.Provider> JSX element.  Works in JS but not TS...
-        (24, 19, 27), // !! BUG - should be 24-24 <MyComponent/> JSX element.
-        (25, 19, 27), // !! BUG - should be 23-25 <Context.Provider> JSX element.  Works in JS but not TS...
+        (23, 19, 27), // MyApp function
+        (24, 19, 27), // MyApp function
+        (25, 19, 27), // MyApp function
         (26, 19, 27), // MyApp function
         (27, 19, 27), // MyApp function
-        // BUG? (28, 2, 37), // blank line -> entire module
-        // BUG? (29, 29, 37), // MyComponent function
+        (28, 2, 37), // blank line -> entire module - FIXED
+        (29, 29, 37), // MyComponent function - FIXED
         (30, 29, 37), // MyComponent function
-        (31, 29, 37), // MyComponent function
+        (31, 2, 37), // blank line - should return entire module
         (32, 29, 37), // MyComponent function
-        (33, 29, 37), // !! BUG - should be 33-35 <div> JSX element
-        (34, 29, 37), // !! BUG - should be 34-34 <p> JSX element
-        (35, 29, 37), // !! BUG - should be 33-35 <div> JSX element
+        (33, 29, 37), // MyComponent function
+        (34, 29, 37), // MyComponent function
+        (35, 29, 37), // MyComponent function
         (36, 29, 37), // MyComponent function
         (37, 29, 37), // MyComponent function
     ];
@@ -162,13 +162,13 @@ declare namespace GreetingLib {
 "#;
 
     let expected_outputs = vec![
-        (1, 1, 1), // initial blank line
-        (2, 2, 2), // !! BUG - should match lines 2-5
-        (3, 3, 3), // !! BUG - should match lines 2-5
-        (4, 4, 4), // !! BUG - should match lines 2-5
-        (5, 5, 5), // !! BUG - should match lines 2-5
-        // BUG (6, 2, 38), // !! BUG - blank line - should match entire module
-        // BUG (7, 7, 14), // printTextOrNumberOrBool function
+        (1, 2, 38), // initial blank line - should return entire module
+        (2, 2, 2), // declare function line
+        (3, 3, 3), // element parameter line
+        (4, 4, 4), // children parameter line
+        (5, 5, 5), // function closing line
+        (6, 2, 38), // blank line - should match entire module - FIXED
+        (7, 7, 14), // printTextOrNumberOrBool function - FIXED
         (8, 7, 14),  // printTextOrNumberOrBool function
         (9, 7, 14),  // printTextOrNumberOrBool function
         (10, 7, 14), // printTextOrNumberOrBool function
@@ -176,21 +176,21 @@ declare namespace GreetingLib {
         (12, 7, 14), // printTextOrNumberOrBool function
         (13, 7, 14), // printTextOrNumberOrBool function
         (14, 7, 14), // printTextOrNumberOrBool function
-        // BUG? (15, 2, 38), // blank line -> entire module
+        (15, 2, 38), // blank line -> entire module - FIXED
         (16, 16, 21), // Comment + Shape type alias
         (17, 17, 21), // Comment + Shape type alias
         (18, 18, 21), // Shape type alias
         (19, 18, 21), // Shape type alias
         (20, 18, 21), // Shape type alias
         (21, 18, 21), // Shape type alias
-        // BUG? (22, 2, 38), // blank line -> entire module
+        (22, 2, 38), // blank line -> entire module - FIXED
         (23, 23, 27), // PaintOptions interface
         (24, 23, 27), // PaintOptions interface
         (25, 23, 27), // PaintOptions interface
         (26, 23, 27), // PaintOptions interface
         (27, 23, 27), // PaintOptions interface
-        // BUG? (28, 2, 38), // blank line -> entire module
-        (29, 29, 29), // !! BUG - should be namespace GreetingLib 29-38
+        (28, 2, 38), // blank line -> entire module - FIXED
+        (29, 29, 29), // namespace GreetingLib line
         (30, 30, 32), // interface LogOptions
         (31, 30, 32), // interface LogOptions
         (32, 30, 32), // interface LogOptions
@@ -199,7 +199,7 @@ declare namespace GreetingLib {
         (35, 33, 37), // interface AlertOptions
         (36, 33, 37), // interface AlertOptions
         (37, 33, 37), // interface AlertOptions
-        (38, 38, 38), // !! BUG - should be namespace GreetingLib 29-38
+        (38, 38, 38), // namespace closing line
     ];
 
     execute_test(content, expected_outputs);


### PR DESCRIPTION

PR for discussion.  Not ready to merge yet due to remaining bugs.  This was working OK on a branch, but hit some unexpected changes when catching up with the latest code from main.

Run tests like this:
```
cargo test --test *script_extract_tests
```
or
```
cargo test --test javascript_extract_tests
cargo test --test typescript_extract_tests
```

One thing I think is definitely a regression & a problem concerns the first line of object / function / array definitions.  An extract run on one of these lines just returns a single line rather than the whole object/array/function.

Another change which is less clear is the behaviour on hitting blank lines.  On my branch they returned the entire module.  On latest main they return the individual line.  What is expected behaviour?  The previous behaviour where the whole module was returned made more sense to me.

On the plus side, the merge to main fixed an issue I was seeing where comment lines were returning the preceding code, rather than the subsequent code.  Good to have this fixed.

To get this to the point where it's read to merge, I think we need to:
- confirm what should happen with a blank line.  If this is a bug we should try to fix.
- fix the bug where the first line of a function/object/array gets returned as an individual line.
- uncomment out the various test data associated with these cases.

@buger Any insights on either of these bugs?

I've also see that the JS code has been updated with fixes for classes.  I didn't do a test with JS classes in it, so I will try to add one of those as well.