### PR TITLE
Change MCP search_code default format to outline

### DIFF
--- a/npm/src/mcp/index.ts
+++ b/npm/src/mcp/index.ts
@@ -331,24 +331,12 @@ class ProbeServer {
         maxTokens: 8000,           // Fits in most AI context windows
       };
 
-<<<<<<< HEAD
-      // Handle format options
-      if (this.defaultFormat === 'outline' || this.defaultFormat === 'outline-xml') {
-        // For outline/outline-xml format, we pass it as a format flag to the search command
-        options.format = this.defaultFormat;
-||||||| d8918b1
-      // Handle format options
-      if (this.defaultFormat === 'outline-xml') {
-        // For outline-xml format, we pass it as a format flag to the search command
-        options.format = 'outline-xml';
-=======
       // Only override defaults if user explicitly set them
       if (args.exact !== undefined) options.exact = args.exact;
 
       // Handle format based on server default
-      if (this.defaultFormat === 'outline-xml') {
-        options.format = 'outline-xml';
->>>>>>> origin/main
+      if (this.defaultFormat === 'outline' || this.defaultFormat === 'outline-xml') {
+        options.format = this.defaultFormat;
       } else if (this.defaultFormat === 'json') {
         options.json = true;
       }


### PR DESCRIPTION
## Summary

Changes the MCP server's default output format from `outline-xml` to `outline`, aligning it with the probe CLI's default behavior.

## Motivation

- The probe CLI defaults to `outline` format (human-readable)
- The MCP server was using `outline-xml` (more verbose, machine-parseable)
- Both formats provide hierarchical context, but `outline` is cleaner and more readable
- This provides consistency between CLI and MCP usage

## Changes

1. **Default format**: Changed from `'outline-xml'` to `'outline'` (line 468)
2. **Format handling**: Updated to support both `'outline'` and `'outline-xml'` formats (lines 339-341)
3. **Documentation**: Updated help text to show the new default (line 47)

## Testing

- [x] Verified format handling logic supports both outline variants
- [x] Updated help text reflects new default
- [x] Backward compatible - users can still specify `--format outline-xml` if needed

## Impact

**Before:**
```bash
probe mcp  # Uses outline-xml format
```

**After:**
```bash
probe mcp  # Uses outline format (matches CLI default)
probe mcp --format outline-xml  # Can still use XML variant if needed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)