### PR TITLE
Fix outline-xml format performance by using file cache

### DIFF
--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -1270,7 +1270,7 @@ fn collect_outline_lines(
         // Collect parent contexts for all matched lines
         let mut all_contexts = Vec::new();
         for &line_num in &matched_lines {
-            let contexts = collect_parent_context_for_line(file_path, line_num, &full_source);
+            let contexts = collect_parent_context_for_line(file_path, line_num, full_source);
             if std::env::var("DEBUG").unwrap_or_default() == "1" {
                 eprintln!(
                     "DEBUG: Parent contexts for line {}: {} contexts found",


### PR DESCRIPTION
## Summary

Fixed a significant performance issue where `outline-xml` format was much slower than `markdown` (outline) format due to redundant file I/O operations.

## Root Cause

The `collect_outline_lines()` function was reading files from disk on every call instead of using the already-cached file content:

- **Markdown format**: Reads each file once via cache (M reads for M files)
- **XML format** (before fix): Reads from disk N times + cache M times = N+M total reads, with N from disk

### Example Performance Impact

For 100 search results across 10 files:
- **Before**: 110 file reads (100 from disk!)
- **After**: 10 file reads (all from cache)

## Changes Made

1. Modified `collect_outline_lines()` to accept `file_cache` parameter
2. Replaced `std::fs::read_to_string()` with cache lookup
3. Updated both call sites in `format_and_print_outline_results()` and `format_and_print_outline_xml_results()`

## Test Plan

- [x] Build succeeds: `cargo build --release` 
- [x] All unit tests pass: `make test-unit`
- [x] All integration tests pass: `make test-integration`
- [x] Code formatting check passes: `make check-format`
- [x] Clippy linting passes: `make lint`

## Impact

This eliminates redundant disk I/O and makes outline-xml performance match markdown format, providing significant speed improvements for large search results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)