### PR TITLE
fix: Improve Mermaid diagram generation instructions

### DIFF
--- a/npm/src/tools/system-message.js
+++ b/npm/src/tools/system-message.js
@@ -73,13 +73,19 @@ For GitHub-compatible mermaid diagrams, avoid single quotes and parentheses in n
 
 **Rules:**
 - NO single quotes in any node labels: 'text' → "text" or text
-- NO parentheses in square brackets: [Text (detail)] → [Text - detail]
+- NO parentheses in square brackets: [Text (detail)] → [Text - detail]  
 - NO complex expressions in diamonds: {a && b} → {condition}
+- NO HTML tags in node labels: [<pre>code</pre>] → ["code block"] or [Code Block]
 - USE single quotes for styles and classes: classDef highlight fill:'#ff9999'
+- CRITICAL: When using quotes in node labels, place them INSIDE the brackets: ["quoted text"], NOT [quoted text"]
 
 **Examples:**
 - ✅ [Load Config] ["Run command"] {Valid?}
+- ✅ ["depends_on: [generate-items]"] (correct quote placement)
+- ✅ ["Code Block"] (clean text instead of HTML)
 - ❌ [Load (config)] [Run 'command'] {isValid('x')}
+- ❌ [depends_on: [generate-items"] (incorrect quote placement - quote ends inside bracket)
+- ❌ [<pre>depends_on: [generate-items]</pre>] (HTML tags in node labels)
 
 **Diagram Type Selection:**
 


### PR DESCRIPTION
## Summary
- Fixed Mermaid diagram quote placement issues by adding explicit instructions
- Prevented HTML tags in node labels for better GitHub compatibility  
- Added clear examples showing correct vs incorrect patterns

## Problem
The probe agent was generating malformed Mermaid diagrams with issues like:
- Incorrect quote placement: `[item"]` instead of `["item"]`
- HTML tags in node labels: `[<pre>code</pre>]` causing rendering problems
- Lack of clear guidance in system instructions

## Solution
Enhanced the Mermaid generation instructions in `npm/src/tools/system-message.js`:

1. **Added critical quote placement rule**: "When using quotes in node labels, place them INSIDE the brackets: ["quoted text"], NOT [quoted text"]"

2. **Added HTML restriction rule**: "NO HTML tags in node labels: [<pre>code</pre>] → ["code block"] or [Code Block]"

3. **Added explicit examples**:
   - ✅ `["depends_on: [generate-items]"]` (correct quote placement)
   - ✅ `["Code Block"]` (clean text instead of HTML)
   - ❌ `[depends_on: [generate-items"]` (incorrect quote placement)
   - ❌ `[<pre>depends_on: [generate-items]</pre>]` (HTML tags in node labels)

## Test plan
- [x] Verify instructions are properly formatted in system message
- [x] Confirm examples demonstrate both correct and incorrect patterns
- [x] Test that HTML restriction rule is clear and actionable
- [ ] Manual testing with probe agent to ensure improved diagram generation

🤖 Generated with [Claude Code](https://claude.ai/code)