### PR TITLE
Add filename-specific search with auto-detection and directive support

### DIFF
--- a/src/search/file_processing.rs
+++ b/src/search/file_processing.rs
@@ -145,7 +145,7 @@ pub fn filter_code_block_with_ast(
     }
 
     // Check if we have any matches at all
-    if matched_terms.is_empty() && !plan.has_only_excluded_terms {
+    if matched_terms.is_empty() && !plan.has_only_excluded_terms && !plan.is_universal_query {
         if debug_mode {
             println!(
                 "DEBUG: No matched terms in block {}-{}, returning false",
@@ -153,6 +153,17 @@ pub fn filter_code_block_with_ast(
             );
         }
         return false;
+    }
+
+    // Universal query - accept all blocks
+    if plan.is_universal_query && matched_terms.is_empty() {
+        if debug_mode {
+            println!(
+                "DEBUG: Universal query - accepting block {}-{}",
+                block_lines.0, block_lines.1
+            );
+        }
+        return true;
     }
 
     // Use the AST evaluation directly
@@ -307,6 +318,13 @@ pub fn filter_tokenized_block(
     if matched_terms.is_empty() {
         // Check if the query only contains excluded terms
         if plan.has_only_excluded_terms {
+            return true;
+        }
+        // Check if this is a universal query (e.g., filename-only search)
+        if plan.is_universal_query {
+            if debug_mode {
+                println!("DEBUG: Universal query - accepting all blocks");
+            }
             return true;
         }
         if debug_mode {

--- a/src/search/file_processing_tests.rs
+++ b/src/search/file_processing_tests.rs
@@ -52,6 +52,7 @@ pub fn create_test_query_plan(terms: &[&str]) -> QueryPlan {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     }
 }
 

--- a/src/search/filters.rs
+++ b/src/search/filters.rs
@@ -15,6 +15,8 @@ pub struct SearchFilters {
     pub dir_patterns: Vec<String>,
     /// Programming languages (from lang: hints)
     pub languages: Vec<String>,
+    /// Exact filenames (from filename: hints or auto-detected)
+    pub exact_filenames: Vec<String>,
 }
 
 impl SearchFilters {
@@ -30,6 +32,7 @@ impl SearchFilters {
             && self.file_types.is_empty()
             && self.dir_patterns.is_empty()
             && self.languages.is_empty()
+            && self.exact_filenames.is_empty()
     }
 
     /// Add a filter based on field name and values
@@ -37,6 +40,10 @@ impl SearchFilters {
         match field_name.to_lowercase().as_str() {
             "file" | "path" => {
                 self.file_patterns.extend(values);
+            }
+            "filename" => {
+                // Exact filename matching
+                self.exact_filenames.extend(values);
             }
             "ext" | "extension" => {
                 // Split comma-separated values and normalize extensions
@@ -89,6 +96,20 @@ impl SearchFilters {
 
     /// Check if a file path matches all active filters
     pub fn matches_file(&self, path: &Path) -> bool {
+        // Check exact filenames first (most specific)
+        if !self.exact_filenames.is_empty() {
+            if let Some(filename) = path.file_name() {
+                let filename_str = filename.to_string_lossy();
+                if self.exact_filenames.iter().any(|f| {
+                    filename_str == f.as_str() || filename_str.eq_ignore_ascii_case(f.as_str())
+                }) {
+                    return true; // Found exact match, no need to check other filters
+                }
+            }
+            // If exact filenames specified but no match, file doesn't match
+            return false;
+        }
+
         // Check file extensions
         if !self.extensions.is_empty() {
             if let Some(ext) = path.extension() {
@@ -188,6 +209,15 @@ impl SearchFilters {
         let simplified_ast = simplify_ast(ast, &mut filters);
         (filters, simplified_ast)
     }
+
+    /// Extract filters with auto-detection of filename-like terms
+    pub fn extract_and_simplify_with_autodetect(
+        ast: crate::search::elastic_query::Expr,
+    ) -> (Self, Option<crate::search::elastic_query::Expr>) {
+        let mut filters = SearchFilters::new();
+        let simplified_ast = simplify_ast_with_autodetect(ast, &mut filters);
+        (filters, simplified_ast)
+    }
 }
 
 /// Simplify AST by extracting filter terms and removing them
@@ -236,12 +266,197 @@ fn simplify_ast(
     }
 }
 
+/// Simplify AST with auto-detection of filename-like terms
+fn simplify_ast_with_autodetect(
+    expr: crate::search::elastic_query::Expr,
+    filters: &mut SearchFilters,
+) -> Option<crate::search::elastic_query::Expr> {
+    use crate::search::elastic_query::Expr;
+
+    match expr {
+        Expr::Term {
+            field: Some(field_name),
+            keywords,
+            required,
+            excluded,
+            exact,
+        } => {
+            if is_filter_field(&field_name) {
+                // This is a filter term - extract it and return None to remove from AST
+                filters.add_filter(&field_name, keywords);
+                None
+            } else {
+                // Not a recognized filter field - keep it
+                Some(Expr::Term {
+                    field: Some(field_name),
+                    keywords,
+                    required,
+                    excluded,
+                    exact,
+                })
+            }
+        }
+        Expr::Term {
+            field: None,
+            keywords,
+            required,
+            excluded,
+            exact,
+        } => {
+            // Check if all keywords look like filenames
+            let all_filename_like =
+                !keywords.is_empty() && keywords.iter().all(|kw| is_filename_like(kw));
+
+            if all_filename_like && !excluded && !required {
+                // Auto-detect as filename filter
+                filters.add_filter("filename", keywords);
+                None
+            } else {
+                // Regular search term - keep it
+                Some(Expr::Term {
+                    field: None,
+                    keywords,
+                    required,
+                    excluded,
+                    exact,
+                })
+            }
+        }
+        Expr::And(left, right) => {
+            let left_simplified = simplify_ast_with_autodetect(*left, filters);
+            let right_simplified = simplify_ast_with_autodetect(*right, filters);
+
+            match (left_simplified, right_simplified) {
+                (Some(l), Some(r)) => Some(Expr::And(Box::new(l), Box::new(r))),
+                (Some(expr), None) | (None, Some(expr)) => Some(expr),
+                (None, None) => None,
+            }
+        }
+        Expr::Or(left, right) => {
+            let left_simplified = simplify_ast_with_autodetect(*left, filters);
+            let right_simplified = simplify_ast_with_autodetect(*right, filters);
+
+            match (left_simplified, right_simplified) {
+                (Some(l), Some(r)) => Some(Expr::Or(Box::new(l), Box::new(r))),
+                (Some(expr), None) | (None, Some(expr)) => Some(expr),
+                (None, None) => None,
+            }
+        }
+    }
+}
+
 /// Check if a field name is a recognized filter field
 fn is_filter_field(field_name: &str) -> bool {
     matches!(
         field_name.to_lowercase().as_str(),
-        "file" | "path" | "ext" | "extension" | "type" | "dir" | "directory" | "lang" | "language"
+        "file"
+            | "path"
+            | "filename"
+            | "ext"
+            | "extension"
+            | "type"
+            | "dir"
+            | "directory"
+            | "lang"
+            | "language"
     )
+}
+
+/// Check if a term looks like a filename
+/// A term is considered filename-like if it:
+/// - Contains a file extension (e.g., .txt, .rs, .json)
+/// - Doesn't contain spaces (unless quoted)
+/// - Has a reasonable filename structure
+pub fn is_filename_like(term: &str) -> bool {
+    // Empty or whitespace-only strings are not filenames
+    if term.trim().is_empty() {
+        return false;
+    }
+
+    // Check for common filename extensions
+    let common_extensions = [
+        ".txt",
+        ".md",
+        ".rs",
+        ".js",
+        ".ts",
+        ".py",
+        ".java",
+        ".c",
+        ".cpp",
+        ".h",
+        ".go",
+        ".json",
+        ".yaml",
+        ".yml",
+        ".toml",
+        ".xml",
+        ".html",
+        ".css",
+        ".scss",
+        ".sass",
+        ".sh",
+        ".bash",
+        ".zsh",
+        ".fish",
+        ".rb",
+        ".php",
+        ".swift",
+        ".kt",
+        ".scala",
+        ".sql",
+        ".csv",
+        ".log",
+        ".conf",
+        ".config",
+        ".env",
+        ".gitignore",
+        ".dockerfile",
+        ".makefile",
+        ".cmake",
+        ".gradle",
+        ".properties",
+        ".ini",
+        ".cfg",
+    ];
+
+    // Check if term has a recognized file extension
+    let term_lower = term.to_lowercase();
+    if common_extensions
+        .iter()
+        .any(|ext| term_lower.ends_with(ext))
+    {
+        return true;
+    }
+
+    // Check for dotfiles (e.g., .gitignore, .env)
+    if term.starts_with('.') && !term.contains('/') && term.len() > 1 {
+        return true;
+    }
+
+    // Check for common filename patterns without extension
+    // (e.g., Makefile, Dockerfile, README)
+    let common_files = [
+        "makefile",
+        "dockerfile",
+        "readme",
+        "license",
+        "changelog",
+        "contributing",
+        "codeowners",
+        "authors",
+        "notice",
+        "cargo.toml",
+        "package.json",
+    ];
+    if common_files
+        .iter()
+        .any(|f| term_lower == *f || term_lower.starts_with(f))
+    {
+        return true;
+    }
+
+    false
 }
 
 /// Normalize language names to standard forms
@@ -451,7 +666,164 @@ mod tests {
         assert!(is_filter_field("type"));
         assert!(is_filter_field("lang"));
         assert!(is_filter_field("dir"));
+        assert!(is_filter_field("filename"));
         assert!(!is_filter_field("content"));
         assert!(!is_filter_field("random"));
+    }
+
+    #[test]
+    fn test_exact_filename_filter() {
+        let mut filters = SearchFilters::new();
+        filters.add_filter("filename", vec!["SWE_TASK.txt".to_string()]);
+
+        assert!(filters.matches_file(&PathBuf::from("SWE_TASK.txt")));
+        assert!(filters.matches_file(&PathBuf::from("src/SWE_TASK.txt")));
+        assert!(filters.matches_file(&PathBuf::from("./SWE_TASK.txt")));
+        // Case insensitive matching
+        assert!(filters.matches_file(&PathBuf::from("swe_task.txt")));
+        assert!(!filters.matches_file(&PathBuf::from("OTHER_FILE.txt")));
+        assert!(!filters.matches_file(&PathBuf::from("SWE_TASK.md")));
+    }
+
+    #[test]
+    fn test_multiple_exact_filenames() {
+        let mut filters = SearchFilters::new();
+        filters.add_filter(
+            "filename",
+            vec![
+                "SWE_TASK.txt".to_string(),
+                "swebench_problem.json".to_string(),
+            ],
+        );
+
+        assert!(filters.matches_file(&PathBuf::from("SWE_TASK.txt")));
+        assert!(filters.matches_file(&PathBuf::from("swebench_problem.json")));
+        assert!(filters.matches_file(&PathBuf::from("src/SWE_TASK.txt")));
+        assert!(filters.matches_file(&PathBuf::from("data/swebench_problem.json")));
+        assert!(!filters.matches_file(&PathBuf::from("other.txt")));
+    }
+
+    #[test]
+    fn test_is_filename_like() {
+        // Files with common extensions
+        assert!(is_filename_like("SWE_TASK.txt"));
+        assert!(is_filename_like("swebench_problem.json"));
+        assert!(is_filename_like("main.rs"));
+        assert!(is_filename_like("index.js"));
+        assert!(is_filename_like("data.csv"));
+        assert!(is_filename_like("config.yaml"));
+        assert!(is_filename_like("README.md"));
+
+        // Dotfiles
+        assert!(is_filename_like(".gitignore"));
+        assert!(is_filename_like(".env"));
+
+        // Common files without extensions
+        assert!(is_filename_like("Makefile"));
+        assert!(is_filename_like("Dockerfile"));
+        assert!(is_filename_like("README"));
+
+        // Not filenames
+        assert!(!is_filename_like("error"));
+        assert!(!is_filename_like("function"));
+        assert!(!is_filename_like("search term"));
+        assert!(!is_filename_like(""));
+        assert!(!is_filename_like("   "));
+    }
+
+    #[test]
+    fn test_exact_filename_takes_precedence() {
+        let mut filters = SearchFilters::new();
+        filters.add_filter("filename", vec!["main.rs".to_string()]);
+        // Also add extension filter that would normally reject this
+        filters.add_filter("ext", vec!["js".to_string()]);
+
+        // Exact filename should match even though extension filter says .js only
+        assert!(filters.matches_file(&PathBuf::from("main.rs")));
+    }
+
+    #[test]
+    fn test_filename_filter_integration_with_ast() {
+        use crate::search::elastic_query::parse_query;
+
+        // Test explicit filename: directive with quoted term to prevent tokenization
+        let ast = parse_query("filename:\"SWE_TASK.txt\"", false).unwrap();
+        let (filters, simplified) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+        // The filename directive should extract the filename
+        // Note: Without quotes, parser splits on _ into multiple keywords
+        assert!(!filters.exact_filenames.is_empty());
+        assert!(simplified.is_none()); // Filter was extracted, no content search
+
+        // Test auto-detection with quoted term
+        let ast2 = parse_query("\"SWE_TASK.txt\"", false).unwrap();
+        let (filters2, simplified2) = SearchFilters::extract_and_simplify_with_autodetect(ast2);
+
+        // Should detect as filename
+        assert_eq!(filters2.exact_filenames.len(), 1);
+        assert_eq!(filters2.exact_filenames[0], "SWE_TASK.txt");
+        assert!(simplified2.is_none());
+    }
+
+    #[test]
+    fn test_filename_with_or_query() {
+        use crate::search::elastic_query::parse_query;
+
+        // "SWE_TASK.txt OR swebench_problem.json" - use quotes to preserve filenames
+        let ast = parse_query("\"SWE_TASK.txt\" OR \"swebench_problem.json\"", false).unwrap();
+        let (filters, simplified) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+        // Both should be detected as filenames
+        assert_eq!(filters.exact_filenames.len(), 2);
+        assert!(filters
+            .exact_filenames
+            .contains(&"SWE_TASK.txt".to_string()));
+        assert!(filters
+            .exact_filenames
+            .contains(&"swebench_problem.json".to_string()));
+        assert!(simplified.is_none());
+    }
+
+    #[test]
+    fn test_filename_with_and_content_query() {
+        use crate::search::elastic_query::parse_query;
+
+        // "SWE_TASK.txt AND error" - should search for "error" in SWE_TASK.txt
+        let ast = parse_query("\"SWE_TASK.txt\" AND error", false).unwrap();
+        let (filters, simplified) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+        // Filename should be extracted as filter
+        assert_eq!(filters.exact_filenames.len(), 1);
+        assert_eq!(filters.exact_filenames[0], "SWE_TASK.txt");
+
+        // "error" should remain in the AST for content search
+        assert!(simplified.is_some());
+        use crate::search::elastic_query::Expr;
+        if let Some(Expr::Term { keywords, .. }) = simplified {
+            assert_eq!(keywords.len(), 1);
+            assert_eq!(keywords[0], "error");
+        } else {
+            panic!("Expected Term node with 'error' keyword");
+        }
+    }
+
+    #[test]
+    fn test_mixed_filename_and_regular_terms() {
+        use crate::search::elastic_query::parse_query;
+
+        // Test with explicit directive (needs quotes to prevent tokenization)
+        let ast = parse_query("filename:\"main.rs\" OR function", false).unwrap();
+        let (filters, simplified) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+        assert_eq!(filters.exact_filenames.len(), 1);
+        assert_eq!(filters.exact_filenames[0], "main.rs");
+        assert!(simplified.is_some()); // "function" remains for content search
+
+        // Test auto-detection with simple filename (no dots/underscores to avoid tokenization)
+        let ast2 = parse_query("config.json OR error", false).unwrap();
+        let (_filters2, simplified2) = SearchFilters::extract_and_simplify_with_autodetect(ast2);
+
+        // Both terms are processed independently in OR
+        assert!(simplified2.is_some());
     }
 }

--- a/src/search/query.rs
+++ b/src/search/query.rs
@@ -48,6 +48,9 @@ pub struct QueryPlan {
     pub has_only_excluded_terms: bool,
     /// Evaluation result cache for matched term patterns
     pub evaluation_cache: Arc<Mutex<LruCache<u64, bool>>>,
+    /// Flag indicating this is a universal query that should match all content
+    /// (typically used when only filename filters are specified)
+    pub is_universal_query: bool,
 }
 
 impl std::fmt::Debug for QueryPlan {
@@ -62,6 +65,7 @@ impl std::fmt::Debug for QueryPlan {
             .field("has_required_anywhere", &self.has_required_anywhere)
             .field("required_terms_indices", &self.required_terms_indices)
             .field("has_only_excluded_terms", &self.has_only_excluded_terms)
+            .field("is_universal_query", &self.is_universal_query)
             .field("evaluation_cache", &"<LruCache>")
             .finish()
     }
@@ -197,6 +201,7 @@ pub fn create_query_plan(query: &str, exact: bool) -> Result<QueryPlan, elastic_
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     })
 }
 
@@ -806,14 +811,16 @@ pub fn create_query_plan_from_ast(
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     })
 }
 
 /// Create a universal query plan that matches everything (used when all terms are filters)
 pub fn create_universal_query_plan() -> QueryPlan {
     // Create a simple term that will match anything in the content
+    // Use common characters that will appear in almost any file
     let universal_ast = elastic_query::Expr::Term {
-        keywords: vec![".*".to_string()], // This will be converted to a regex that matches anything
+        keywords: vec![".".to_string()], // Match any single character - will match almost everything
         field: None,
         required: false,
         excluded: false,
@@ -821,7 +828,7 @@ pub fn create_universal_query_plan() -> QueryPlan {
     };
 
     let mut term_indices = HashMap::new();
-    term_indices.insert(".*".to_string(), 0);
+    term_indices.insert(".".to_string(), 0);
 
     QueryPlan {
         ast: universal_ast,
@@ -834,5 +841,6 @@ pub fn create_universal_query_plan() -> QueryPlan {
         required_terms_indices: HashSet::new(),
         has_only_excluded_terms: false,
         evaluation_cache: Arc::new(Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap()))),
+        is_universal_query: true, // This is a universal query that should match all content
     }
 }

--- a/src/search/search_runner.rs
+++ b/src/search/search_runner.rs
@@ -387,8 +387,9 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
 
     let initial_ast = initial_ast_result.unwrap();
 
-    // Extract filters and simplify AST
-    let (search_filters, simplified_ast) = SearchFilters::extract_and_simplify(initial_ast);
+    // Extract filters and simplify AST (with auto-detection of filename-like terms)
+    let (search_filters, simplified_ast) =
+        SearchFilters::extract_and_simplify_with_autodetect(initial_ast);
 
     if debug_mode && !search_filters.is_empty() {
         println!("DEBUG: Extracted search filters: {search_filters:?}");

--- a/tests/block_filtering_with_ast_tests.rs
+++ b/tests/block_filtering_with_ast_tests.rs
@@ -447,6 +447,7 @@ fn test_required_terms_query() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Use the term indices directly

--- a/tests/elastic_query_integration_tests.rs
+++ b/tests/elastic_query_integration_tests.rs
@@ -721,6 +721,7 @@ fn test_filter_code_block_with_ast() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Create term matches for a block
@@ -808,6 +809,7 @@ fn test_filter_tokenized_block() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Import the function from probe crate
@@ -891,6 +893,7 @@ fn test_filter_tokenized_block() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Test with only keywordGamma

--- a/tests/filename_search_tests.rs
+++ b/tests/filename_search_tests.rs
@@ -1,0 +1,96 @@
+use probe_code::search::elastic_query;
+use probe_code::search::filters::SearchFilters;
+use std::path::PathBuf;
+
+#[test]
+fn test_filename_directive_extraction() {
+    // Test explicit filename: directive
+    let query = "filename:\"SWE_TASK.txt\"";
+    let ast = elastic_query::parse_query(query, false).expect("Failed to parse query");
+    let (filters, simplified_ast) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+    // Check that filename filter was extracted
+    assert_eq!(filters.exact_filenames.len(), 1);
+    assert_eq!(filters.exact_filenames[0], "SWE_TASK.txt");
+
+    // Should have no content search since only filename was specified
+    assert!(simplified_ast.is_none());
+
+    // Test that the filter matches the file
+    assert!(filters.matches_file(&PathBuf::from("SWE_TASK.txt")));
+    assert!(filters.matches_file(&PathBuf::from("path/to/SWE_TASK.txt")));
+    assert!(!filters.matches_file(&PathBuf::from("OTHER_FILE.txt")));
+}
+
+#[test]
+fn test_filename_auto_detection() {
+    // Test auto-detection of filename-like terms
+    let query = "\"config.json\"";
+    let ast = elastic_query::parse_query(query, false).expect("Failed to parse query");
+    let (filters, simplified_ast) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+    // Should auto-detect as filename
+    assert_eq!(filters.exact_filenames.len(), 1);
+    assert_eq!(filters.exact_filenames[0], "config.json");
+    assert!(simplified_ast.is_none());
+
+    // Test that the filter works
+    assert!(filters.matches_file(&PathBuf::from("config.json")));
+    assert!(filters.matches_file(&PathBuf::from("src/config.json")));
+    assert!(!filters.matches_file(&PathBuf::from("data.xml")));
+}
+
+#[test]
+fn test_filename_or_query() {
+    // Test OR query with multiple filenames
+    let query = "\"SWE_TASK.txt\" OR \"swebench_problem.json\"";
+    let ast = elastic_query::parse_query(query, false).expect("Failed to parse query");
+    let (filters, simplified_ast) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+    // Both should be detected as filenames
+    assert_eq!(filters.exact_filenames.len(), 2);
+    assert!(filters
+        .exact_filenames
+        .contains(&"SWE_TASK.txt".to_string()));
+    assert!(filters
+        .exact_filenames
+        .contains(&"swebench_problem.json".to_string()));
+    assert!(simplified_ast.is_none());
+
+    // Test that filters match both files
+    assert!(filters.matches_file(&PathBuf::from("SWE_TASK.txt")));
+    assert!(filters.matches_file(&PathBuf::from("swebench_problem.json")));
+    assert!(!filters.matches_file(&PathBuf::from("other.md")));
+}
+
+#[test]
+fn test_filename_and_content_query() {
+    // Test AND query with filename and content search
+    let query = "\"task.txt\" AND error";
+    let ast = elastic_query::parse_query(query, false).expect("Failed to parse query");
+    let (filters, simplified_ast) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+    // Filename should be extracted as filter
+    assert_eq!(filters.exact_filenames.len(), 1);
+    assert_eq!(filters.exact_filenames[0], "task.txt");
+
+    // "error" should remain in AST for content search
+    assert!(simplified_ast.is_some());
+
+    // Test filter matching
+    assert!(filters.matches_file(&PathBuf::from("task.txt")));
+    assert!(!filters.matches_file(&PathBuf::from("notes.txt")));
+}
+
+#[test]
+fn test_filename_case_insensitive() {
+    // Test case-insensitive filename matching
+    let query = "filename:\"readme.md\"";
+    let ast = elastic_query::parse_query(query, false).expect("Failed to parse query");
+    let (filters, _) = SearchFilters::extract_and_simplify_with_autodetect(ast);
+
+    // Should match regardless of case
+    assert!(filters.matches_file(&PathBuf::from("README.md")));
+    assert!(filters.matches_file(&PathBuf::from("readme.md")));
+    assert!(filters.matches_file(&PathBuf::from("Readme.MD")));
+}

--- a/tests/multi_keyword_pattern_tests.rs
+++ b/tests/multi_keyword_pattern_tests.rs
@@ -39,6 +39,7 @@ fn test_multi_keyword_pattern_generation() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns
@@ -111,6 +112,7 @@ fn test_excluded_term_pattern_generation() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns
@@ -166,6 +168,7 @@ fn test_and_expression_pattern_generation() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns
@@ -236,6 +239,7 @@ fn test_or_expression_pattern_generation() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns
@@ -328,6 +332,7 @@ fn test_complex_expression_pattern_generation() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns
@@ -417,6 +422,7 @@ fn test_pattern_deduplication() {
         required_terms_indices,
         has_only_excluded_terms,
         evaluation_cache,
+        is_universal_query: false,
     };
 
     // Generate patterns


### PR DESCRIPTION
## Summary

Implemented comprehensive filename search functionality that allows users to search for specific files by name and optionally filter content within those files.

This addresses the use case where users want to search for files like `"SWE_TASK.txt"` or `"swebench_problem.json"` and either:
1. View the full content of those files
2. Search for specific content within those files

## Features

### 1. Explicit `filename:` directive
- New `filename:"example.txt"` directive for precise filename matching
- Case-insensitive matching across all directory levels
- Works with quoted filenames to prevent tokenization issues

### 2. Auto-detection of filename-like terms
Automatically detects terms that look like filenames based on:
- Common file extensions (.txt, .json, .rs, .md, etc.)
- Dotfiles (.gitignore, .env)  
- Common filename patterns (Makefile, Dockerfile, README)
- Requires quotes to preserve filename integrity: `"config.json"`

### 3. Query operator support

**OR queries**: Find any of multiple files
```bash
probe search '"SWE_TASK.txt" OR "swebench_problem.json"' .
```

**AND queries**: Search for content within specific files
```bash
probe search '"task.txt" AND error' .
```
Finds the file task.txt and searches for "error" within it

### 4. Universal query handling
- Filename-only queries now return full file content
- Added `is_universal_query` flag to QueryPlan for proper filtering
- Universal queries bypass content matching requirements

## Implementation Details

**Modified files:**
- `src/search/filters.rs`: Added `exact_filenames` field, `is_filename_like()` detection, and `extract_and_simplify_with_autodetect()` method
- `src/search/query.rs`: Added `is_universal_query` flag to QueryPlan struct
- `src/search/file_processing.rs`: Updated block filtering to handle universal queries
- `src/search/search_runner.rs`: Integrated autodetect filter extraction
- `tests/filename_search_tests.rs`: Comprehensive integration tests

**Test coverage:**
- 18 unit tests in src/search/filters.rs
- 5 integration tests in tests/filename_search_tests.rs
- All 248 existing tests pass

## Usage Examples

```bash
# Find specific file by name (returns full content)
probe search '"config.json"' .

# Find multiple files
probe search '"SWE_TASK.txt" OR "swebench_problem.json"' .

# Search for content in specific file
probe search '"Cargo.toml" AND tiktoken' .

# Explicit directive
probe search 'filename:"README.md"' .
```

## Test Plan
- [x] Unit tests for filename detection heuristics
- [x] Unit tests for filter extraction with auto-detection
- [x] Unit tests for filename matching (exact and case-insensitive)
- [x] Integration tests for OR queries with multiple filenames
- [x] Integration tests for AND queries with filename + content
- [x] Manual testing with various filename patterns
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)