### PR TITLE
Add detailed MCP tools logging to ProbeAgent

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -644,16 +644,23 @@ export class ProbeAgent {
       this.mcpBridge = new MCPXmlBridge({ debug: this.debug });
       await this.mcpBridge.initialize(mcpConfig);
 
-      const mcpToolCount = this.mcpBridge.getToolNames().length;
+      const mcpToolNames = this.mcpBridge.getToolNames();
+      const mcpToolCount = mcpToolNames.length;
       if (mcpToolCount > 0) {
         if (this.debug) {
-          console.log(`[DEBUG] Loaded ${mcpToolCount} MCP tools`);
+          console.error('\n[DEBUG] ========================================');
+          console.error(`[DEBUG] MCP Tools Initialized (${mcpToolCount} tools)`);
+          console.error('[DEBUG] Available MCP tools:');
+          for (const toolName of mcpToolNames) {
+            console.error(`[DEBUG]   - ${toolName}`);
+          }
+          console.error('[DEBUG] ========================================\n');
         }
       } else {
         // For backward compatibility: if no tools were loaded, set bridge to null
         // This maintains the behavior expected by existing tests
         if (this.debug) {
-          console.log('[DEBUG] No MCP tools loaded, setting bridge to null');
+          console.error('[DEBUG] No MCP tools loaded, setting bridge to null');
         }
         this.mcpBridge = null;
       }


### PR DESCRIPTION
## Summary
Fixes missing MCP tool names in ProbeAgent debug output. Previously only showed count, now lists individual tool names.

## Changes
- Extract MCP tool names array from bridge
- Log each MCP tool name individually in debug mode
- Use console.error for consistency with native tools logging
- Add bordered section matching native tools format

## Before
```
[DEBUG] Loaded 3 MCP tools
```

## After
```
[DEBUG] ========================================
[DEBUG] MCP Tools Initialized (3 tools)
[DEBUG] Available MCP tools:
[DEBUG]   - logoscope
[DEBUG]   - tool2
[DEBUG]   - tool3
[DEBUG] ========================================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)