### PR TITLE
Fix MCP stdout leaks causing JSON-RPC corruption

### DIFF
--- a/npm/bin/probe
+++ b/npm/bin/probe
@@ -29,12 +29,12 @@ async function ensureBinary(binaryPath) {
   try {
     // Try to import the downloader and download the binary
     const { downloadProbeBinary } = await import('../src/downloader.js');
-    console.log('Probe binary not found, downloading...');
+    console.error('Probe binary not found, downloading...');
     await downloadProbeBinary();
     
     // Check if the binary now exists and is executable
     if (await isExecutable(binaryPath)) {
-      console.log('Binary downloaded successfully.');
+      console.error('Binary downloaded successfully.');
       
       // On macOS, try to remove quarantine attributes that might prevent execution
       if (process.platform === 'darwin') {
@@ -133,7 +133,7 @@ async function main() {
       
       // Check if binary exists and is executable
       if (!(await isExecutable(binaryPath))) {
-        console.log('Probe binary not found or not executable, attempting to download...');
+        console.error('Probe binary not found or not executable, attempting to download...');
         const downloadSuccess = await ensureBinary(binaryPath);
         if (!downloadSuccess) {
           console.error('Failed to download probe binary. Please try installing again or check your internet connection.');

--- a/npm/src/agent/index.js
+++ b/npm/src/agent/index.js
@@ -214,7 +214,7 @@ function parseArgs() {
 
 // Show help message
 function showHelp() {
-  console.log(`
+  console.error(`
 probe agent - AI-powered code exploration tool
 
 Usage:
@@ -696,7 +696,7 @@ async function main() {
       }
       
       if (config.verbose) {
-        console.log('Bash command execution enabled');
+        console.error('Bash command execution enabled');
       }
     }
 

--- a/npm/src/mcp/index.ts
+++ b/npm/src/mcp/index.ts
@@ -36,7 +36,7 @@ function parseArgs(): { timeout?: number; format?: string } {
       console.error(`Format set to ${config.format}`);
       i++; // Skip the next argument
     } else if (args[i] === '--help' || args[i] === '-h') {
-      console.log(`
+      console.error(`
 Probe MCP Server
 
 Usage:
@@ -72,11 +72,11 @@ const possiblePaths = [
 for (const packageJsonPath of possiblePaths) {
   try {
     if (fs.existsSync(packageJsonPath)) {
-      console.log(`Found package.json at: ${packageJsonPath}`);
+      console.error(`Found package.json at: ${packageJsonPath}`);
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       if (packageJson.version) {
         packageVersion = packageJson.version;
-        console.log(`Using version from package.json: ${packageVersion}`);
+        console.error(`Using version from package.json: ${packageVersion}`);
         break;
       }
     }
@@ -93,7 +93,7 @@ if (packageVersion === '0.0.0') {
     const npmList = JSON.parse(result.stdout);
     if (npmList.dependencies && npmList.dependencies['@probelabs/probe']) {
       packageVersion = npmList.dependencies['@probelabs/probe'].version;
-      console.log(`Using version from npm list: ${packageVersion}`);
+      console.error(`Using version from npm list: ${packageVersion}`);
     }
   } catch (error) {
     console.error('Error getting version from npm:', error);
@@ -104,7 +104,7 @@ import { existsSync } from 'fs';
 
 // Get the path to the bin directory
 const binDir = path.resolve(__dirname, '..', 'bin');
-console.log(`Bin directory: ${binDir}`);
+console.error(`Bin directory: ${binDir}`);
 
 // The @probelabs/probe package now handles binary path management internally
 // We don't need to manage the binary path in the MCP server anymore

--- a/npm/tests/integration/mcpStdoutPurity.test.js
+++ b/npm/tests/integration/mcpStdoutPurity.test.js
@@ -1,0 +1,355 @@
+/**
+ * Tests to verify MCP servers only output JSON-RPC messages to stdout
+ * and all diagnostic/debug messages go to stderr
+ */
+
+import { spawn } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { writeFile, rm, mkdir } from 'fs/promises';
+import { tmpdir } from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('MCP Stdout Purity Tests', () => {
+  let tempDir;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `mcp-stdout-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Helper to validate that output is valid JSON-RPC
+   */
+  function isValidJsonRpc(line) {
+    try {
+      const parsed = JSON.parse(line);
+      // Must have jsonrpc field
+      if (parsed.jsonrpc !== '2.0') return false;
+      // Must have either method (request) or result/error (response)
+      if (!parsed.method && !('result' in parsed) && !('error' in parsed)) return false;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Helper to spawn MCP server and collect stdout/stderr
+   */
+  function spawnMcpServer(serverPath, args = []) {
+    return new Promise((resolve, reject) => {
+      const stdoutLines = [];
+      const stderrLines = [];
+      let stdoutBuffer = '';
+      let stderrBuffer = '';
+
+      const proc = spawn('node', [serverPath, ...args], {
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      proc.stdout.on('data', (data) => {
+        stdoutBuffer += data.toString();
+        const lines = stdoutBuffer.split('\n');
+        stdoutBuffer = lines.pop(); // Keep incomplete line in buffer
+        stdoutLines.push(...lines.filter(line => line.trim()));
+      });
+
+      proc.stderr.on('data', (data) => {
+        stderrBuffer += data.toString();
+        const lines = stderrBuffer.split('\n');
+        stderrBuffer = lines.pop(); // Keep incomplete line in buffer
+        stderrLines.push(...lines.filter(line => line.trim()));
+      });
+
+      proc.on('error', reject);
+
+      // Send initialize request
+      const initRequest = JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      });
+
+      proc.stdin.write(initRequest + '\n');
+
+      // Wait for response
+      setTimeout(() => {
+        proc.kill();
+        resolve({ stdoutLines, stderrLines });
+      }, 2000);
+    });
+  }
+
+  describe('Probe MCP Server Stdout Purity', () => {
+    test('should only output JSON-RPC messages to stdout', async () => {
+      const mcpServerPath = join(__dirname, '../../build/mcp/index.js');
+
+      const { stdoutLines, stderrLines } = await spawnMcpServer(mcpServerPath);
+
+      // Verify ALL stdout lines are valid JSON-RPC
+      stdoutLines.forEach((line, index) => {
+        const isValid = isValidJsonRpc(line);
+        if (!isValid) {
+          console.error(`Invalid JSON-RPC on stdout line ${index}:`, line);
+        }
+        expect(isValid).toBe(true);
+      });
+
+      // Stderr can contain diagnostic messages (this is OK)
+      console.log(`Probe MCP server stderr lines: ${stderrLines.length}`);
+      console.log('Sample stderr output:', stderrLines.slice(0, 3));
+    }, 10000);
+
+    test('should handle --help flag without polluting stdout', async () => {
+      const mcpServerPath = join(__dirname, '../../build/mcp/index.js');
+
+      return new Promise((resolve, reject) => {
+        const stdoutLines = [];
+        const stderrLines = [];
+
+        const proc = spawn('node', [mcpServerPath, '--help'], {
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+
+        proc.stdout.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stdoutLines.push(line);
+          });
+        });
+
+        proc.stderr.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stderrLines.push(line);
+          });
+        });
+
+        proc.on('close', () => {
+          // Help message should go to stderr, not stdout
+          expect(stdoutLines.length).toBe(0);
+          expect(stderrLines.length).toBeGreaterThan(0);
+
+          // Verify help content is in stderr
+          const helpText = stderrLines.join('\n');
+          expect(helpText).toContain('Probe MCP Server');
+          expect(helpText).toContain('Usage:');
+
+          resolve();
+        });
+
+        proc.on('error', reject);
+      });
+    });
+  });
+
+  describe('Probe Agent MCP Server Stdout Purity', () => {
+    test('should only output JSON-RPC messages to stdout', async () => {
+      const agentMcpPath = join(__dirname, '../../src/agent/index.js');
+
+      const { stdoutLines, stderrLines } = await spawnMcpServer(agentMcpPath, ['--mcp']);
+
+      // Verify ALL stdout lines are valid JSON-RPC
+      stdoutLines.forEach((line, index) => {
+        const isValid = isValidJsonRpc(line);
+        if (!isValid) {
+          console.error(`Invalid JSON-RPC on stdout line ${index}:`, line);
+        }
+        expect(isValid).toBe(true);
+      });
+
+      // Stderr can contain diagnostic messages (this is OK)
+      console.log(`Probe Agent MCP server stderr lines: ${stderrLines.length}`);
+      console.log('Sample stderr output:', stderrLines.slice(0, 3));
+    }, 10000);
+
+    test('should handle --help flag without polluting stdout when in MCP mode', async () => {
+      const agentPath = join(__dirname, '../../src/agent/index.js');
+
+      return new Promise((resolve, reject) => {
+        const stdoutLines = [];
+        const stderrLines = [];
+
+        const proc = spawn('node', [agentPath, '--help'], {
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+
+        proc.stdout.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stdoutLines.push(line);
+          });
+        });
+
+        proc.stderr.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stderrLines.push(line);
+          });
+        });
+
+        proc.on('close', () => {
+          // Help message should go to stderr, not stdout
+          expect(stdoutLines.length).toBe(0);
+          expect(stderrLines.length).toBeGreaterThan(0);
+
+          // Verify help content is in stderr
+          const helpText = stderrLines.join('\n');
+          expect(helpText).toContain('probe agent');
+          expect(helpText).toContain('Usage:');
+
+          resolve();
+        });
+
+        proc.on('error', reject);
+      });
+    });
+  });
+
+  describe('Binary Wrapper Stdout Purity', () => {
+    test('should only output JSON-RPC when calling probe mcp', async () => {
+      const probeBinPath = join(__dirname, '../../bin/probe');
+
+      const { stdoutLines, stderrLines } = await spawnMcpServer(probeBinPath, ['mcp']);
+
+      // Verify ALL stdout lines are valid JSON-RPC
+      stdoutLines.forEach((line, index) => {
+        const isValid = isValidJsonRpc(line);
+        if (!isValid) {
+          console.error(`Invalid JSON-RPC on stdout line ${index}:`, line);
+        }
+        expect(isValid).toBe(true);
+      });
+
+      // Binary download messages should go to stderr
+      console.log(`Probe binary wrapper stderr lines: ${stderrLines.length}`);
+      console.log('Sample stderr output:', stderrLines.slice(0, 3));
+    }, 10000);
+  });
+
+  describe('Error Scenarios', () => {
+    test('should keep error messages on stderr even during failures', async () => {
+      const mcpServerPath = join(__dirname, '../../build/mcp/index.js');
+
+      return new Promise((resolve, reject) => {
+        const stdoutLines = [];
+        const stderrLines = [];
+
+        const proc = spawn('node', [mcpServerPath], {
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+
+        proc.stdout.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stdoutLines.push(line);
+          });
+        });
+
+        proc.stderr.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stderrLines.push(line);
+          });
+        });
+
+        // Send malformed request
+        proc.stdin.write('invalid json\n');
+
+        setTimeout(() => {
+          proc.kill();
+
+          // Even with errors, stdout should only contain JSON-RPC messages
+          stdoutLines.forEach((line, index) => {
+            if (line.trim()) {
+              const isValid = isValidJsonRpc(line);
+              if (!isValid) {
+                console.error(`Invalid JSON-RPC on stdout line ${index}:`, line);
+              }
+              expect(isValid).toBe(true);
+            }
+          });
+
+          // Error messages can be on stderr
+          console.log('Error scenario stderr:', stderrLines.slice(0, 5));
+
+          resolve();
+        }, 2000);
+
+        proc.on('error', reject);
+      });
+    }, 10000);
+  });
+
+  describe('Regression Tests', () => {
+    test('should not leak package.json discovery logs to stdout', async () => {
+      const mcpServerPath = join(__dirname, '../../build/mcp/index.js');
+
+      const { stdoutLines, stderrLines } = await spawnMcpServer(mcpServerPath);
+
+      // Check that package.json messages don't leak to stdout
+      stdoutLines.forEach(line => {
+        expect(line).not.toContain('Found package.json at:');
+        expect(line).not.toContain('Using version from package.json:');
+        expect(line).not.toContain('Bin directory:');
+      });
+
+      // These messages should be in stderr instead
+      const stderrText = stderrLines.join('\n');
+      // Note: These might not always appear depending on installation
+      // but if they do, they should be in stderr
+      if (stderrText.includes('package.json')) {
+        console.log('✓ Package.json discovery logs correctly sent to stderr');
+      }
+    }, 10000);
+
+    test('should not leak binary download messages to stdout', async () => {
+      // This test verifies the fix in npm/bin/probe
+      const probeBinPath = join(__dirname, '../../bin/probe');
+
+      return new Promise((resolve, reject) => {
+        const stdoutLines = [];
+        const stderrLines = [];
+
+        const proc = spawn('node', [probeBinPath, 'mcp'], {
+          stdio: ['pipe', 'pipe', 'pipe']
+        });
+
+        proc.stdout.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stdoutLines.push(line);
+          });
+        });
+
+        proc.stderr.on('data', (data) => {
+          data.toString().split('\n').forEach(line => {
+            if (line.trim()) stderrLines.push(line);
+          });
+        });
+
+        setTimeout(() => {
+          proc.kill();
+
+          // Binary download messages should NOT be in stdout
+          stdoutLines.forEach(line => {
+            expect(line).not.toContain('Probe binary not found');
+            expect(line).not.toContain('downloading');
+            expect(line).not.toContain('Binary downloaded successfully');
+          });
+
+          resolve();
+        }, 2000);
+
+        proc.on('error', reject);
+      });
+    }, 10000);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes stdout leaks in MCP servers that were causing JSON-RPC deserialization errors. MCP servers communicate via JSON-RPC over stdio, so any non-JSON output to stdout corrupts the protocol.

## Problem

The MCP servers were using `console.log()` to write diagnostic messages to stdout, which caused errors like:
```
ERROR codex_mcp_client::mcp_client: failed to deserialize JSONRPCMessage: 
expected value at line 1 column 1; line = Found package.json at: /home/user/.npm/...
```

## Solution

Changed all `console.log()` calls to `console.error()` in MCP server code to ensure only JSON-RPC messages go to stdout:

- `npm/src/mcp/index.ts` - Package.json discovery, version detection, help messages
- `npm/src/agent/index.js` - Help and verbose mode messages  
- `npm/bin/probe` - Binary download messages

## Testing

Added comprehensive test suite (`tests/integration/mcpStdoutPurity.test.js`) with 8 test cases that verify:

✅ Every line on stdout is valid JSON-RPC (has `jsonrpc: "2.0"` and either `method` or `result`/`error`)  
✅ Help messages go to stderr  
✅ Error messages stay on stderr even during failures  
✅ No package.json discovery leaks (regression test)  
✅ No binary download leaks  

The tests spawn actual MCP server processes and validate stdout purity, ensuring any future stdout leaks are caught immediately.

## Test Results

All existing tests pass + 8 new tests pass:
```
PASS tests/integration/mcpStdoutPurity.test.js
  ✓ should only output JSON-RPC messages to stdout (Probe MCP)
  ✓ should handle --help flag without polluting stdout
  ✓ should only output JSON-RPC messages to stdout (Agent MCP)
  ✓ should handle --help flag without polluting stdout when in MCP mode
  ✓ should only output JSON-RPC when calling probe mcp
  ✓ should keep error messages on stderr even during failures
  ✓ should not leak package.json discovery logs to stdout
  ✓ should not leak binary download messages to stdout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)