### PR TITLE
fix: Remove <result> tags from probe agent CLI output

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -384,7 +384,7 @@ Examples:
 </extract>
 
 <attempt_completion>
-<result>The configuration is loaded from src/config.js lines 15-25 which contains the database settings.</result>
+The configuration is loaded from src/config.js lines 15-25 which contains the database settings.
 </attempt_completion>
 
 # Special Case: Quick Completion
@@ -411,7 +411,7 @@ I need to find code related to error handling in the search module. The most app
 6. Wait for the tool execution result, which will be provided in the next message (within a <tool_result> block).
 7. Analyze the tool result and decide the next step. If more tool calls are needed, repeat steps 2-6.
 8. If the task is fully complete and all previous steps were successful, use the \`<attempt_completion>\` tool to provide the final answer. This is the ONLY way to finish the task.
-9. If you cannot proceed (e.g., missing information, invalid request), explain the issue clearly before using \`<attempt_completion>\` with an appropriate message in the \`<result>\` tag.
+9. If you cannot proceed (e.g., missing information, invalid request), use \`<attempt_completion>\` to explain the issue clearly with an appropriate message directly inside the tags.
 10. If your previous response was already correct and complete, you may use \`<attempt_complete>\` as a shorthand.
 
 Available Tools:

--- a/npm/src/agent/index.js
+++ b/npm/src/agent/index.js
@@ -763,8 +763,13 @@ async function main() {
       }
     }
 
-    // Output the result
-    console.log(result);
+    // Output the result (strip <result> tags if present for cleaner CLI output)
+    const resultMatch = result.match(/<result>([\s\S]*?)<\/result>/);
+    if (resultMatch) {
+      console.log(resultMatch[1].trim());
+    } else {
+      console.log(result);
+    }
 
     // Show token usage in verbose mode
     if (config.verbose) {


### PR DESCRIPTION
## Summary
- Fixed probe agent CLI output wrapping responses in `<result>` tags
- Made system message examples consistent with tool definitions 
- Added backward compatibility for existing result tag format

## Problem
When running `npx probelabs/probe agent "hi!"`, responses were wrapped in `<result>` tags:
```
<result>Hi there! I'm ProbeChat Code Explorer...</result>
```

This created poor CLI user experience as users saw XML protocol tags instead of clean responses.

## Root Cause
The system message in `ProbeAgent.js` contained examples using `<result>` tags within `<attempt_completion>`, but the tool definition said to put content "directly inside the XML tags without any parameter wrapper". The AI followed the examples rather than the tool definition.

## Solution
1. **Removed `<result>` tags from system message examples** to match tool definition
2. **Added result tag stripping logic** for backward compatibility with any existing responses that still use the old format  
3. **Clarified instruction** about using `<attempt_completion>` for error cases

## Test plan
- [x] Verify system message examples no longer show `<result>` tags
- [x] Test result tag stripping logic with both old and new formats
- [x] Confirm agent responses now show clean output without XML protocol tags

🤖 Generated with [Claude Code](https://claude.ai/code)