### PR TITLE
Fix: Strip thinking tags from final ProbeAgent responses

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -40,6 +40,7 @@ import {
   createSchemaDefinitionCorrectionPrompt,
   validateAndFixMermaidResponse
 } from './schemaUtils.js';
+import { removeThinkingTags } from './xmlParsingUtils.js';
 import {
   MCPXmlBridge,
   parseHybridXmlToolCall,
@@ -1752,6 +1753,12 @@ Convert your previous response content into actual JSON data that follows this s
         }
       } else if (this.debug) {
         console.log(`[DEBUG] Mermaid validation: Skipped final validation due to disableMermaidValidation option`);
+      }
+
+      // Remove thinking tags from final result before returning to user
+      finalResult = removeThinkingTags(finalResult);
+      if (this.debug) {
+        console.log(`[DEBUG] Removed thinking tags from final result`);
       }
 
       return finalResult;


### PR DESCRIPTION
## Summary

Fixes an issue where AI responses containing `<thinking>` tags (both closed and unclosed) were not being stripped from the final result before being returned to SDK users. This caused GitHub PR comments (when using Visor) to display thinking content that should have been internal to the AI's reasoning process.

## Problem

When using ProbeAgent SDK:
1. AI generates a response with `<thinking>` tags for internal reasoning
2. The thinking tags were stripped during tool call parsing but **not** from the final result
3. Users saw malformed thinking content in GitHub PR comments like:

```
thinking>
The search results confirm my initial hypothesis. Here's a summary...
```

## Root Cause

The `removeThinkingTags` function existed in `xmlParsingUtils.js` and was being used during tool call parsing, but it was never applied to the `finalResult` before returning it from `ProbeAgent.answer()`.

## Solution

- Import `removeThinkingTags` from `xmlParsingUtils.js` into `ProbeAgent.js`
- Call `removeThinkingTags(finalResult)` right before returning the final result to the user (line 1759)
- Add debug logging to track when thinking tags are removed

## Testing

Verified that the existing `removeThinkingTags` function correctly handles:
- ✅ Closed thinking tags
- ✅ Unclosed thinking tags  
- ✅ Multiple thinking tags
- ✅ Unclosed thinking tags with tool calls after them
- ✅ The specific malformed case from the GitHub issue

## Impact

This ensures all thinking content is stripped from responses before they're posted to GitHub or returned to any SDK user, preventing the display of AI reasoning artifacts in user-facing content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>