### PR TITLE
Add debug logging for tool loop message exchanges

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -506,6 +506,13 @@ When troubleshooting:
         if (this.debug) {
           console.log(`\n[DEBUG] --- Tool Loop Iteration ${currentIteration}/${maxIterations} ---`);
           console.log(`[DEBUG] Current messages count for AI call: ${currentMessages.length}`);
+          
+          // Log first 200 characters of the latest user message (helpful for debugging loops)
+          const lastUserMessage = [...currentMessages].reverse().find(msg => msg.role === 'user');
+          if (lastUserMessage && lastUserMessage.content) {
+            const userPreview = lastUserMessage.content.substring(0, 200);
+            console.log(`[DEBUG] Latest user message (200 chars): ${userPreview}${lastUserMessage.content.length > 200 ? '...' : ''}`);
+          }
         }
 
         // Add iteration tracing event
@@ -587,6 +594,12 @@ When troubleshooting:
           console.error(`Error during streamText (Iter ${currentIteration}):`, error);
           finalResult = `Error: Failed to get response from AI model during iteration ${currentIteration}. ${error.message}`;
           throw new Error(finalResult);
+        }
+
+        // Log first 200 characters of assistant response for debugging loops
+        if (this.debug && assistantResponseContent) {
+          const assistantPreview = assistantResponseContent.substring(0, 200);
+          console.log(`[DEBUG] Assistant response (200 chars): ${assistantPreview}${assistantResponseContent.length > 200 ? '...' : ''}`);
         }
 
         // Parse tool call from response with valid tools list


### PR DESCRIPTION
## Summary
- Added debug logging to show first 200 characters of user and assistant messages in each tool loop iteration
- Helps debug infinite loops by providing visibility into message exchanges
- Only active when debug mode is enabled

## Changes
- Enhanced tool loop debug logging in ProbeAgent.js to include:
  - Latest user message preview at start of each iteration  
  - Assistant response preview after receiving response
- Logs are truncated to 200 characters with "..." indicator for longer messages

## Test plan
- [x] Verify syntax is valid
- [x] Test that logs only appear in debug mode
- [x] Confirm message truncation works correctly
- [ ] Test with actual infinite loop scenario to verify debugging utility

🤖 Generated with [Claude Code](https://claude.ai/code)