### PR TITLE
Add Google Analytics tracking to documentation site

### DIFF
--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -20,7 +20,15 @@ export default defineConfig({
     ['meta', { property: 'og:site_name', content: 'Probe Labs' }],
     ['meta', { property: 'og:url', content: 'https://probelabs.com/' }],
     ['meta', { property: 'twitter:site', content: '@buger' }],
-    ['meta', { name: 'robots', content: 'index,follow' }]
+    ['meta', { name: 'robots', content: 'index,follow' }],
+    // Google Analytics
+    ['script', { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-3Y0Z9SZLF2' }],
+    ['script', {}, `
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-3Y0Z9SZLF2');
+    `]
   ],
   
   markdown: {


### PR DESCRIPTION
## Summary
• Add Google Analytics 4 (GA4) tracking code to the documentation site
• Tracking ID: G-3Y0Z9SZLF2
• Implemented via VitePress config head array for optimal performance

## Test plan
- [ ] Verify the build completes successfully
- [ ] Check that GA scripts are properly injected in the HTML head
- [ ] Confirm tracking is working after deployment to probelabs.com
- [ ] Monitor for any console errors or performance impacts

🤖 Generated with [Claude Code](https://claude.ai/code)