### PR TITLE
Fix TypeError in extract() with content parameter

### DIFF
--- a/npm/src/extract.js
+++ b/npm/src/extract.js
@@ -115,7 +115,7 @@ export async function extract(options) {
  */
 function extractWithStdin(binaryPath, cliArgs, content, options) {
 	return new Promise((resolve, reject) => {
-		const process = spawn(binaryPath, ['extract', ...cliArgs], {
+		const childProcess = spawn(binaryPath, ['extract', ...cliArgs], {
 			stdio: ['pipe', 'pipe', 'pipe']
 		});
 
@@ -123,17 +123,17 @@ function extractWithStdin(binaryPath, cliArgs, content, options) {
 		let stderr = '';
 
 		// Collect stdout
-		process.stdout.on('data', (data) => {
+		childProcess.stdout.on('data', (data) => {
 			stdout += data.toString();
 		});
 
 		// Collect stderr
-		process.stderr.on('data', (data) => {
+		childProcess.stderr.on('data', (data) => {
 			stderr += data.toString();
 		});
 
 		// Handle process exit
-		process.on('close', (code) => {
+		childProcess.on('close', (code) => {
 			if (stderr && process.env.DEBUG === '1') {
 				console.error(`stderr: ${stderr}`);
 			}
@@ -152,17 +152,17 @@ function extractWithStdin(binaryPath, cliArgs, content, options) {
 		});
 
 		// Handle errors
-		process.on('error', (error) => {
+		childProcess.on('error', (error) => {
 			reject(new Error(`Failed to spawn extract process: ${error.message}`));
 		});
 
 		// Write content to stdin and close
 		if (typeof content === 'string') {
-			process.stdin.write(content);
+			childProcess.stdin.write(content);
 		} else {
-			process.stdin.write(content);
+			childProcess.stdin.write(content);
 		}
-		process.stdin.end();
+		childProcess.stdin.end();
 	});
 }
 

--- a/npm/tests/unit/extract-content.test.js
+++ b/npm/tests/unit/extract-content.test.js
@@ -1,0 +1,83 @@
+/**
+ * Test for extract() function with content parameter
+ * This test verifies the fix for the process.env.DEBUG bug
+ */
+
+import { extract } from '../../src/index.js';
+import path from 'path';
+
+describe('extract() with content parameter', () => {
+	// Sample diff content for testing
+	const diffContent = `diff --git a/src/main.rs b/src/main.rs
+index 123..456
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -10,3 +10,4 @@
+ fn main() {
+-    println!("old");
++    println!("new");
+ }`;
+
+	test('should process diff content without crashing', async () => {
+		// This test verifies that the extract function doesn't crash
+		// when accessing process.env.DEBUG
+		const result = await extract({
+			content: diffContent,
+			format: 'outline-xml',
+		});
+
+		// Should return a result (string for outline-xml format)
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	test('should handle DEBUG environment variable correctly', async () => {
+		// Test with DEBUG enabled
+		const originalDebug = process.env.DEBUG;
+		process.env.DEBUG = '1';
+
+		try {
+			const result = await extract({
+				content: diffContent,
+				format: 'outline-xml',
+			});
+
+			expect(result).toBeDefined();
+		} finally {
+			// Restore original DEBUG value
+			if (originalDebug === undefined) {
+				delete process.env.DEBUG;
+			} else {
+				process.env.DEBUG = originalDebug;
+			}
+		}
+	});
+
+	test('should work with outline-xml format', async () => {
+		const result = await extract({
+			content: diffContent,
+			format: 'outline-xml',
+		});
+
+		expect(result).toBeDefined();
+		expect(typeof result).toBe('string');
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	test('should handle errors gracefully', async () => {
+		// Test with invalid content
+		try {
+			await extract({
+				content: 'invalid diff content',
+				format: 'outline-xml',
+			});
+			// If it succeeds, that's also acceptable
+		} catch (error) {
+			// Should throw a proper Error object, not a TypeError about undefined
+			expect(error).toBeInstanceOf(Error);
+			expect(error.message).not.toContain('Cannot read properties of undefined');
+			expect(error.message).not.toContain('process2');
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Fixed a critical bug in the `extract()` function that caused a `TypeError` when called with the `content` parameter. The error occurred due to variable shadowing where a local `process` variable (ChildProcess instance) shadowed the global Node.js `process` object.

## Problem

In version `0.6.0-rc139`, calling `extract()` with the `content` parameter would crash with:

```
TypeError: Cannot read properties of undefined (reading 'DEBUG')
    at ChildProcess.<anonymous> (/path/to/node_modules/@probelabs/probe/cjs/index.cjs:1103:34)
```

### Root Cause

The `extractWithStdin()` function in `npm/src/extract.js` had a variable shadowing issue:

1. Line 118 created a local variable: `const process = spawn(...)`
2. Line 137 tried to access: `process.env.DEBUG`
3. When bundled for CommonJS, esbuild renamed the local variable to `process2`
4. This caused `process2.env.DEBUG` to be undefined since `process2` is a ChildProcess, not the global process object

## Solution

- Renamed the local variable from `process` to `childProcess` throughout the `extractWithStdin()` function
- Line 137 now correctly accesses the global `process.env.DEBUG`
- The bundled CommonJS code now properly distinguishes between the ChildProcess instance and the global process object

## Changes

- **npm/src/extract.js**: Renamed local `process` variable to `childProcess` (lines 118-166)
- **npm/tests/unit/extract-content.test.js**: Added comprehensive test suite to prevent regression
- **npm/cjs/index.cjs**: Automatically rebuilt with the fix (gitignored)

## Testing

Added 4 new tests that verify:
1. ✅ extract() processes diff content without crashing
2. ✅ DEBUG environment variable is handled correctly
3. ✅ outline-xml format works properly
4. ✅ Errors are handled gracefully (no more TypeError about undefined)

All tests pass:
- **810 tests passed** (including 4 new tests)
- 1 pre-existing failure unrelated to this fix

## Impact

This fix enables the `content` parameter feature for `extract()`, allowing users to:
- Process diffs without writing to temporary files
- Use the `outline-xml` format with inline content
- Properly handle DEBUG mode without crashes

## Test plan

- [x] Unit tests pass (`npm test`)
- [x] Manual testing with content parameter works
- [x] DEBUG=1 mode works correctly
- [x] CJS bundle generated correctly
- [x] No regression in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)