### PR TITLE
Export SimpleTelemetry classes for SDK usage

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -16,6 +16,10 @@
       "types": "./src/agent/ProbeAgent.d.ts",
       "import": "./src/agent/ProbeAgent.js",
       "require": "./cjs/agent/ProbeAgent.cjs"
+    },
+    "./telemetry": {
+      "import": "./src/agent/simpleTelemetry.js",
+      "require": "./cjs/agent/simpleTelemetry.cjs"
     }
   },
   "bin": {

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -30,6 +30,7 @@ import {
 } from './tools/common.js';
 import { searchTool, queryTool, extractTool, delegateTool } from './tools/vercel.js';
 import { ProbeAgent } from './agent/ProbeAgent.js';
+import { SimpleTelemetry, SimpleAppTracer, initializeSimpleTelemetryFromOptions } from './agent/simpleTelemetry.js';
 
 export {
 	search,
@@ -43,6 +44,10 @@ export {
 	DEFAULT_SYSTEM_MESSAGE,
 	// Export AI Agent (NEW!)
 	ProbeAgent,
+	// Export telemetry classes
+	SimpleTelemetry,
+	SimpleAppTracer,
+	initializeSimpleTelemetryFromOptions,
 	// Export tool generators directly
 	searchTool,
 	queryTool,


### PR DESCRIPTION
## Summary
• Export SimpleTelemetry, SimpleAppTracer, and initializeSimpleTelemetryFromOptions classes to npm package
• Add dedicated `/telemetry` export path for clean imports
• Enable SDK users to access the same lightweight telemetry functionality used by the CLI

## Changes
• **npm/src/index.js**: Add telemetry class imports and exports to main package
• **npm/package.json**: Add `./telemetry` export path for dedicated telemetry imports

## Usage
```javascript
// From main package
import { SimpleTelemetry, SimpleAppTracer } from '@probelabs/probe';

// From dedicated export
import { SimpleTelemetry, SimpleAppTracer } from '@probelabs/probe/telemetry';

// Setup telemetry with ProbeAgent
const telemetry = new SimpleTelemetry({ enableFile: true, filePath: './traces.jsonl' });
const tracer = new SimpleAppTracer(telemetry, 'session-id');
const agent = new ProbeAgent({ tracer });
```

## Test plan
- [x] Verify exports work from main package
- [x] Verify exports work from dedicated `/telemetry` path  
- [x] Test functional usage with span creation and events
- [x] Confirm backwards compatibility maintained

🤖 Generated with [Claude Code](https://claude.ai/code)