### PR TITLE
Add TypeScript definitions for ProbeAgent.clone() method

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -207,6 +207,22 @@ export interface AnswerOptions {
 }
 
 /**
+ * Clone options for creating a new agent with shared history
+ */
+export interface CloneOptions {
+  /** Session ID for the cloned agent (defaults to new UUID) */
+  sessionId?: string;
+  /** Remove internal messages (schema reminders, mermaid fixes, etc.) */
+  stripInternalMessages?: boolean;
+  /** Keep the system message in cloned history */
+  keepSystemMessage?: boolean;
+  /** Deep copy messages to prevent mutations */
+  deepCopy?: boolean;
+  /** Override any ProbeAgent constructor options */
+  overrides?: Partial<ProbeAgentOptions>;
+}
+
+/**
  * ProbeAgent class - AI-powered code exploration and interaction
  */
 export declare class ProbeAgent {
@@ -272,6 +288,13 @@ export declare class ProbeAgent {
    * @param messages - Array of chat messages
    */
   setHistory(messages: ChatMessage[]): void;
+
+  /**
+   * Clone this agent's session to create a new agent with shared conversation history
+   * @param options - Clone options
+   * @returns New agent instance with cloned history
+   */
+  clone(options?: CloneOptions): ProbeAgent;
 }
 
 /**

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -112,6 +112,22 @@ export interface AnswerOptions {
 }
 
 /**
+ * Clone options for creating a new agent with shared history
+ */
+export interface CloneOptions {
+  /** Session ID for the cloned agent (defaults to new UUID) */
+  sessionId?: string;
+  /** Remove internal messages (schema reminders, mermaid fixes, etc.) */
+  stripInternalMessages?: boolean;
+  /** Keep the system message in cloned history */
+  keepSystemMessage?: boolean;
+  /** Deep copy messages to prevent mutations */
+  deepCopy?: boolean;
+  /** Override any ProbeAgent constructor options */
+  overrides?: Partial<ProbeAgentOptions>;
+}
+
+/**
  * ProbeAgent class - AI-powered code exploration and interaction
  */
 export declare class ProbeAgent {
@@ -183,6 +199,13 @@ export declare class ProbeAgent {
    * @param messages - Array of chat messages
    */
   setHistory(messages: ChatMessage[]): void;
+
+  /**
+   * Clone this agent's session to create a new agent with shared conversation history
+   * @param options - Clone options
+   * @returns New agent instance with cloned history
+   */
+  clone(options?: CloneOptions): ProbeAgent;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `CloneOptions` interface to TypeScript definitions
- Add `clone()` method signature to ProbeAgent class

## Context
The `clone()` method was implemented in PR #230 but the TypeScript definitions were not updated. This PR adds the missing type definitions to both `npm/index.d.ts` and `npm/src/agent/ProbeAgent.d.ts`.

## Changes
- Added `CloneOptions` interface with all clone options (sessionId, stripInternalMessages, keepSystemMessage, deepCopy, overrides)
- Added `clone(options?: CloneOptions): ProbeAgent` method to ProbeAgent class

## Test Plan
Type definitions match the implementation in `npm/src/agent/ProbeAgent.js:2177` and the usage in test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)