### PR TITLE
Fix probe agent MCP mode timeout issues

### DIFF
--- a/mcp-agent/src/agent.js
+++ b/mcp-agent/src/agent.js
@@ -305,6 +305,12 @@ Examples:
 			}
 			const tools = this.createTools(toolConfig);
 
+			// Calculate AI model timeout - use 80% of total timeout, minimum 60 seconds
+			const totalTimeoutMs = (options.timeout || 300) * 1000; // Convert to milliseconds
+			const aiTimeoutMs = Math.max(totalTimeoutMs * 0.8, 60000); // 80% of total, min 1 minute
+			
+			console.error(`[DEBUG] Total timeout: ${totalTimeoutMs/1000}s, AI model timeout: ${aiTimeoutMs/1000}s`);
+
 			// Configure generateText options
 			const generateOptions = {
 				model: this.provider(this.model),
@@ -330,7 +336,9 @@ Examples:
 				}),
 				maxSteps: 15,
 				temperature: 0.7,
-				maxTokens: config.maxTokens
+				maxTokens: config.maxTokens,
+				abortSignal: AbortSignal.timeout(aiTimeoutMs), // Add timeout for AI model
+				maxRetries: 2 // Add retry mechanism
 			};
 
 			// Add API-specific options
@@ -345,7 +353,26 @@ Examples:
 			}
 
 			// Generate response using AI model with tools
-			const result = await generateText(generateOptions);
+			console.error(`[DEBUG] Starting AI model generation at ${new Date().toISOString()}`);
+			const startTime = Date.now();
+			
+			let result;
+			try {
+				result = await generateText(generateOptions);
+				const endTime = Date.now();
+				const durationMs = endTime - startTime;
+				console.error(`[DEBUG] AI model generation completed in ${durationMs}ms (${(durationMs/1000).toFixed(1)}s)`);
+			} catch (error) {
+				const endTime = Date.now();
+				const durationMs = endTime - startTime;
+				console.error(`[ERROR] AI model generation failed after ${durationMs}ms (${(durationMs/1000).toFixed(1)}s): ${error.message}`);
+				
+				// Check if it's a timeout error
+				if (error.name === 'AbortError' || error.message.includes('timeout') || error.message.includes('timed out')) {
+					throw new Error(`AI model request timed out after ${(aiTimeoutMs/1000).toFixed(1)}s. Try increasing the timeout or simplifying your query.`);
+				}
+				throw error;
+			}
 
 			// Extract the text content from the response
 			const responseText = result.text;


### PR DESCRIPTION
## Summary

• Fixed probe agent MCP mode timeout issues by increasing default timeout and implementing proper AI model timeouts
• Changed MCP server to follow correct pattern: fast startup, expose simple tools, lazy initialize AI only when called
• Renamed tool from `search_code` to `question` for better clarity

## Key Changes

### Timeout Improvements
- **Increased default timeout**: 120s → 300s (5 minutes) for AI processing overhead
- **Added AI model timeout**: Uses `AbortSignal.timeout()` with 80% of total timeout, minimum 60s
- **Added retry mechanism**: `maxRetries: 2` for AI model calls
- **Comprehensive timing logs**: Debug output for timeout tracking and performance analysis

### MCP Server Architecture Fix
- **Lazy AI initialization**: AI agent only loads when `question` tool is first called
- **Fast startup**: Server connects quickly without heavy AI model initialization
- **Correct MCP pattern**: Expose tools → wait for calls → initialize AI on demand
- **Single simple tool**: Changed from complex `search_code` to simple `question` tool

### Enhanced Debugging
- **Startup diagnostics**: Process PID, Node.js version, timeout configuration
- **Tool registration logging**: Verification that tools are properly exposed
- **AI generation timing**: Precise timing measurements with error handling
- **Better timeout error messages**: Clear guidance when timeouts occur

## Test Plan

- [x] MCP server starts quickly without AI initialization
- [x] Single `question` tool is properly exposed via tools/list
- [x] AI agent lazy loads on first tool call
- [x] Timeout configuration is respected (300s default)
- [x] Debug logging provides visibility into operations
- [x] Error handling works for timeout scenarios

## Technical Details

**Before**: Heavy startup with immediate AI initialization causing timeouts
**After**: Lightweight startup, lazy AI loading, proper timeout cascading

The standard "probe mcp" command already worked fine - this fix makes "probe agent" follow the same correct MCP pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)