### PR TITLE
Fix ESM import compatibility for Bun/Next.js environments

### DIFF
--- a/examples/chat/fileSpanExporter.js
+++ b/examples/chat/fileSpanExporter.js
@@ -1,7 +1,5 @@
 import { createWriteStream } from 'fs';
-import corePkg from '@opentelemetry/core';
-
-const { ExportResultCode } = corePkg;
+import { ExportResultCode } from '@opentelemetry/core';
 
 /**
  * File exporter for OpenTelemetry spans

--- a/examples/chat/telemetry.js
+++ b/examples/chat/telemetry.js
@@ -1,18 +1,12 @@
-import nodeSDKPkg from '@opentelemetry/sdk-node';
-import resourcesPkg from '@opentelemetry/resources';
-import semanticConventionsPkg from '@opentelemetry/semantic-conventions';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { resourceFromAttributes } from '@opentelemetry/resources';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { trace, context } from '@opentelemetry/api';
-import otlpPkg from '@opentelemetry/exporter-trace-otlp-http';
-import spanPkg from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { BatchSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
 import { existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { FileSpanExporter } from './fileSpanExporter.js';
-
-const { NodeSDK } = nodeSDKPkg;
-const { resourceFromAttributes } = resourcesPkg;
-const { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } = semanticConventionsPkg;
-const { OTLPTraceExporter } = otlpPkg;
-const { BatchSpanProcessor, ConsoleSpanExporter } = spanPkg;
 
 /**
  * Custom OpenTelemetry configuration for probe-chat

--- a/npm/src/agent/fileSpanExporter.js
+++ b/npm/src/agent/fileSpanExporter.js
@@ -1,7 +1,5 @@
 import { createWriteStream } from 'fs';
-import corePkg from '@opentelemetry/core';
-
-const { ExportResultCode } = corePkg;
+import { ExportResultCode } from '@opentelemetry/core';
 
 /**
  * File exporter for OpenTelemetry spans

--- a/npm/src/agent/telemetry.js
+++ b/npm/src/agent/telemetry.js
@@ -1,18 +1,13 @@
-import nodeSDKPkg from '@opentelemetry/sdk-node';
-import resourcesPkg from '@opentelemetry/resources';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { trace, context, SpanStatusCode } from '@opentelemetry/api';
-import otlpPkg from '@opentelemetry/exporter-trace-otlp-http';
-import spanPkg from '@opentelemetry/sdk-trace-base';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { BatchSpanProcessor, ConsoleSpanExporter } from '@opentelemetry/sdk-trace-base';
 
 import { existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { FileSpanExporter } from './fileSpanExporter.js';
-
-const { NodeSDK } = nodeSDKPkg;
-const { Resource } = resourcesPkg;
-const { OTLPTraceExporter } = otlpPkg;
-const { BatchSpanProcessor, ConsoleSpanExporter } = spanPkg;
 
 /**
  * Custom OpenTelemetry configuration for probe-agent
@@ -39,7 +34,7 @@ export class TelemetryConfig {
       return;
     }
 
-    const resource = new Resource({
+    const resource = resourceFromAttributes({
       [ATTR_SERVICE_NAME]: this.serviceName,
       [ATTR_SERVICE_VERSION]: this.serviceVersion,
     });

--- a/npm/tests/unit/esm-imports.test.js
+++ b/npm/tests/unit/esm-imports.test.js
@@ -1,0 +1,118 @@
+/**
+ * Tests for ESM import compatibility
+ * Ensures all OpenTelemetry imports use named exports instead of default exports
+ * to maintain compatibility with strict ESM environments (Bun, Next.js Turbopack, etc.)
+ * @module tests/unit/esm-imports
+ */
+
+import { describe, test, expect } from '@jest/globals';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('ESM Import Compatibility', () => {
+  describe('telemetry.js', () => {
+    const telemetryPath = join(__dirname, '../../src/agent/telemetry.js');
+    let telemetryContent;
+
+    beforeAll(() => {
+      telemetryContent = readFileSync(telemetryPath, 'utf-8');
+    });
+
+    test('should not use default imports for @opentelemetry/sdk-node', () => {
+      // Check for default import pattern
+      const defaultImportPattern = /import\s+\w+\s+from\s+['"]@opentelemetry\/sdk-node['"]/;
+      expect(telemetryContent).not.toMatch(defaultImportPattern);
+
+      // Verify named import is used
+      expect(telemetryContent).toMatch(/import\s+\{\s*NodeSDK\s*\}\s+from\s+['"]@opentelemetry\/sdk-node['"]/);
+    });
+
+    test('should not use default imports for @opentelemetry/resources', () => {
+      const defaultImportPattern = /import\s+\w+\s+from\s+['"]@opentelemetry\/resources['"]/;
+      expect(telemetryContent).not.toMatch(defaultImportPattern);
+
+      expect(telemetryContent).toMatch(/import\s+\{\s*resourceFromAttributes\s*\}\s+from\s+['"]@opentelemetry\/resources['"]/);
+    });
+
+    test('should not use default imports for @opentelemetry/exporter-trace-otlp-http', () => {
+      const defaultImportPattern = /import\s+\w+\s+from\s+['"]@opentelemetry\/exporter-trace-otlp-http['"]/;
+      expect(telemetryContent).not.toMatch(defaultImportPattern);
+
+      expect(telemetryContent).toMatch(/import\s+\{\s*OTLPTraceExporter\s*\}\s+from\s+['"]@opentelemetry\/exporter-trace-otlp-http['"]/);
+    });
+
+    test('should not use default imports for @opentelemetry/sdk-trace-base', () => {
+      const defaultImportPattern = /import\s+\w+\s+from\s+['"]@opentelemetry\/sdk-trace-base['"]/;
+      expect(telemetryContent).not.toMatch(defaultImportPattern);
+
+      expect(telemetryContent).toMatch(/import\s+\{\s*BatchSpanProcessor\s*,\s*ConsoleSpanExporter\s*\}\s+from\s+['"]@opentelemetry\/sdk-trace-base['"]/);
+    });
+
+    test('should not have intermediate destructuring of default imports', () => {
+      // Check that we don't have patterns like:
+      // const { NodeSDK } = nodeSDKPkg;
+      const destructuringPatterns = [
+        /const\s+\{\s*NodeSDK\s*\}\s*=\s*\w+Pkg/,
+        /const\s+\{\s*resourceFromAttributes\s*\}\s*=\s*\w+Pkg/,
+        /const\s+\{\s*OTLPTraceExporter\s*\}\s*=\s*\w+Pkg/,
+        /const\s+\{\s*BatchSpanProcessor\s*,\s*ConsoleSpanExporter\s*\}\s*=\s*\w+Pkg/,
+      ];
+
+      destructuringPatterns.forEach((pattern) => {
+        expect(telemetryContent).not.toMatch(pattern);
+      });
+    });
+
+    test('should be valid ESM module', () => {
+      // Verify it doesn't use require() or module.exports
+      expect(telemetryContent).not.toMatch(/\brequire\s*\(/);
+      expect(telemetryContent).not.toMatch(/module\.exports/);
+      expect(telemetryContent).not.toMatch(/exports\./);
+    });
+  });
+
+  describe('fileSpanExporter.js', () => {
+    const exporterPath = join(__dirname, '../../src/agent/fileSpanExporter.js');
+    let exporterContent;
+
+    beforeAll(() => {
+      exporterContent = readFileSync(exporterPath, 'utf-8');
+    });
+
+    test('should not use default imports for @opentelemetry/core', () => {
+      const defaultImportPattern = /import\s+\w+\s+from\s+['"]@opentelemetry\/core['"]/;
+      expect(exporterContent).not.toMatch(defaultImportPattern);
+
+      expect(exporterContent).toMatch(/import\s+\{\s*ExportResultCode\s*\}\s+from\s+['"]@opentelemetry\/core['"]/);
+    });
+
+    test('should not have intermediate destructuring of default imports', () => {
+      expect(exporterContent).not.toMatch(/const\s+\{\s*ExportResultCode\s*\}\s*=\s*\w+Pkg/);
+    });
+  });
+
+  describe('General ESM patterns', () => {
+    test('should verify key OpenTelemetry packages support named exports', async () => {
+      // This test attempts to import the packages to ensure they work in strict ESM
+      // If default imports were used, this would fail in strict ESM environments
+
+      const { NodeSDK } = await import('@opentelemetry/sdk-node');
+      const { resourceFromAttributes } = await import('@opentelemetry/resources');
+      const { OTLPTraceExporter } = await import('@opentelemetry/exporter-trace-otlp-http');
+      const { BatchSpanProcessor, ConsoleSpanExporter } = await import('@opentelemetry/sdk-trace-base');
+      const { ExportResultCode } = await import('@opentelemetry/core');
+
+      // Verify they are constructors/enums/functions
+      expect(typeof NodeSDK).toBe('function');
+      expect(typeof resourceFromAttributes).toBe('function');
+      expect(typeof OTLPTraceExporter).toBe('function');
+      expect(typeof BatchSpanProcessor).toBe('function');
+      expect(typeof ConsoleSpanExporter).toBe('function');
+      expect(ExportResultCode).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes ESM import errors when using `@probelabs/probe@0.6.0-rc136` with Bun and Next.js 15 (Turbopack). The issue was caused by incorrect default imports of OpenTelemetry packages that only provide named exports.

## Problem

When using strict ESM environments (Bun with Next.js Turbopack), the application failed to compile with errors:

```
Export default doesn't exist in target module
import resourcesPkg from '@opentelemetry/resources';
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

The export default was not found in module '@opentelemetry/resources'
Did you mean to import defaultResource?
```

This worked in Node.js due to CommonJS interop but fails in strict ESM environments.

## Changes

Converted all default imports to named imports for OpenTelemetry packages:

**Before:**
```javascript
import nodeSDKPkg from '@opentelemetry/sdk-node';
const { NodeSDK } = nodeSDKPkg;
```

**After:**
```javascript
import { NodeSDK } from '@opentelemetry/sdk-node';
```

### Files Modified
- ✅ `npm/src/agent/telemetry.js` - 4 imports fixed
- ✅ `npm/src/agent/fileSpanExporter.js` - 1 import fixed  
- ✅ `examples/chat/telemetry.js` - 5 imports fixed
- ✅ `examples/chat/fileSpanExporter.js` - 1 import fixed

### Test Coverage
- ✅ Added comprehensive test suite: `npm/tests/unit/esm-imports.test.js`
  - Statically analyzes files for incorrect default imports
  - Verifies named imports are used correctly
  - Ensures no intermediate destructuring patterns
  - Validates ESM module compatibility
  - Tests actual imports work in strict ESM environments
  - **9 tests, all passing**

## Test Results

```
PASS tests/unit/esm-imports.test.js
  ESM Import Compatibility
    telemetry.js
      ✓ should not use default imports for @opentelemetry/sdk-node
      ✓ should not use default imports for @opentelemetry/resources
      ✓ should not use default imports for @opentelemetry/exporter-trace-otlp-http
      ✓ should not use default imports for @opentelemetry/sdk-trace-base
      ✓ should not have intermediate destructuring of default imports
      ✓ should be valid ESM module
    fileSpanExporter.js
      ✓ should not use default imports for @opentelemetry/core
      ✓ should not have intermediate destructuring of default imports
    General ESM patterns
      ✓ should verify key OpenTelemetry packages support named exports

Test Suites: 1 passed, 1 total
Tests:       9 passed, 9 total
```

## Affected Versions

- **Broken:** `@probelabs/probe@0.6.0-rc136`
- **Last working:** `@probelabs/probe@0.6.0-rc128`

## Environment

This fix ensures compatibility with:
- Bun 1.3.0+
- Next.js 15+ with Turbopack
- All strict ESM environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)