### PR TITLE
Fix edition2024 Cargo error by updating Rust toolchain to 1.85.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
 
       # Install Rust toolchain
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.84.0
+        uses: dtolnay/rust-toolchain@1.85.0
         with:
           targets: ${{ matrix.target }}
           components: rustfmt, clippy


### PR DESCRIPTION
## Summary
- Fix release workflow failing due to edition2024 compatibility error
- Update Rust toolchain from 1.84.0 to 1.85.0 in GitHub Actions workflow

## Problem
The release workflow was failing with this error:
```
error: failed to parse manifest at `/home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/moxcms-0.7.5/Cargo.toml`

Caused by:
  feature `edition2024` is required

  The package requires the Cargo feature called `edition2024`, but that feature is not stabilized in this version of Cargo (1.84.0 (66221abde 2024-11-19)).
```

## Root Cause
- The `moxcms` crate v0.7.5 (transitive dependency: `arboard` → `image` → `moxcms`) uses `edition2024`
- Rust Edition 2024 requires Rust 1.85.0 or newer to compile
- GitHub Actions workflow was pinned to Rust 1.84.0

## Solution
Updated the Rust toolchain version from `1.84.0` to `1.85.0` in `.github/workflows/release.yml`

## Test plan
- [x] Local build verification - cargo check passes with current Rust version
- [x] Pre-commit checks pass
- [ ] CI workflow validation on merge

🤖 Generated with [Claude Code](https://claude.ai/code)