### PR TITLE
Make MCP strict ElasticSearch syntax optional with relaxed default

### DIFF
--- a/npm/src/mcp/index.ts
+++ b/npm/src/mcp/index.ts
@@ -113,6 +113,7 @@ interface SearchCodeArgs {
   path: string;
   query: string | string[];
   exact?: boolean;
+  strictElasticSyntax?: boolean;
 }
 
 interface ExtractCodeArgs {
@@ -175,11 +176,16 @@ class ProbeServer {
               },
               query: {
                 type: 'string',
-                description: 'ElasticSearch query syntax. MUST use explicit AND/OR operators and parentheses for grouping. For exact matches, ALWAYS wrap terms in quotes. Examples: "functionName" (exact match), (error AND handler), ("getUserId" AND NOT deprecated)',
+                description: 'ElasticSearch query syntax. Use explicit AND/OR operators and parentheses for grouping. For exact matches, wrap terms in quotes. Examples: "functionName" (exact match), (error AND handler), ("getUserId" AND NOT deprecated)',
               },
               exact: {
                 type: 'boolean',
                 description: 'Use when searching for exact function/class/variable names',
+                default: false
+              },
+              strictElasticSyntax: {
+                type: 'boolean',
+                description: 'Enforce strict ElasticSearch query syntax (require explicit AND/OR operators and quotes for exact matches)',
                 default: false
               }
             },
@@ -329,11 +335,12 @@ class ProbeServer {
         session: "new",            // Fresh session each time
         maxResults: 20,            // Reasonable limit for context window
         maxTokens: 8000,           // Fits in most AI context windows
-        strictElasticSyntax: true, // Enforce strict ES syntax in MCP mode
+        strictElasticSyntax: false, // Relaxed syntax by default in MCP mode
       };
 
       // Only override defaults if user explicitly set them
       if (args.exact !== undefined) options.exact = args.exact;
+      if (args.strictElasticSyntax !== undefined) options.strictElasticSyntax = args.strictElasticSyntax;
 
       // Handle format based on server default
       if (this.defaultFormat === 'outline' || this.defaultFormat === 'outline-xml') {

--- a/npm/tests/mcp-strict-syntax.test.js
+++ b/npm/tests/mcp-strict-syntax.test.js
@@ -302,7 +302,7 @@ function handleError(err) {
     expect(typeof result).toBe('string');
   });
 
-  test('MCP default behavior enables strict syntax', () => {
+  test('MCP default behavior disables strict syntax', () => {
     // This is a static test, always runs
     const mcpOptions = {
       path: '/some/path',
@@ -311,9 +311,9 @@ function handleError(err) {
       session: "new",
       maxResults: 20,
       maxTokens: 8000,
-      strictElasticSyntax: true, // This is the MCP default
+      strictElasticSyntax: false, // This is the MCP default (relaxed syntax)
     };
 
-    expect(mcpOptions.strictElasticSyntax).toBe(true);
+    expect(mcpOptions.strictElasticSyntax).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The MCP `search_code` tool previously enforced strict ElasticSearch syntax by default, requiring explicit AND/OR operators for multi-word queries. This was too restrictive for natural language queries from AI assistants.

This PR makes strict syntax **optional** and changes the **default to relaxed** (false).

## Changes

- ✅ Added `strictElasticSyntax` parameter to MCP `search_code` tool schema
- ✅ Changed default from `strictElasticSyntax: true` to `strictElasticSyntax: false`
- ✅ Updated tool description to be less prescriptive (removed "MUST")
- ✅ Users can now opt-in to strict syntax when needed
- ✅ Updated tests to reflect new default behavior

## Before vs After

**Before:**
- Query `"error handler"` → ❌ Error (requires explicit AND/OR)
- No way to disable strict syntax

**After:**
- Query `"error handler"` → ✅ Works (relaxed mode)
- Query `"error handler"` with `strictElasticSyntax: true` → ❌ Error (strict mode)
- Users have full control via the parameter

## Test Results

All tests passing:
- ✅ 10/10 MCP strict syntax tests
- ✅ 249 Rust unit tests
- ✅ Integration tests

## Files Changed

- `npm/src/mcp/index.ts` - Added parameter, changed default, updated description
- `npm/tests/mcp-strict-syntax.test.js` - Updated test to reflect new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)