### PR TITLE
test: Minimal ARM64 setup - test if GitHub defaults handle multi-arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,45 +67,28 @@ jobs:
             ${{ runner.os }}-${{ matrix.target }}-cargo-
             ${{ runner.os }}-cargo-
 
-      - name: Configure APT sources for arm64
+      - name: Setup ARM64 architecture
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          # Disable automatic Ubuntu mirrors and create completely clean configuration
-          sudo rm -rf /etc/apt/sources.list.d/
-          sudo mkdir -p /etc/apt/sources.list.d
+          # Test minimal approach - just add ARM64 architecture and let GitHub's defaults handle repositories
+          echo "=== BEFORE: Default GitHub APT Configuration ==="
+          echo "Architecture:"
+          dpkg --print-architecture || echo "No architecture"
+          dpkg --print-foreign-architectures || echo "No foreign architectures"
+          echo "Sources.list:"
+          cat /etc/apt/sources.list || echo "No sources.list"
+          echo "Sources.list.d:"
+          ls -la /etc/apt/sources.list.d/ || echo "No sources.list.d"
+          echo "Apt mirrors:"
+          cat /etc/apt/apt-mirrors.txt || echo "No apt-mirrors.txt"
           
-          # Remove any apt-mirrors configuration that might override our settings
-          sudo rm -f /etc/apt/apt-mirrors.txt
-          
-          # Backup original sources.list
-          sudo cp /etc/apt/sources.list /etc/apt/sources.list.bak
-          
-          # Create ONLY ports.ubuntu.com configuration for clean ARM64 support
-          sudo bash -c 'cat > /etc/apt/sources.list << EOF
-          # Multi-arch configuration for cross-compilation
-          # AMD64 packages (host architecture)
-          deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble main restricted universe multiverse
-          deb [arch=amd64] http://archive.ubuntu.com/ubuntu noble-updates main restricted universe multiverse
-          deb [arch=amd64] http://security.ubuntu.com/ubuntu noble-security main restricted universe multiverse
-          
-          # ARM64 packages (target architecture) - MUST use ports.ubuntu.com
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
-          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
-          EOF'
-          
-          # Ensure dpkg knows about arm64 architecture
+          # Simply add ARM64 architecture - let GitHub handle the repos
           sudo dpkg --add-architecture arm64
           
-          # Display configuration for debugging
-          echo "=== APT Configuration ==="
-          cat /etc/apt/sources.list
-          echo "=== Sources.list.d directory ==="
-          ls -la /etc/apt/sources.list.d/ || echo "Directory empty/doesn't exist"
-          echo "=== Architectures ==="
+          echo "=== AFTER: Added ARM64 Architecture ==="
+          echo "Architecture:"
           dpkg --print-architecture
           dpkg --print-foreign-architectures
-          echo "=== End Configuration ==="
 
       - name: Setup cross-compilation
         if: matrix.target == 'aarch64-unknown-linux-gnu'


### PR DESCRIPTION
## Hypothesis Test: Do we need complex APT configuration?

Testing whether GitHub Actions runners already have proper multi-arch support and we're overengineering the ARM64 cross-compilation fix.

## 🤔 The Question
Instead of complex custom APT repository configuration, can we simply:
1. Add ARM64 architecture with `dpkg --add-architecture arm64`
2. Let GitHub's default configuration handle the repositories

## 🔍 Evidence Suggesting This Might Work

From previous failure logs, we observed:
- GitHub was already contacting `http://ports.ubuntu.com/ubuntu-ports` 
- ARM64 package fetches were "ignored" rather than 404ing
- Ubuntu 24.04 runners likely have mature multi-arch support

## 🧪 What This PR Tests

### Comprehensive Debugging Output
This PR adds extensive debugging to show:
- **Default APT configuration** GitHub provides
- **Default architecture setup**
- **Repository sources** already configured
- **What happens** when we just add ARM64 architecture

### Minimal Change Approach
```bash
# Instead of 40+ lines of custom APT configuration:
sudo dpkg --add-architecture arm64

# That's it! Let GitHub handle the repos.
```

## 📊 Expected Outcomes

**If this works:** 
- ✅ Much simpler, cleaner solution
- ✅ More maintainable (relies on GitHub's tested config)
- ✅ Fewer moving parts to break

**If this fails:**
- 📝 We'll have detailed logs of what GitHub provides by default
- 📝 Can then make targeted fixes based on actual gaps
- 📝 Fall back to custom configuration approach

## 🎯 Testing Strategy

This PR will run the ARM64 build and show us exactly:
1. What GitHub's default APT setup looks like
2. Whether adding ARM64 architecture is sufficient
3. Where the real bottleneck actually is

## Why This Approach Makes Sense

- **Occam's Razor**: Simplest solution is often correct
- **GitHub Expertise**: They likely solved multi-arch properly
- **Maintenance**: Less custom config = fewer things to break
- **Evidence-Based**: Previous logs suggest this might work

Let's see what the actual GitHub defaults are before we overcomplicate things! 🚀

🤖 Generated with [Claude Code](https://claude.ai/code)