### PR TITLE
Fix TypeScript class method extraction with property_identifier support

### DIFF
--- a/src/extract/symbol_finder.rs
+++ b/src/extract/symbol_finder.rs
@@ -825,13 +825,8 @@ fn test_function() {
         ];
 
         for method in &methods {
-            let result = find_symbol_in_file(
-                &test_file,
-                &format!("TestClass.{method}"),
-                content,
-                true,
-                0,
-            );
+            let result =
+                find_symbol_in_file(&test_file, &format!("TestClass.{method}"), content, true, 0);
             assert!(result.is_ok(), "Should find TestClass.{method} method");
             let search_result = result.unwrap();
             assert_eq!(search_result.node_type, "method_definition");


### PR DESCRIPTION
## Summary
- Fixes TypeScript class method extraction by adding support for `property_identifier` nodes
- Resolves issue where `file.ts#ClassName.methodName` extraction was failing for TypeScript methods
- Adds comprehensive test coverage for TypeScript method extraction scenarios

## Test plan
- [x] Added unit tests for TypeScript class method extraction
- [x] Tests cover simple method extraction (`methodName`) 
- [x] Tests cover nested extraction (`ClassName.methodName`)
- [x] Tests cover different visibility modifiers (private, public, protected)
- [x] Verified fix works with original user example: `FailureConditionEvaluator.evaluateExpression`

🤖 Generated with [Claude Code](https://claude.ai/code)