### PR TITLE
Fix JSON schema prompt contradictions and validation loop

### DIFF
--- a/npm/tests/unit/schema-aware-reminders.test.js
+++ b/npm/tests/unit/schema-aware-reminders.test.js
@@ -27,15 +27,14 @@ Remember: Use proper XML format with BOTH opening and closing tags:
 <parameter>value</parameter>
 </tool_name>
 
-IMPORTANT: A schema was provided. You MUST respond with data that matches this schema.
-Use attempt_completion with your response directly inside the tags:
+IMPORTANT: A schema was provided for the final output format.
 
+You MUST use attempt_completion to provide your answer:
 <attempt_completion>
-{"key": "value", "field": "your actual data here matching the schema"}
+[Your complete answer here - provide in natural language, it will be automatically formatted to match the schema]
 </attempt_completion>
 
-Your response must conform to this schema:
-${options.schema}`;
+Your response will be automatically formatted to JSON. You can provide your answer in natural language or as JSON - either will work.`;
         } else {
           // Standard reminder without schema
           reminderContent = `Please use one of the available tools to help answer the question, or use attempt_completion if you have enough information to provide a final answer.
@@ -63,17 +62,16 @@ Or for quick completion if your previous response was already correct:
       const reminder = mockAgent.buildReminderMessage(options);
 
       expect(reminder).toContain('A schema was provided');
-      expect(reminder).toContain('You MUST respond with data that matches this schema');
+      expect(reminder).toContain('You MUST use attempt_completion');
       expect(reminder).toContain('attempt_completion');
-      expect(reminder).toContain('{"key": "value", "field": "your actual data here matching the schema"}');
-      expect(reminder).toContain('Your response must conform to this schema:');
-      expect(reminder).toContain(options.schema);
+      expect(reminder).toContain('provide in natural language');
+      expect(reminder).toContain('automatically formatted to JSON');
 
       // Should NOT contain the shorthand attempt_complete
       expect(reminder).not.toContain('<attempt_complete>');
     });
 
-    test('should include full schema in reminder without truncation', () => {
+    test('should include schema instructions in reminder', () => {
       const longSchema = `{
         "type": "object",
         "properties": {
@@ -99,10 +97,9 @@ Or for quick completion if your previous response was already correct:
       const options = { schema: longSchema };
       const reminder = mockAgent.buildReminderMessage(options);
 
-      // Should include the complete schema, not truncated
-      expect(reminder).toContain(longSchema);
-      expect(reminder).toContain('"recommendations"');
-      expect(reminder).toContain('"priority"');
+      // Should include schema-related instructions
+      expect(reminder).toContain('A schema was provided');
+      expect(reminder).toContain('automatically formatted');
     });
 
     test('should work with non-JSON schemas too', () => {
@@ -114,9 +111,8 @@ Or for quick completion if your previous response was already correct:
       const reminder = mockAgent.buildReminderMessage(options);
 
       expect(reminder).toContain('A schema was provided');
-      expect(reminder).toContain('You MUST respond with data that matches this schema');
-      expect(reminder).toContain(mermaidSchema);
-      expect(reminder).toContain('graph TD');
+      expect(reminder).toContain('You MUST use attempt_completion');
+      expect(reminder).toContain('automatically formatted');
     });
 
     test('should provide clear example of attempt_completion format', () => {
@@ -127,8 +123,9 @@ Or for quick completion if your previous response was already correct:
       const reminder = mockAgent.buildReminderMessage(options);
 
       expect(reminder).toContain('<attempt_completion>');
-      expect(reminder).toContain('{"key": "value", "field": "your actual data here matching the schema"}');
+      expect(reminder).toContain('provide in natural language');
       expect(reminder).toContain('</attempt_completion>');
+      expect(reminder).toContain('automatically formatted');
 
       // Should show the direct content format, not <result> wrapper
       expect(reminder).not.toContain('<result>');
@@ -192,8 +189,8 @@ Or for quick completion if your previous response was already correct:
       const reminder = mockAgent.buildReminderMessage(options);
 
       expect(reminder).toContain('A schema was provided');
-      expect(reminder).toContain(options.schema);
-      expect(reminder).toContain('<>&\\"\\n\\t');
+      expect(reminder).toContain('You MUST use attempt_completion');
+      expect(reminder).toContain('automatically formatted');
     });
 
     test('should be consistent with tool formatting instructions', () => {
@@ -233,15 +230,14 @@ Remember: Use proper XML format with BOTH opening and closing tags:
 <parameter>value</parameter>
 </tool_name>
 
-IMPORTANT: A schema was provided. You MUST respond with data that matches this schema.
-Use attempt_completion with your response directly inside the tags:
+IMPORTANT: A schema was provided for the final output format.
 
+You MUST use attempt_completion to provide your answer:
 <attempt_completion>
-{"key": "value", "field": "your actual data here matching the schema"}
+[Your complete answer here - provide in natural language, it will be automatically formatted to match the schema]
 </attempt_completion>
 
-Your response must conform to this schema:
-${options.schema}`;
+Your response will be automatically formatted to JSON. You can provide your answer in natural language or as JSON - either will work.`;
         } else {
           // Standard reminder without schema
           reminderContent = `Please use one of the available tools to help answer the question, or use attempt_completion if you have enough information to provide a final answer.
@@ -269,17 +265,14 @@ Or for quick completion if your previous response was already correct:
     const reminder = integrationMockAgent.buildReminderMessage(options);
 
     // The reminder should clearly state what's expected
-    expect(reminder).toContain('You MUST respond with data that matches this schema');
-    expect(reminder).toContain('Use attempt_completion with your response directly inside the tags');
+    expect(reminder).toContain('A schema was provided');
+    expect(reminder).toContain('You MUST use attempt_completion');
 
     // Should show the exact format expected
     expect(reminder).toContain('<attempt_completion>');
-    expect(reminder).toContain('{"key": "value"');
+    expect(reminder).toContain('provide in natural language');
     expect(reminder).toContain('</attempt_completion>');
-
-    // Should include the schema for reference
-    expect(reminder).toContain('"analysis": "string"');
-    expect(reminder).toContain('"score": "number"');
+    expect(reminder).toContain('automatically formatted');
   });
 
   test('should maintain backward compatibility for non-schema usage', () => {


### PR DESCRIPTION
## Summary

This PR fixes two critical issues in ProbeAgent's JSON schema handling that were causing confusion and performance problems.

## Issue 1: Contradictory and Non-Functional "Option 2" ❌

### Problem
The Schema Reminder prompt told the AI it had two options:
- **Option 1:** Use `attempt_completion`  
- **Option 2:** Provide natural response without tools (will be auto-formatted)

**Option 2 was non-functional** because:
1. If AI responds without tools, the system adds a reminder and continues the loop
2. Eventually hits max iterations
3. Schema formatting is **skipped** when max iterations reached (check at line 1710: `!reachedMaxIterations`)
4. The prompt also said "Do NOT format JSON yourself" which contradicted later formatting requirements

### Fix
Updated Schema Reminder prompt to be clear and accurate:
- ✅ Removed misleading "Option 2"
- ✅ Clarified that `attempt_completion` is **REQUIRED** for schema responses
- ✅ Explained that natural language input will be auto-formatted to JSON
- ✅ Removed contradictory "do NOT format JSON" instruction

**Before:**
```
Option 1 - Use attempt_completion with your complete answer:
<attempt_completion>
[Your complete answer here - will be automatically formatted to match the schema]
</attempt_completion>

Option 2 - Provide a natural response without any tool, and it will be automatically formatted.

Do NOT try to format your response as JSON yourself - this will be done automatically.
```

**After:**
```
You MUST use attempt_completion to provide your answer:
<attempt_completion>
[Your complete answer here - provide in natural language, it will be automatically formatted to match the schema]
</attempt_completion>

Your response will be automatically formatted to JSON. You can provide your answer in natural language or as JSON - either will work.
```

## Issue 2: Validation Loop Causing 4x Repetition 🔄

### Problem
When JSON validation failed in the `attempt_completion` path, recursive correction calls triggered nested validation, causing the same validation to run multiple times as the recursion unwound.

**Example from logs:**
```
[DEBUG] JSON validation: attempt_completion correction successful on attempt 1
[DEBUG] JSON validation: attempt_completion result validation successful
[DEBUG] Mermaid validation: Performing final mermaid validation on result...
[DEBUG] Removed thinking tags from final result
```
This block repeated **4 identical times** (lines 353-412 in user's logs).

**Root Cause Flow:**
1. First `attempt_completion` returns markdown (invalid JSON) → validation fails
2. Recursive `answer()` call with correction prompt
3. Second `attempt_completion` still returns markdown → validation fails again
4. Another recursive `answer()` call
5. This continues 3-4 times
6. As recursion unwinds, **each level runs its own validation**
7. Result: Same validation executed 4 times

### Fix
Added `_skipValidation` flag to prevent validation in recursive correction contexts:
- ✅ Recursive correction calls now pass `_skipValidation: true`
- ✅ Updated condition at line 1928 to check `!options._skipValidation`  
- ✅ Prevents nested validation loops while still validating the final result

## Changes Made

### `npm/src/agent/ProbeAgent.js`
- **Lines 1615-1632:** Updated Schema Reminder to remove Option 2 and contradictions
- **Line 1928:** Added `_skipValidation` check to prevent nested validation
- **Lines 1996-1999, 2040-2043:** Pass `_skipValidation: true` in recursive correction calls

### `npm/tests/unit/schema-aware-reminders.test.js`
- Updated all test expectations to match new prompt wording
- Tests now verify "provide in natural language" and "automatically formatted" messaging

## Testing

✅ All 135 JSON and schema-related tests passing:
- `tests/unit/schemaUtils.test.js` (55 tests)
- `tests/integration/schema-validation-loop-prevention.test.js` (7 tests)
- `tests/unit/attemptCompletionJsonFix.test.js` (8 tests)
- `tests/unit/jsonValidationInfiniteLoopFix.test.js` (7 tests)
- `tests/unit/json-fixing-agent.test.js` (15 tests)
- `tests/unit/json-validation-enhanced-errors.test.js` (15 tests)
- `tests/unit/attemptCompletionJsonIssue.test.js` (4 tests)
- `tests/unit/schemaDefinitionDetection.test.js` (8 tests)
- `tests/integration/schemaRetryLogic.test.js` (3 tests)
- `tests/unit/schema-aware-reminders.test.js` (12 tests)

## Impact

### Before
- AI was confused by contradictory instructions
- "Option 2" path didn't work, leading to max iterations timeout
- Validation ran 4x unnecessarily, wasting tokens and time
- Unclear whether to format JSON or provide natural language

### After
- Clear, single instruction: use `attempt_completion`
- Natural language explicitly allowed and encouraged
- Validation runs once per correction attempt
- Better performance and lower token usage

## Breaking Changes

None - this is a bug fix that improves existing behavior without breaking API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)