### PR TITLE
Move version printing to start of text output

### DIFF
--- a/src/extract/formatter.rs
+++ b/src/extract/formatter.rs
@@ -422,11 +422,6 @@ fn format_extraction_internal(
                     let total_tokens: usize = sum_tokens_with_deduplication(&code_blocks);
                     writeln!(output, "Total bytes returned: {total_bytes}")?;
                     writeln!(output, "Total tokens returned: {total_tokens}")?;
-                    writeln!(
-                        output,
-                        "Probe version: {}",
-                        probe_code::version::get_version()
-                    )?;
                 }
             }
         }

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -70,6 +70,11 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
     use arboard::Clipboard;
     use colored::*;
 
+    // Print version at the start for text-based formats
+    if options.format != "json" && options.format != "xml" {
+        println!("Probe version: {}", crate::version::get_version());
+    }
+
     // Check if debug mode is enabled
     let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,11 @@ struct BenchmarkParams {
 }
 
 fn handle_search(params: SearchParams) -> Result<()> {
+    // Print version at the start for text-based formats
+    if params.format != "json" && params.format != "xml" {
+        println!("Probe version: {}", probe_code::version::get_version());
+    }
+
     let use_frequency = params.frequency_search;
 
     println!("{} {}", "Pattern:".bold().green(), params.pattern);

--- a/src/query.rs
+++ b/src/query.rs
@@ -470,6 +470,11 @@ pub fn handle_query(
     format: &str,
     no_gitignore: bool,
 ) -> Result<()> {
+    // Print version at the start for text-based formats
+    if format != "json" && format != "xml" {
+        println!("Probe version: {}", probe_code::version::get_version());
+    }
+
     // Only print information for non-JSON/XML formats
     if format != "json" && format != "xml" {
         println!("{} {}", "Pattern:".bold().green(), pattern);
@@ -554,7 +559,6 @@ pub fn handle_query(
 
             println!("Total bytes returned: {total_bytes}");
             println!("Total tokens returned: {total_tokens}");
-            println!("Probe version: {}", probe_code::version::get_version());
         }
     }
 

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -178,7 +178,6 @@ pub fn format_and_print_search_results(
     let total_tokens: usize = sum_tokens_with_deduplication(&code_blocks);
     println!("Total bytes returned: {total_bytes}");
     println!("Total tokens returned: {total_tokens}");
-    println!("Probe version: {}", probe_code::version::get_version());
 }
 
 /// Format and print search results with color highlighting for matching words


### PR DESCRIPTION
## Summary

This PR moves version information from the end to the beginning of command output for text-based formats in both search and extract commands. This improves user experience by making version information immediately visible when commands are executed.

### Changes Made

- **Search Command**: Version now prints at the start of `handle_search()` function before any other output
- **Extract Command**: Version now prints at the start of `handle_extract()` function before any other output  
- **Query Command**: Version now prints at the start of `handle_query()` function before any other output
- **Removed**: Version printing from end of output in search and extract formatters

### Behavior Change

**Before:**
```
Pattern: println
Path: test.rs
...
Found 1 search results
Total bytes returned: 32
Total tokens returned: 10
Probe version: 0.6.0
```

**After:**
```
Probe version: 0.6.0
Pattern: println  
Path: test.rs
...
Found 1 search results
Total bytes returned: 32
Total tokens returned: 10
```

### Technical Details

- Version is only printed for text-based formats (excludes JSON and XML)
- JSON and XML formats continue to include version in structured data as before
- All existing tests pass with no behavior changes for non-text formats
- Implementation is consistent across search, extract, and query commands

## Test Plan

- [x] All unit tests pass
- [x] All integration tests pass  
- [x] All CLI tests pass
- [x] Manual testing of search command shows version at start
- [x] Manual testing of extract command shows version at start
- [x] JSON format verification (version not printed to console but included in structured output)
- [x] Code formatting and linting checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)