### PR TITLE
Fix Docker build error by using published npm package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,7 +326,7 @@ jobs:
 
   publish-docker-images:
     name: Publish Docker Images
-    needs: build-and-release
+    needs: [build-and-release, publish-npm-package]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/examples/chat/ChatSessionManager.js
+++ b/examples/chat/ChatSessionManager.js
@@ -1,5 +1,5 @@
 // ChatSessionManager - Bridge between web server and ProbeAgent
-import { ProbeAgent } from '../../npm/src/agent/ProbeAgent.js';
+import { ProbeAgent } from '@probelabs/probe';
 import { toolCallEmitter } from './probeTool.js';
 import { randomUUID } from 'crypto';
 


### PR DESCRIPTION
## Summary
- Fix Docker build error where ChatSessionManager couldn't resolve relative import path
- Update Docker workflow to depend on npm package publishing step

## Changes Made
- **Fixed import path**: Changed `ChatSessionManager.js` to import from `@probelabs/probe` instead of `../../npm/src/agent/ProbeAgent.js`
- **Updated workflow dependencies**: Modified `publish-docker-images` job to depend on `publish-npm-package` 

## Problem Solved
The Docker build was failing with:
```
ERROR: Could not resolve "../../npm/src/agent/ProbeAgent.js"
```

This happened because during Docker build, only the chat package files were copied, not the npm build artifacts. The solution uses the published npm package instead of relative paths.

## Test Plan
- [x] Local build tests pass (`npm run build` and `npm run build:prod`)
- [x] Unit tests pass (`make test-unit`)
- [x] Linting passes (`make lint`, `make format`)
- [x] Workflow dependency order is correct: binaries → npm package → Docker images

🤖 Generated with [Claude Code](https://claude.ai/code)