### PR TITLE
Update site package references from buger to probelabs

### DIFF
--- a/site/.vitepress/components/HomeFeatures.vue
+++ b/site/.vitepress/components/HomeFeatures.vue
@@ -138,7 +138,7 @@ Lines: 56-62
 
 <span style="color: rgb(136, 0, 0); font-weight: 400;">jobs</span>:
   <span style="color: rgb(136, 0, 0); font-weight: 400;">trigger_probe_chat</span>:
-    <span style="color: rgb(136, 0, 0); font-weight: 400;">uses</span>: <span style="color: rgb(0, 136, 0); font-weight: 400;">buger/probe/.github/workflows/probe.yml@main</span>
+    <span style="color: rgb(136, 0, 0); font-weight: 400;">uses</span>: <span style="color: rgb(0, 136, 0); font-weight: 400;">probelabs/probe/.github/workflows/probe.yml@main</span>
     <span style="color: rgb(136, 0, 0); font-weight: 400;">with</span>:
       <span style="color: rgb(136, 0, 0); font-weight: 400;">command_prefix</span>: <span style="color: rgb(0, 136, 0); font-weight: 400;">"/probe"</span>
     <span style="color: rgb(136, 0, 0); font-weight: 400;">secrets</span>:
@@ -154,17 +154,17 @@ Lines: 56-62
         <p>Built by developers for developers, Probe is designed to be easy to install and extend:</p>
         
         <div class="language-bash"><pre style="font-family:monospace;color: rgb(68, 68, 68); background-color: rgb(243, 243, 243); font-weight: 400; "><code><span style="color: rgb(105, 112, 112); font-weight: 400;"># Use the core Probe tool without installation</span>
-npx -y @buger/probe@latest search <span style="color: rgb(136, 0, 0); font-weight: 400;">"error handling"</span> ./src
+npx -y @probelabs/probe@latest search <span style="color: rgb(136, 0, 0); font-weight: 400;">"error handling"</span> ./src
 
 <span style="color: rgb(105, 112, 112); font-weight: 400;"># Start an interactive AI chat with your codebase</span>
-npx -y @buger/probe-chat@latest
+npx -y @probelabs/probe-chat@latest
 
 <span style="color: rgb(105, 112, 112); font-weight: 400;"># Start the web interface on localhost:3000</span>
-npx -y @buger/probe-chat@latest --web</code></pre></div>
+npx -y @probelabs/probe-chat@latest --web</code></pre></div>
       </template>
       <template #code>
         <div class="language-typescript"><pre style="font-family:monospace;color: rgb(68, 68, 68); background-color: rgb(243, 243, 243); font-weight: 400; "><code><span style="color: rgb(105, 112, 112); font-weight: 400;">// Example of using Probe's Node.js SDK</span>
-<span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { search } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@buger/probe'</span>;
+<span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { search } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@probelabs/probe'</span>;
 
 <span style="color: rgb(0, 0, 136); font-weight: 400;">const</span> results = <span style="color: rgb(0, 0, 136); font-weight: 400;">await</span> search({
   <span style="color: rgb(136, 0, 0); font-weight: 400;">query</span>: <span style="color: rgb(136, 0, 0); font-weight: 400;">"error handling"</span>,
@@ -194,9 +194,9 @@ console.log(<span style="color: rgb(136, 0, 0); font-weight: 400;">`Found ${resu
         </ul>
       </template>
       <template #code>
-        <div class="language-typescript"><pre style="font-family:monospace;color: rgb(68, 68, 68); background-color: rgb(243, 243, 243); font-weight: 400; "><code><span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { search } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@buger/probe'</span>;
+        <div class="language-typescript"><pre style="font-family:monospace;color: rgb(68, 68, 68); background-color: rgb(243, 243, 243); font-weight: 400; "><code><span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { search } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@probelabs/probe'</span>;
 <span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { ChatOpenAI } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@langchain/openai'</span>;
-<span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { tools } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@buger/probe'</span>;
+<span style="color: rgb(0, 0, 136); font-weight: 400;">import</span> { tools } <span style="color: rgb(0, 0, 136); font-weight: 400;">from</span> <span style="color: rgb(136, 0, 0); font-weight: 400;">'@probelabs/probe'</span>;
 
 <span style="color: rgb(105, 112, 112); font-weight: 400;">// Create AI assistant with code search capability</span>
 <span style="color: rgb(0, 0, 136); font-weight: 400;">const</span> searchTool = tools.createSearchTool();

--- a/site/.vitepress/config.mts
+++ b/site/.vitepress/config.mts
@@ -88,7 +88,7 @@ export default defineConfig({
           ]}
         ]
       },
-      { text: 'GitHub', link: 'https://github.com/buger/probe' },
+      { text: 'GitHub', link: 'https://github.com/probelabs/probe' },
       { text: 'Discord', link: 'https://discord.gg/hBN4UsTZ' }
     ],
 
@@ -137,8 +137,8 @@ export default defineConfig({
         text: 'Contributing',
         collapsed: true,
         items: [
-          { text: 'Contributing Guide', link: 'https://github.com/buger/probe/blob/main/CONTRIBUTING.md' },
-          { text: 'Code of Conduct', link: 'https://github.com/buger/probe/blob/main/CODE_OF_CONDUCT.md' },
+          { text: 'Contributing Guide', link: 'https://github.com/probelabs/probe/blob/main/CONTRIBUTING.md' },
+          { text: 'Code of Conduct', link: 'https://github.com/probelabs/probe/blob/main/CODE_OF_CONDUCT.md' },
           { text: 'Documentation Maintenance', link: '/contributing/documentation-maintenance' },
           { text: 'Documentation Structure', link: '/contributing/documentation-structure' },
           { text: 'Documentation Cross-References', link: '/contributing/documentation-cross-references' }
@@ -150,13 +150,13 @@ export default defineConfig({
         items: [
           { text: 'Changelog', link: '/changelog' },
           { text: 'Blog', link: '/blog/' },
-          { text: 'GitHub Releases', link: 'https://github.com/buger/probe/releases' }
+          { text: 'GitHub Releases', link: 'https://github.com/probelabs/probe/releases' }
         ]
       }
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/buger/probe' },
+      { icon: 'github', link: 'https://github.com/probelabs/probe' },
       { icon: 'discord', link: 'https://discord.gg/hBN4UsTZ' }
     ],
     

--- a/site/.vitepress/theme/layouts/BlogLayout.vue
+++ b/site/.vitepress/theme/layouts/BlogLayout.vue
@@ -16,7 +16,7 @@ const { page, frontmatter } = useData()
           <a href="/" class="nav-link">Home</a>
           <a href="/quick-start" class="nav-link">Docs</a>
           <a href="/blog/" class="nav-link active">Blog</a>
-          <a href="https://github.com/buger/probe" class="nav-link" target="_blank">GitHub</a>
+          <a href="https://github.com/probelabs/probe" class="nav-link" target="_blank">GitHub</a>
         </nav>
       </div>
     </header>
@@ -33,7 +33,7 @@ const { page, frontmatter } = useData()
             Copyright © 2025 Leonid Bugaev
           </div>
           <div class="footer-links">
-            <a href="https://github.com/buger/probe" target="_blank" class="footer-link">
+            <a href="https://github.com/probelabs/probe" target="_blank" class="footer-link">
               <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2C6.475 2 2 6.475 2 12a9.994 9.994 0 0 0 6.838 9.488c.5.087.687-.213.687-.476c0-.237-.013-1.024-.013-1.862c-2.512.463-3.162-.612-3.362-1.175c-.113-.288-.6-1.175-1.025-1.413c-.35-.187-.85-.65-.013-.662c.788-.013 1.35.725 1.538 1.025c.9 1.512 2.338 1.087 2.912.825c.088-.65.35-1.087.638-1.337c-2.225-.25-4.55-1.113-4.55-4.938c0-1.088.387-1.987 1.025-2.688c-.1-.25-.45-1.275.1-2.65c0 0 .837-.262 2.75 1.026a9.28 9.28 0 0 1 2.5-.338c.85 0 1.7.112 2.5.337c1.912-1.3 2.75-1.024 2.75-1.024c.55 1.375.2 2.4.1 2.65c.637.7 1.025 1.587 1.025 2.687c0 3.838-2.337 4.688-4.562 4.938c.362.312.675.912.675 1.85c0 1.337-.013 2.412-.013 2.75c0 .262.188.574.688.474A10.016 10.016 0 0 0 22 12c0-5.525-4.475-10-10-10z"/></svg>
             </a>
             <a href="https://discord.gg/hBN4UsTZ" target="_blank" class="footer-link">

--- a/site/blog/v0.6.0-release.md
+++ b/site/blog/v0.6.0-release.md
@@ -68,18 +68,18 @@ v0.6.0 introduces comprehensive Docker support, making Probe deployment and inte
 
 #### Official Docker Images
 - **Pre-built images**: Available on Docker Hub with automatic CI/CD publishing
-  - `buger/probe` - CLI tool for code search and analysis
-  - `buger/probe-chat` - AI-powered chat interface
+  - `probelabs/probe` - CLI tool for code search and analysis
+  - `probelabs/probe-chat` - AI-powered chat interface
 - **Multi-platform support**: Images built for linux/amd64 and linux/arm64
 - **Semantic versioning**: Tagged releases with `latest`, `X.Y.Z`, `X.Y`, and `X` tags
 
 ```bash
 # Quick start with Docker
-docker pull buger/probe:latest
-docker run --rm -v $(pwd):/workspace buger/probe search "function" /workspace
+docker pull probelabs/probe:latest
+docker run --rm -v $(pwd):/workspace probelabs/probe search "function" /workspace
 
 # AI chat interface
-docker run --rm -e ANTHROPIC_API_KEY=your_key -p 3000:3000 buger/probe-chat --web
+docker run --rm -e ANTHROPIC_API_KEY=your_key -p 3000:3000 probelabs/probe-chat --web
 ```
 
 #### Production-Ready Features
@@ -96,7 +96,7 @@ Docker images are automatically built and published as part of the release workf
 - name: Analyze Code Structure
   run: |
     docker run --rm -v ${{ github.workspace }}:/workspace \
-      buger/probe search "TODO|FIXME" /workspace --format json
+      probelabs/probe search "TODO|FIXME" /workspace --format json
 ```
 
 ### Crates.io Publishing
@@ -161,7 +161,7 @@ Automatic trace collection in CI/CD workflows:
 
 ```yaml
 # Enhanced GitHub Actions with tracing
-- uses: buger/probe@v0.6.0
+- uses: probelabs/probe@v0.6.0
   with:
     enable_tracing: true    # Enable tracing
     allow_suggestions: true # Enable suggestions
@@ -300,7 +300,7 @@ AI: "Fixed! The error handling now properly catches network timeouts."
 #### Automated Code Reviews
 ```yaml
 # .github/workflows/ai-review.yml
-- uses: buger/probe@v0.6.0
+- uses: probelabs/probe@v0.6.0
   with:
     allow_suggestions: true
     prompt: "code-review"
@@ -350,10 +350,10 @@ Update your workflows to take advantage of new features:
 
 ```yaml
 # Old configuration
-- uses: buger/probe@v0.5.0
+- uses: probelabs/probe@v0.5.0
 
 # New configuration with v0.6.0 features
-- uses: buger/probe@v0.6.0
+- uses: probelabs/probe@v0.6.0
   with:
     allow_edit: true          # Enable code editing
     allow_suggestions: true   # Enable PR suggestions

--- a/site/changelog.md
+++ b/site/changelog.md
@@ -39,8 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Docker Integration & CI/CD
 - **Official Docker images**: Pre-built images available on Docker Hub
-  - `buger/probe` - CLI tool for code search
-  - `buger/probe-chat` - AI-powered chat interface
+  - `probelabs/probe` - CLI tool for code search
+  - `probelabs/probe-chat` - AI-powered chat interface
 - **Multi-platform support**: Images built for linux/amd64 and linux/arm64
 - **Docker Compose configuration**: Easy local development setup
 - **Automated CI/CD**: Docker images automatically built and published on releases

--- a/site/index.md
+++ b/site/index.md
@@ -38,11 +38,18 @@ hero:
               <p class="option-description">Built-in AI agent. <small>OpenAI or Anthropic (API key required)</small></p>
             </div>
             <div class="quick-start-option">
-              <h3>Docker</h3>
+              <h3>MCP Server</h3>
               <div class="pre-wrapper">
-                <div class="language-bash"><pre><code>docker run --rm -v $(pwd):/workspace buger/probe search "function"</code></pre></div>
+                <div class="language-bash"><pre><code>probe mcp</code></pre></div>
               </div>
-              <p class="option-description">Containerized deployment with multi-platform support</p>
+              <p class="option-description">Model Context Protocol server for AI editors</p>
+            </div>
+            <div class="quick-start-option">
+              <h3>Probe Agent</h3>
+              <div class="pre-wrapper">
+                <div class="language-bash"><pre><code>npx -y @probelabs/probe@latest extract "main.rs:42" --prompt engineer</code></pre></div>
+              </div>
+              <p class="option-description">LLM-optimized code extraction with prompt templates</p>
             </div>
     </div>
   </div>
@@ -70,6 +77,7 @@ hero:
 .quick-start-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
   gap: 2rem;
   max-width: 1200px;
   margin: 0 auto;

--- a/site/index.md.bak
+++ b/site/index.md.bak
@@ -76,7 +76,7 @@ features:
 
     <p>Get started with a single command:</p>
     
-    <div class="language-bash"><pre><code>curl -fsSL https://raw.githubusercontent.com/buger/probe/main/install.sh | bash</code></pre></div>
+    <div class="language-bash"><pre><code>curl -fsSL https://raw.githubusercontent.com/probelabs/probe/main/install.sh | bash</code></pre></div>
     
     <p>Then start exploring your code:</p>
     

--- a/site/installation.md
+++ b/site/installation.md
@@ -10,13 +10,13 @@ You can install Probe in several ways - choose the method that best fits your en
 
 ```bash
 # Pull the CLI image
-docker pull buger/probe:latest
+docker pull probelabs/probe:latest
 
 # Create an alias for easy usage
-alias probe='docker run --rm -v $(pwd):/workspace buger/probe'
+alias probe='docker run --rm -v $(pwd):/workspace probelabs/probe'
 
 # For the AI chat interface
-docker pull buger/probe-chat:latest
+docker pull probelabs/probe-chat:latest
 ```
 
 **Benefits of Docker installation**:
@@ -37,7 +37,7 @@ npm install -g @probelabs/probe@latest
 ### Using curl (For macOS and Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/buger/probe/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/probelabs/probe/main/install.sh | bash
 ```
 
 **What the curl script does**:
@@ -51,7 +51,7 @@ curl -fsSL https://raw.githubusercontent.com/buger/probe/main/install.sh | bash
 ### Using PowerShell (For Windows)
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex
 ```
 
 **What the PowerShell script does**:
@@ -69,16 +69,16 @@ The PowerShell script supports several options:
 
 ```powershell
 # Install for current user (default)
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex
 
 # Install system-wide (requires admin privileges)
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex -args "--system"
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex -args "--system"
 
 # Install to a custom directory
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex -args "--dir", "C:\Tools\Probe"
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex -args "--dir", "C:\Tools\Probe"
 
 # Show help
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex -args "--help"
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex -args "--help"
 ```
 
 ## Requirements

--- a/site/integrations/docker.md
+++ b/site/integrations/docker.md
@@ -10,8 +10,8 @@ Probe provides Docker images for both the CLI tool and the web interface, making
 ## Docker Hub Images
 
 Pre-built images are available on Docker Hub:
-- **Probe CLI**: `buger/probe:latest`
-- **Probe Chat**: `buger/probe-chat:latest`
+- **Probe CLI**: `probelabs/probe:latest`
+- **Probe Chat**: `probelabs/probe-chat:latest`
 
 ### Available Tags
 - `latest` - Latest stable release
@@ -25,13 +25,13 @@ Pre-built images are available on Docker Hub:
 
 ```bash
 # Pull the image
-docker pull buger/probe:latest
+docker pull probelabs/probe:latest
 
 # Basic usage
-docker run --rm -v $(pwd):/workspace buger/probe search "function" /workspace
+docker run --rm -v $(pwd):/workspace probelabs/probe search "function" /workspace
 
 # Create an alias for convenience
-alias probe='docker run --rm -v $(pwd):/workspace buger/probe'
+alias probe='docker run --rm -v $(pwd):/workspace probelabs/probe'
 probe search "class" .
 ```
 
@@ -43,7 +43,7 @@ probe search "class" .
 docker run --rm -it \
   -e ANTHROPIC_API_KEY=your_api_key \
   -v $(pwd):/workspace \
-  buger/probe-chat
+  probelabs/probe-chat
 ```
 
 #### Web Mode
@@ -53,7 +53,7 @@ docker run --rm \
   -e ANTHROPIC_API_KEY=your_api_key \
   -v $(pwd):/workspace \
   -p 3000:3000 \
-  buger/probe-chat --web
+  probelabs/probe-chat --web
 ```
 
 ## Docker Compose
@@ -104,7 +104,7 @@ docker compose up probe-chat-web
 - name: Analyze Code Structure
   run: |
     docker run --rm -v ${{ github.workspace }}:/workspace \
-      buger/probe search "TODO|FIXME" /workspace --format json > analysis.json
+      probelabs/probe search "TODO|FIXME" /workspace --format json > analysis.json
 ```
 
 ### Development Teams
@@ -115,7 +115,7 @@ docker run --rm -it \
   -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \
   -v $(pwd):/workspace \
   -p 3000:3000 \
-  buger/probe-chat --web
+  probelabs/probe-chat --web
 ```
 
 ### Code Review Automation
@@ -124,7 +124,7 @@ docker run --rm -it \
 # Automated code review
 docker run --rm \
   -v $(pwd):/workspace \
-  buger/probe extract "security|auth" /workspace --format markdown
+  probelabs/probe extract "security|auth" /workspace --format markdown
 ```
 
 ## Multi-Platform Support
@@ -168,7 +168,7 @@ Both images include health checks:
 ### Port Already in Use
 If port 3000 is already in use:
 ```bash
-docker run --rm -e ANTHROPIC_API_KEY=your_key -p 8080:3000 buger/probe-chat --web
+docker run --rm -e ANTHROPIC_API_KEY=your_key -p 8080:3000 probelabs/probe-chat --web
 ```
 
 ### Permission Issues
@@ -195,7 +195,7 @@ export ANTHROPIC_API_KEY=your_actual_key
 For advanced use cases, you can extend the base images:
 
 ```dockerfile
-FROM buger/probe-chat:latest
+FROM probelabs/probe-chat:latest
 
 # Add custom configurations
 COPY custom-config.json /app/config/
@@ -223,7 +223,7 @@ For production deployments, consider:
 version: '3.8'
 services:
   probe-chat:
-    image: buger/probe-chat:1.0.0
+    image: probelabs/probe-chat:1.0.0
     environment:
       - ANTHROPIC_API_KEY_FILE=/run/secrets/anthropic_api_key
     secrets:

--- a/site/integrations/github-actions.md
+++ b/site/integrations/github-actions.md
@@ -35,7 +35,7 @@ permissions:
 jobs:
   trigger_probe_chat:
     # Use the reusable workflow from the main Probe repository
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     # Pass required inputs
     with:
       # Define the command prefix to trigger the bot
@@ -56,7 +56,7 @@ jobs:
 
 1.  **Triggers**: The workflow runs when a new PR/issue is opened or a comment is made on an issue.
 2.  **Permissions**: It requires `write` permissions for issues/PRs to post comments and `read` permission for `contents` to access repository code for analysis.
-3.  **Reusable Workflow**: It utilizes `buger/probe/.github/workflows/probe.yml@main`, which handles parsing the command, invoking the Probe AI agent, searching the codebase, generating a response, and posting it back as a comment.
+3.  **Reusable Workflow**: It utilizes `probelabs/probe/.github/workflows/probe.yml@main`, which handles parsing the command, invoking the Probe AI agent, searching the codebase, generating a response, and posting it back as a comment.
 4.  **Configuration**:
     *   `command_prefix`: Defines how users trigger the bot (e.g., `/probe <Your question>`).
     *   `secrets`: Requires AI provider secrets (e.g., `ANTHROPIC_API_KEY`).
@@ -83,7 +83,7 @@ permissions:
 jobs:
   trigger_probe_implement:
     # Use the reusable workflow
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     with:
       # Define the command prefix
       command_prefix: "/engineer" # Specific prefix for this persona
@@ -109,7 +109,7 @@ jobs:
 
 1.  **Trigger**: This workflow specifically triggers on issue comments.
 2.  **Permissions**: Crucially, it requires `contents: write` permission in addition to `issues: write` and potentially `pull-requests: write`. The `contents: write` permission is essential for allowing the workflow to modify files in the repository.
-3.  **Reusable Workflow**: Still uses `buger/probe/.github/workflows/probe.yml@main`.
+3.  **Reusable Workflow**: Still uses `probelabs/probe/.github/workflows/probe.yml@main`.
 4.  **Configuration**:
     *   `command_prefix`: Uses `/engineer` to invoke this specific workflow.
     *   `allow_edit: true`: This flag enables Probe's code editing capabilities (likely via the `implement` tool). **Use with caution.**
@@ -176,7 +176,7 @@ You can allow workflows using `probe.yml` to be triggered manually from the GitH
 
     jobs:
       trigger_probe_manual:
-        uses: buger/probe/.github/workflows/probe.yml@main
+        uses: probelabs/probe/.github/workflows/probe.yml@main
         with:
           # Use the input from the manual trigger
           manual_input: ${{ github.event.inputs.user_request }}
@@ -209,7 +209,7 @@ Add the `enable_tracing` parameter to your workflow:
 ```yaml
 jobs:
   trigger_probe_chat:
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     with:
       command_prefix: "/probe"
       enable_tracing: true # Enable OpenTelemetry tracing
@@ -229,7 +229,7 @@ When `enable_tracing: true` is set without `TRACING_URL`, traces are saved to a 
 ```yaml
 jobs:
   trigger_probe_chat:
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     with:
       command_prefix: "/probe"
       enable_tracing: true
@@ -245,7 +245,7 @@ For remote tracing to an OpenTelemetry collector, add the `TRACING_URL` secret:
 ```yaml
 jobs:
   trigger_probe_chat:
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     with:
       command_prefix: "/probe"
       enable_tracing: true
@@ -323,7 +323,7 @@ For remote tracing with Jaeger:
    ```yaml
    jobs:
      trigger_probe_chat:
-       uses: buger/probe/.github/workflows/probe.yml@main
+       uses: probelabs/probe/.github/workflows/probe.yml@main
        with:
          enable_tracing: true
        secrets:
@@ -381,7 +381,7 @@ By default, Probe creates a new comment for each invocation. However, you can co
 ```yaml
 jobs:
   trigger_probe_chat:
-    uses: buger/probe/.github/workflows/probe.yml@main
+    uses: probelabs/probe/.github/workflows/probe.yml@main
     with:
       command_prefix: "/probe"
       # Enable comment updating

--- a/site/quick-start.md
+++ b/site/quick-start.md
@@ -13,13 +13,13 @@ npm install -g @probelabs/probe@latest
 Or using curl (for macOS and Linux):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/buger/probe/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/probelabs/probe/main/install.sh | bash
 ```
 
 Or using PowerShell (for Windows):
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/buger/probe/main/install.ps1 | iex
+iwr -useb https://raw.githubusercontent.com/probelabs/probe/main/install.ps1 | iex
 ```
 
 For more detailed installation instructions, including manual installation and building from source, see the [Installation Guide](/installation).


### PR DESCRIPTION
## Summary

Updates all site documentation to use the new `probelabs` organization instead of `buger`:

- **GitHub repository URLs**: Changed from `buger/probe` to `probelabs/probe` across all documentation
- **Docker Hub images**: Updated to `probelabs/probe` and `probelabs/probe-chat` 
- **Home page examples**: Replaced Docker quick-start with MCP server example and added probe agent showcase
- **VitePress configuration**: Updated all navigation links and social links
- **Vue components**: Updated all embedded code examples and links

## Key Changes

### Home Page (index.md)
- ✅ Replaced Docker example with MCP server example (`probe mcp`)
- ✅ Added probe agent example with `--prompt engineer` flag  
- ✅ Updated CSS grid layout for 2x2 display

### Site-wide Updates
- ✅ All GitHub URLs now point to `probelabs/probe` repository
- ✅ All Docker image references use `probelabs/` organization
- ✅ All npm package references use `@probelabs/probe` format
- ✅ VitePress config and Vue components fully updated

### MCP Integration
- ✅ All MCP examples correctly show `probe mcp` subcommand format
- ✅ Migration documentation guides users from old package to new format

## Test Plan

- [x] Verify no references to old `buger/probe` GitHub URLs remain
- [x] Verify no references to old `@buger/probe` npm packages remain  
- [x] Confirm MCP server example displays correctly on home page
- [x] Confirm probe agent example displays correctly on home page
- [x] Verify all MCP configurations use `probe mcp` subcommand format

🤖 Generated with [Claude Code](https://claude.ai/code)