### PR TITLE
Fix XML parameter parsing bug in probe agent tools

### DIFF
--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -296,8 +296,11 @@ export function parseXmlToolCall(xmlString, validTools = DEFAULT_VALID_TOOLS) {
 
 		// Parse parameters using string-based approach for better safety
 		// Common parameter names to look for (can be extended as needed)
+		// Note: includes both camelCase and underscore_case variants to handle inconsistencies
 		const commonParams = ['query', 'file_path', 'line', 'end_line', 'path', 'recursive', 'includeHidden', 
-		                      'max_results', 'result', 'command', 'description', 'task', 'param'];
+		                      'max_results', 'maxResults', 'result', 'command', 'description', 'task', 'param', 'pattern',
+		                      'allow_tests', 'exact', 'maxTokens', 'language', 'input_content',
+		                      'context_lines', 'format', 'directory', 'autoCommits', 'files'];
 		
 		for (const paramName of commonParams) {
 			const paramOpenTag = `<${paramName}>`;


### PR DESCRIPTION
## Summary
- Fix critical XML parameter parsing bug causing probe agent tools to fail
- Resolve "Pattern is required for file search" and similar parameter validation errors
- Add comprehensive parameter support for all tool types

## Root Cause Analysis
The `parseXmlToolCall` function in `npm/src/tools/common.js` had an incomplete `commonParams` array that was missing many parameters used by various tools. Additionally, the codebase uses inconsistent parameter naming conventions:

- **underscore_case**: `allow_tests`, `context_lines`, `max_results`
- **camelCase**: `maxResults`, `maxTokens`, `autoCommits`

When AI agents made tool calls like `<searchFiles><pattern>*.js</pattern></searchFiles>`, the `pattern` parameter was silently ignored during XML parsing, causing tools to receive incomplete parameter objects.

## Issues Fixed
- **searchFiles tool**: Missing `pattern` parameter (original bug report)
- **search tool**: Missing `allow_tests`, `exact`, `maxResults`, `maxTokens`, `language`
- **query tool**: Missing `language`, `allow_tests`  
- **extract tool**: Missing `input_content`, `context_lines`, `format`, `files`
- **listFiles tool**: Missing `directory`
- **implement tool**: Missing `autoCommits`

## Solution
Updated the `commonParams` array to include all missing parameters and handle both naming conventions:

```js
const commonParams = ['query', 'file_path', 'line', 'end_line', 'path', 'recursive', 'includeHidden', 
                      'max_results', 'maxResults', 'result', 'command', 'description', 'task', 'param', 'pattern',
                      'allow_tests', 'exact', 'maxTokens', 'language', 'input_content',
                      'context_lines', 'format', 'directory', 'autoCommits', 'files'];
```

## Test plan
- [x] Verify `searchFiles` tool now works with `pattern` parameter
- [x] Verify all tool definitions match implemented parameters
- [x] Cross-reference XML tool definitions against actual tool implementations
- [x] Confirm both camelCase and underscore_case parameters are supported
- [ ] Test tool execution with various parameter combinations
- [ ] Verify no regression in existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)