### PR TITLE
Fix mermaid auto-fix format issue with JSON template

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -804,7 +804,7 @@ IMPORTANT: A schema was provided. You MUST respond with data that matches this s
 Use attempt_completion with your response directly inside the tags:
 
 <attempt_completion>
-{"key": "value", "field": "your actual data here matching the schema"}
+[Your response content matching the provided schema format]
 </attempt_completion>
 
 Your response must conform to this schema:


### PR DESCRIPTION
## Summary

- Fixed misleading JSON template in ProbeAgent schema reminder message
- Resolves issue where mermaid auto-fixing returned structured objects instead of plain mermaid content
- Changed specific JSON example to generic placeholder for better schema compliance

## Problem

The mermaid auto-fixing flow was returning responses in this format:
```json
{
  "key": "correctedDiagram",
  "field": "...mermaid content..."
}
```

Instead of the expected plain mermaid content. This happened because the schema reminder message in `ProbeAgent.js` showed a specific JSON object template that misled the AI.

## Solution

Replaced the specific JSON template:
```javascript
{"key": "value", "field": "your actual data here matching the schema"}
```

With a generic placeholder:
```javascript
[Your response content matching the provided schema format]
```

This allows the AI to respond appropriately based on the actual schema provided, whether it requests plain text (like mermaid diagrams) or structured data.

## Test plan

- [x] All MermaidFixingAgent tests pass (4/4)
- [x] All validateAndFixMermaidResponse tests pass (6/6)
- [x] Full enhanced mermaid validation test suite passes (31/31)
- [x] Manual verification that mermaid auto-fix now returns plain content

🤖 Generated with [Claude Code](https://claude.ai/code)