### PR TITLE
fix: Eliminate ARM64 APT repository conflicts for cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,24 +70,42 @@ jobs:
       - name: Configure APT sources for arm64
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          # Remove existing sources and create clean configuration
-          sudo rm -f /etc/apt/sources.list.d/*.list
+          # Disable automatic Ubuntu mirrors and create completely clean configuration
+          sudo rm -rf /etc/apt/sources.list.d/
+          sudo mkdir -p /etc/apt/sources.list.d
+          
+          # Remove any apt-mirrors configuration that might override our settings
+          sudo rm -f /etc/apt/apt-mirrors.txt
+          
+          # Backup original sources.list
+          sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
+          
+          # Create ONLY ports.ubuntu.com configuration for clean ARM64 support
           sudo bash -c 'cat > /etc/apt/sources.list << EOF
-          # AMD64 packages from main Ubuntu repositories
+          # Multi-arch configuration for cross-compilation
+          # AMD64 packages (host architecture)
           deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
           deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse
           deb [arch=amd64] http://security.ubuntu.com/ubuntu noble-security main restricted universe multiverse
           
-          # ARM64 packages from Ubuntu Ports
+          # ARM64 packages (target architecture) - MUST use ports.ubuntu.com
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
           EOF'
-          sudo bash -c 'cat > /etc/apt/sources.list.d/ports.list << EOF
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
-          EOF'
+          
+          # Ensure dpkg knows about arm64 architecture
+          sudo dpkg --add-architecture arm64
+          
+          # Display configuration for debugging
+          echo "=== APT Configuration ==="
+          cat /etc/apt/sources.list
+          echo "=== Sources.list.d directory ==="
+          ls -la /etc/apt/sources.list.d/ || echo "Directory empty/doesn't exist"
+          echo "=== Architectures ==="
+          dpkg --print-architecture
+          dpkg --print-foreign-architectures
+          echo "=== End Configuration ==="
 
       - name: Setup cross-compilation
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
## Summary
Clean fix for the remaining ARM64 cross-compilation issues without unnecessary commits.

## Problem
The ARM64 Linux builds were failing due to APT repository configuration conflicts:
- Duplicate ARM64 repository entries causing "configured multiple times" warnings
- GitHub's automatic mirror configuration interfering with custom sources
- Missing proper architecture setup for cross-compilation

## Solution

### ✅ Remove Repository Conflicts
- **Eliminate duplicate ports.list**: Remove the redundant sources.list.d/ports.list creation
- **Clean sources.list.d**: Completely remove and recreate directory to prevent conflicts
- **Override GitHub mirrors**: Remove apt-mirrors.txt to prevent automatic mirror selection

### ✅ Proper Architecture Setup
- **Explicit architecture registration**: Add `dpkg --add-architecture arm64` 
- **Clean repository separation**: AMD64 from archive.ubuntu.com, ARM64 from ports.ubuntu.com
- **No duplicate entries**: Single, clean configuration without conflicts

### ✅ Enhanced Debugging
- Display final APT configuration for verification
- Show architecture setup
- List sources.list.d directory contents

## Expected Result
This should achieve **100% cross-compilation success** for all platforms:
- ✅ Windows (x86_64-pc-windows-msvc) - Already working
- ✅ macOS Intel (x86_64-apple-darwin) - Already working  
- ✅ macOS Apple Silicon (aarch64-apple-darwin) - Already working
- ✅ **Linux ARM64 (aarch64-unknown-linux-gnu) - Now fixed** 🎯

## Testing
- [x] YAML syntax validated
- [x] Pre-commit hooks pass
- [x] actionlint validates workflow
- [x] APT configuration reviewed for clean multi-arch setup

This completes the cross-compilation workflow fixes by resolving the final ARM64 repository configuration conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)