### PR TITLE
Fix SimpleAppTracer missing Mermaid validation methods

### DIFF
--- a/npm/src/agent/simpleTelemetry.js
+++ b/npm/src/agent/simpleTelemetry.js
@@ -170,6 +170,42 @@ export class SimpleAppTracer {
     }
   }
 
+  /**
+   * Record delegation events
+   */
+  recordDelegationEvent(eventType, data = {}) {
+    if (!this.isEnabled()) return;
+
+    this.addEvent(`delegation.${eventType}`, {
+      'session.id': this.sessionId,
+      ...data
+    });
+  }
+
+  /**
+   * Record JSON validation events
+   */
+  recordJsonValidationEvent(eventType, data = {}) {
+    if (!this.isEnabled()) return;
+
+    this.addEvent(`json_validation.${eventType}`, {
+      'session.id': this.sessionId,
+      ...data
+    });
+  }
+
+  /**
+   * Record Mermaid validation events
+   */
+  recordMermaidValidationEvent(eventType, data = {}) {
+    if (!this.isEnabled()) return;
+
+    this.addEvent(`mermaid_validation.${eventType}`, {
+      'session.id': this.sessionId,
+      ...data
+    });
+  }
+
   setAttributes(attributes) {
     // For simplicity, just log attributes when no active span
     if (this.telemetry && this.telemetry.enableConsole) {


### PR DESCRIPTION
## Summary
Fixes the `tracer.recordMermaidValidationEvent is not a function` error that occurs when using probe agent via SDK with Mermaid schema validation.

## Problem
The SDK uses `SimpleAppTracer` instead of the full `AppTracer`, but `SimpleAppTracer` was missing telemetry methods required by the Mermaid validation code in `attempt_completion` cleanup:
- `recordMermaidValidationEvent()`
- `recordJsonValidationEvent()`  
- `recordDelegationEvent()`

This caused errors when SDK users provided schemas containing Mermaid diagrams.

## Solution
Added the missing methods to `SimpleAppTracer` class in `src/agent/simpleTelemetry.js`. The methods mirror the `AppTracer` implementation but use the simple event logging approach consistent with `SimpleAppTracer`.

## Test Plan
- [x] Verified syntax is valid with `node -c`
- [x] Created and ran test to confirm all three methods exist and can be called successfully
- [x] Methods properly log telemetry events with session ID and event data
- [x] No breaking changes to existing functionality

## Impact
- ✅ SDK users can now use Mermaid schemas without encountering method-not-found errors
- ✅ Proper telemetry logging for validation events in SDK usage
- ✅ Maintains consistency between AppTracer and SimpleAppTracer APIs

🤖 Generated with [Claude Code](https://claude.ai/code)