### PR TITLE
Fix mermaid validation infinite recursion loop

### DIFF
--- a/npm/src/agent/schemaUtils.js
+++ b/npm/src/agent/schemaUtils.js
@@ -777,6 +777,7 @@ FIXING METHODOLOGY:
    - Incorrect formatting for diagram-specific elements
    - **Parentheses in node labels or subgraph names**: Wrap text containing parentheses in double quotes to prevent GitHub parsing errors
    - Single quotes in node labels (GitHub's parser expects double quotes)
+   - **Edge/Arrow labels with spaces**: MUST use pipe syntax like "A --|Label Text|--> B" or "A -- |Label Text| --> B". NEVER use double quotes like "A -- \\"Label\\" --> B" which is INVALID
 4. **Preserve semantic meaning** - never change the intended flow or relationships
 5. **Use proper escaping** for special characters and spaces
 6. **Ensure consistency** in naming conventions and formatting
@@ -812,7 +813,8 @@ When presented with a broken Mermaid diagram, analyze it thoroughly and provide 
         debug: this.options.debug,
         tracer: this.options.tracer,
         allowEdit: this.options.allowEdit,
-        maxIterations: 2  // Limit mermaid fixing to 2 iterations to prevent long loops
+        maxIterations: 2,  // Limit mermaid fixing to 2 iterations to prevent long loops
+        disableMermaidValidation: true  // CRITICAL: Disable mermaid validation in nested agent to prevent infinite recursion
       });
     }
 

--- a/npm/tests/unit/mermaidEdgeLabelFix.test.js
+++ b/npm/tests/unit/mermaidEdgeLabelFix.test.js
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for Mermaid edge label syntax fixing
+ *
+ * Tests that MermaidFixingAgent correctly instructs AI to use pipe syntax
+ * for edge labels instead of double quotes, preventing validation loops.
+ */
+
+import { describe, test, expect, jest } from '@jest/globals';
+import { validateMermaidDiagram } from '../../src/agent/schemaUtils.js';
+
+// Dynamically import MermaidFixingAgent to avoid circular dependency
+const { MermaidFixingAgent } = await import('../../src/agent/schemaUtils.js');
+
+describe('Mermaid Edge Label Syntax Fixing', () => {
+  test('should detect invalid edge labels with double quotes', async () => {
+    const invalidDiagrams = [
+      'graph TD\n    A -- "Label Text" --> B',
+      'graph TD\n    E -- "JSON-RPC Messages ONLY" --> F[stdout]',
+      'flowchart LR\n    X -- "Step 1" --> Y\n    Y -- "Step 2" --> Z'
+    ];
+
+    for (const diagram of invalidDiagrams) {
+      const result = await validateMermaidDiagram(diagram);
+      expect(result.isValid).toBe(false);
+      expect(result.error).toBeDefined();
+    }
+  });
+
+  test('should validate edge labels with pipe syntax', async () => {
+    const validDiagrams = [
+      { desc: 'dashes with pipes', diagram: 'graph TD\n    A --|Label Text|--> B' },
+      { desc: 'dashes with spaced pipes', diagram: 'graph TD\n    A -- |Label Text| --> B' },
+      { desc: 'arrow with spaced pipes', diagram: 'graph TD\n    A -->|Label Text| B' },
+      { desc: 'complex label', diagram: 'graph TD\n    E --|JSON-RPC Messages ONLY|--> F[stdout]' },
+      { desc: 'multiple edges', diagram: 'flowchart LR\n    X --|Step 1|--> Y\n    Y --|Step 2|--> Z' }
+    ];
+
+    for (const { desc, diagram } of validDiagrams) {
+      const result = await validateMermaidDiagram(diagram);
+      expect(result.isValid).toBe(true);
+      expect(result.diagramType).toBe('flowchart');
+    }
+  });
+
+  test('MermaidFixingAgent prompt should include edge label syntax rules', async () => {
+    const fixer = new MermaidFixingAgent({ debug: false });
+    const prompt = fixer.getMermaidFixingPrompt();
+
+    // Verify prompt instructs to use pipe syntax
+    expect(prompt).toContain('Edge/Arrow labels');
+    expect(prompt).toContain('pipe syntax');
+    expect(prompt).toContain('--|');
+    expect(prompt).toContain('NEVER use double quotes');
+  });
+
+  test('should fix invalid edge labels using mocked AI', async () => {
+    // Create mock AI that returns corrected diagram with pipe syntax
+    const invalidDiagram = `graph TD
+    A[Start]
+    A -- "Invalid Label 1" --> B[Process]
+    B -- "Invalid Label 2" --> C[End]`;
+
+    const fixedDiagram = `graph TD
+    A[Start]
+    A -->|Invalid Label 1| B[Process]
+    B -->|Invalid Label 2| C[End]`;
+
+    // Mock ProbeAgent.answer to return fixed diagram
+    const mockAgent = {
+      answer: jest.fn().mockResolvedValue(`\`\`\`mermaid\n${fixedDiagram}\n\`\`\``)
+    };
+
+    // Create MermaidFixingAgent and inject mock
+    const fixer = new MermaidFixingAgent({ debug: false });
+    await fixer.initializeAgent();
+    fixer.agent = mockAgent;
+
+    // Verify original diagram is invalid
+    const validationBefore = await validateMermaidDiagram(invalidDiagram);
+    expect(validationBefore.isValid).toBe(false);
+
+    // Trigger the fixing flow
+    const errors = ['line 4:14: Expecting token sequences, but found: "JSON-RPC Messages ONLY"'];
+    const result = await fixer.fixMermaidDiagram(invalidDiagram, errors, {});
+
+
+    // Verify the fix - result should have pipe syntax
+    expect(result).toContain('-->|Invalid Label 1|');
+    expect(result).toContain('-->|Invalid Label 2|');
+    expect(result).not.toContain('"Invalid Label 1"');
+    expect(result).not.toContain('"Invalid Label 2"');
+
+    // Verify the AI was called with correct prompt
+    expect(mockAgent.answer).toHaveBeenCalled();
+    const callArgs = mockAgent.answer.mock.calls[0];
+    expect(callArgs[0]).toContain('Analyze and fix');
+    expect(callArgs[0]).toContain('Mermaid diagram');
+
+    // Verify no schema parameter (this was causing the loop)
+    if (callArgs.length >= 3) {
+      expect(callArgs[2]).not.toHaveProperty('schema');
+    }
+
+    // Verify fixed diagram is valid
+    const validationAfter = await validateMermaidDiagram(result);
+    if (!validationAfter.isValid) {
+      throw new Error(`Fixed diagram validation failed: ${validationAfter.error}\nResult: ${result}`);
+    }
+    expect(validationAfter.isValid).toBe(true);
+  });
+
+  test('should not fix already valid edge labels', async () => {
+    const validDiagram = `graph TD
+    A --|Label Text|--> B
+    B --|Another Label|--> C`;
+
+    const validation = await validateMermaidDiagram(validDiagram);
+    expect(validation.isValid).toBe(true);
+    expect(validation.diagramType).toBe('flowchart');
+  });
+
+  test('should handle mixed valid and invalid edge labels', async () => {
+    const mixedDiagram = `graph TD
+    A --|Valid Label|--> B
+    B -- "Invalid Label" --> C`;
+
+    const result = await validateMermaidDiagram(mixedDiagram);
+    expect(result.isValid).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  test('MermaidFixingAgent should not loop infinitely', async () => {
+    // Mock AI that returns a fixed diagram (this test ensures the flow completes)
+    const mockAgent = {
+      answer: jest.fn().mockResolvedValue('```mermaid\ngraph TD\n    A -->|Fixed Label| B\n```')
+    };
+
+    const fixer = new MermaidFixingAgent({ debug: false });
+    await fixer.initializeAgent();
+    fixer.agent = mockAgent;
+
+    const invalidDiagram = 'graph TD\n    A -- "Invalid" --> B';
+
+    // This should complete without looping
+    const result = await fixer.fixMermaidDiagram(invalidDiagram, ['Invalid syntax'], {});
+
+    // Verify AI was only called once (not in infinite loop)
+    expect(mockAgent.answer).toHaveBeenCalledTimes(1);
+    expect(result).toContain('-->|Fixed Label|');
+  });
+
+  test('MermaidFixingAgent should disable mermaid validation in nested ProbeAgent', async () => {
+    // This test verifies the fix for the infinite recursion bug
+    // The inner ProbeAgent used by MermaidFixingAgent must have disableMermaidValidation=true
+    const fixer = new MermaidFixingAgent({ debug: false });
+    await fixer.initializeAgent();
+
+    // Verify the nested ProbeAgent has mermaid validation disabled
+    expect(fixer.agent.disableMermaidValidation).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Mermaid validation was causing **infinite recursion** when nested agents performed the same validation as their parent:

1. **Outer ProbeAgent** returns response with mermaid diagram
2. ProbeAgent calls `validateAndFixMermaidResponse()` (line 1729) to validate/fix
3. `validateAndFixMermaidResponse()` creates **MermaidFixingAgent** → creates **inner ProbeAgent**
4. Inner ProbeAgent's `.answer()` completes → **ALSO calls `validateAndFixMermaidResponse()`** (line 1729)
5. Creates **another MermaidFixingAgent** → **another ProbeAgent** → infinite loop!

### Evidence from logs:
```
[DEBUG] Generated session ID for agent: mermaid-fixer-1759473875783  # Nested agent 1
[DEBUG] Maximum tool iterations configured: 30  # NOT the maxIterations=2 set for MermaidFixingAgent
...
[DEBUG] Generated session ID for agent: mermaid-fixer-1759473902628  # Nested agent 2
[DEBUG] Maximum tool iterations configured: 30
...
[DEBUG] Generated session ID for agent: mermaid-fixer-1759473914360  # Nested agent 3
```

The `maxIterations=2` limit on MermaidFixingAgent was bypassed because each recursion created a **new** agent with default settings.

## Root Cause

**ProbeAgent.answer()** line 1729 calls `validateAndFixMermaidResponse()` on ALL responses.  
**MermaidFixingAgent** creates a nested ProbeAgent which also triggers validation → recursion.

## Solution

Set `disableMermaidValidation: true` when creating the inner ProbeAgent in `MermaidFixingAgent.initializeAgent()` to break the recursion chain.

## Changes

### Core Fix
- **npm/src/agent/schemaUtils.js:817** - Added `disableMermaidValidation: true` to inner ProbeAgent
- **npm/src/agent/schemaUtils.js:780** - Added edge label syntax guidance to prompt (secondary fix)

### Tests
- **npm/tests/unit/mermaidEdgeLabelFix.test.js** - 8 comprehensive tests:
  - Invalid edge label detection
  - Valid pipe syntax validation
  - Prompt verification
  - Mocked AI integration flow
  - Edge cases
  - **Recursion prevention verification** (new test ensures `disableMermaidValidation=true`)

## Test Results

✅ **8 new tests** - All passing  
✅ **673 existing tests** - All still passing (1 skipped)  
✅ **No regressions**

## Before/After

**Before:** Infinite recursion creating nested agents indefinitely  
**After:** Single-level mermaid validation, terminates properly

## Technical Details

The fix is minimal and surgical:
```javascript
this.agent = new this.ProbeAgent({
  // ... other options
  maxIterations: 2,  // Existing limit
  disableMermaidValidation: true  // NEW: Prevents recursion
});
```

This ensures the inner ProbeAgent used for fixing mermaid diagrams doesn't itself try to validate/fix mermaid diagrams, which would create infinite nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>