### PR TITLE
Fix npm MCP command module resolution error

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -14,8 +14,7 @@
     "bin/probe.exe",
     "bin/.gitkeep",
     "scripts/postinstall.js",
-    "build/mcp/**/*",
-    "build/agent/**/*"
+    "build/**/*"
   ],
   "scripts": {
     "postinstall": "node scripts/postinstall.js",


### PR DESCRIPTION
## Summary
- Fixed "Cannot find module" error when running `npx @probelabs/probe mcp`
- The issue was that `build/index.js` wasn't being included in the published npm package
- Changed package.json files array to include entire `build/**/*` directory

## Root Cause
The MCP server (`build/mcp/index.js`) was trying to import `../index.js` (which should be `build/index.js`), but the package.json `files` array only included:
- `build/mcp/**/*`  
- `build/agent/**/*`

This meant the main `build/index.js` file was missing from published packages.

## Solution
Updated package.json to include `build/**/*` instead of specific subdirectories, ensuring all built files are packaged correctly.

## Test Plan
- [x] Verified build process works locally (`npm run build`)
- [x] Tested MCP command works via binary wrapper (`node bin/probe mcp --help`)
- [x] Confirmed `build/index.js` is now included in `npm pack` output
- [x] MCP server starts successfully without module resolution errors

🤖 Generated with [Claude Code](https://claude.ai/code)