### PR TITLE
Conditionally show verbose search output

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,10 @@ pub struct Args {
     #[arg(long = "question")]
     pub question: Option<String>,
 
+    /// Enable verbose output (show probe version, pattern, path, options, and timing)
+    #[arg(short = 'v', long = "verbose")]
+    pub verbose: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -212,6 +216,10 @@ pub enum Commands {
         /// Natural language question for BERT reranking (requires --features bert-reranker)
         #[arg(long = "question")]
         question: Option<String>,
+
+        /// Enable verbose output (show probe version, pattern, path, options, and timing)
+        #[arg(short = 'v', long = "verbose")]
+        verbose: bool,
     },
 
     /// Extract code blocks from files

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ struct SearchParams {
     timeout: u64,
     question: Option<String>,
     no_gitignore: bool,
+    verbose: bool,
 }
 
 struct BenchmarkParams {
@@ -54,15 +55,15 @@ struct BenchmarkParams {
 }
 
 fn handle_search(params: SearchParams) -> Result<()> {
-    // Print version at the start for text-based formats
-    if params.format != "json" && params.format != "xml" {
+    // Print version at the start for text-based formats (only if verbose)
+    if params.verbose && params.format != "json" && params.format != "xml" {
         println!("Probe version: {}", probe_code::version::get_version());
     }
 
     let use_frequency = params.frequency_search;
 
-    // Don't print these headers for JSON/XML formats
-    if params.format != "json" && params.format != "xml" {
+    // Don't print these headers for JSON/XML formats (only if verbose)
+    if params.verbose && params.format != "json" && params.format != "xml" {
         println!("{} {}", "Pattern:".bold().green(), params.pattern);
         println!(
             "{} {}",
@@ -112,7 +113,11 @@ fn handle_search(params: SearchParams) -> Result<()> {
         advanced_options.push(format!("Timeout: {} seconds", params.timeout));
     }
 
-    if !advanced_options.is_empty() && params.format != "json" && params.format != "xml" {
+    if params.verbose
+        && !advanced_options.is_empty()
+        && params.format != "json"
+        && params.format != "xml"
+    {
         println!(
             "{} {}",
             "Options:".bold().green(),
@@ -176,11 +181,13 @@ fn handle_search(params: SearchParams) -> Result<()> {
         } else {
             // For other formats, print the "No results found" message
             println!("{}", "No results found.".yellow().bold());
-            println!("Search completed in {duration:.2?}");
+            if params.verbose {
+                println!("Search completed in {duration:.2?}");
+            }
         }
     } else {
-        // For non-JSON/XML formats, print search time
-        if params.format != "json" && params.format != "xml" {
+        // For non-JSON/XML formats, print search time (only if verbose)
+        if params.verbose && params.format != "json" && params.format != "xml" {
             println!("Search completed in {duration:.2?}");
             println!();
         }
@@ -478,6 +485,7 @@ async fn main() -> Result<()> {
                 question: args.question,
                 no_gitignore: args.no_gitignore
                     || std::env::var("PROBE_NO_GITIGNORE").unwrap_or_default() == "1",
+                verbose: args.verbose,
             })?
         }
         Some(Commands::Search {
@@ -502,6 +510,7 @@ async fn main() -> Result<()> {
             timeout,
             question,
             no_gitignore,
+            verbose,
         }) => handle_search(SearchParams {
             pattern,
             paths,
@@ -525,6 +534,7 @@ async fn main() -> Result<()> {
             question,
             no_gitignore: no_gitignore
                 || std::env::var("PROBE_NO_GITIGNORE").unwrap_or_default() == "1",
+            verbose,
         })?,
         Some(Commands::Extract {
             files,


### PR DESCRIPTION
## Background
The default search output was too verbose, printing headers and timing information that are not always desired. This change introduces a `--verbose` flag to control this behavior.

## Changes
- **`src/cli.rs`**:
  - Added a `verbose: bool` field to the `Args` struct.
  - Added a `verbose: bool` field to the `Search` subcommand within `Commands`.
- **`src/main.rs`**:
  - Added a `verbose: bool` field to the `SearchParams` struct.
  - Modified `handle_search` to conditionally print:
    - Probe version
    - Pattern, path, and options headers
    - "Search completed in..." timing message
    - The "Search completed in..." timing message when no results are found.
  - The `SearchParams` struct is now populated with the `verbose` flag from `Args` and `Commands::Search`.

## Testing
- [ ] Run `probe search <pattern>` without the `--verbose` flag. Verify that only the Session ID (if applicable) and results (or "No results found.") are displayed, without version, pattern, or timing information.
- [ ] Run `probe search <pattern> -v` (or `--verbose`). Verify that the Probe version, Pattern, Path, Options, and "Search completed in..." timing information are displayed.
- [ ] Run `probe search <pattern> --question "some question"` with and without `-v`. Verify that the verbose output for search options and timing is applied correctly based on the flag.
