### PR TITLE
fix: Resolve SDK binary redownload issue by fixing naming mismatch

### DIFF
--- a/npm/src/utils.js
+++ b/npm/src/utils.js
@@ -43,7 +43,7 @@ export async function getBinaryPath(options = {}) {
 	
 	// Check bin directory
 	const isWindows = process.platform === 'win32';
-	const binaryName = isWindows ? 'probe.exe' : 'probe';
+	const binaryName = isWindows ? 'probe.exe' : 'probe-binary';
 	const binaryPath = path.join(binDir, binaryName);
 
 	if (fs.existsSync(binaryPath) && !forceDownload) {


### PR DESCRIPTION
## Summary
- Fixed binary name inconsistency between `utils.js` and other SDK components that caused repeated "Binary not found. Downloading probe binary..." messages
- The downloader saves binaries as `probe-binary` (Unix) but `utils.js` was looking for `probe`, creating a disconnect
- Updated `utils.js` to use consistent naming with `bin/probe` and `downloader.js`

## Test plan
- [x] Verified binary resolution works correctly on first and subsequent calls
- [x] Confirmed no "Binary not found" messages appear after fix
- [x] All existing npm tests pass
- [x] Manual testing with `node bin/probe --version` shows consistent behavior

🤖 Generated with [Claude Code](https://claude.ai/code)