### PR TITLE
Change default formats to outline and outline-xml

### DIFF
--- a/npm/src/mcp/index.ts
+++ b/npm/src/mcp/index.ts
@@ -604,5 +604,5 @@ class ProbeServer {
   }
 }
 
-const server = new ProbeServer(cliConfig.timeout, cliConfig.format);
+const server = new ProbeServer(cliConfig.timeout, cliConfig.format || 'outline-xml');
 server.run().catch(console.error);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -75,9 +75,9 @@ pub struct Args {
     #[arg(long = "dry-run")]
     pub dry_run: bool,
 
-    /// Output format (default: color)
+    /// Output format (default: outline)
     /// Use 'json' or 'xml' for machine-readable output
-    #[arg(short = 'o', long = "format", default_value = "color", value_parser = ["terminal", "markdown", "plain", "json", "xml", "color", "outline", "outline-xml"])]
+    #[arg(short = 'o', long = "format", default_value = "outline", value_parser = ["terminal", "markdown", "plain", "json", "xml", "color", "outline", "outline-xml"])]
     pub format: String,
 
     /// Session ID for caching search results
@@ -196,9 +196,9 @@ pub enum Commands {
         #[arg(long = "dry-run")]
         dry_run: bool,
 
-        /// Output format (default: color)
+        /// Output format (default: outline)
         /// Use 'json' or 'xml' for machine-readable output with structured data
-        #[arg(short = 'o', long = "format", default_value = "color", value_parser = ["terminal", "markdown", "plain", "json", "xml", "color", "outline", "outline-xml"])]
+        #[arg(short = 'o', long = "format", default_value = "outline", value_parser = ["terminal", "markdown", "plain", "json", "xml", "color", "outline", "outline-xml"])]
         format: String,
 
         /// Session ID for caching search results


### PR DESCRIPTION
## Summary

- Set search command default format from 'color' to 'outline' for better structured output
- Set MCP server default format to 'outline-xml' for machine-readable structured output
- Updated help text to reflect new defaults

## Test plan

- [x] Verified search command now defaults to outline format
- [x] Confirmed MCP server uses outline-xml as default
- [x] Tested both formats produce expected output
- [x] Ensured backward compatibility with explicit format options
- [x] All npm tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)