### PR TITLE
Fix extract tool to handle multiple space-separated targets

### DIFF
--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -484,6 +484,30 @@ export function createMessagePreview(message, charsPerSide = 200) {
 	// Message is longer - show start and end with ... in between
 	const start = message.substring(0, charsPerSide);
 	const end = message.substring(message.length - charsPerSide);
-	
+
 	return `${start}...${end}`;
+}
+
+/**
+ * Parse targets string into array of file specifications
+ * Handles space-separated targets for extract tool
+ *
+ * @param {string} targets - Space-separated file targets (e.g., "file1.rs:10-20 file2.rs#symbol")
+ * @returns {string[]} Array of individual file specifications
+ *
+ * @example
+ * parseTargets("file1.rs:10-20 file2.rs:30-40")
+ * // Returns: ["file1.rs:10-20", "file2.rs:30-40"]
+ *
+ * @example
+ * parseTargets("session.rs#AuthService.login auth.rs:2-100 config.rs#DatabaseConfig")
+ * // Returns: ["session.rs#AuthService.login", "auth.rs:2-100", "config.rs#DatabaseConfig"]
+ */
+export function parseTargets(targets) {
+	if (!targets || typeof targets !== 'string') {
+		return [];
+	}
+
+	// Split on any whitespace (spaces, tabs, newlines) and filter out empty strings
+	return targets.split(/\s+/).filter(f => f.length > 0);
 }

--- a/npm/src/tools/langchain.js
+++ b/npm/src/tools/langchain.js
@@ -6,7 +6,7 @@
 import { search } from '../search.js';
 import { query } from '../query.js';
 import { extract } from '../extract.js';
-import { searchSchema, querySchema, extractSchema, searchDescription, queryDescription, extractDescription } from './common.js';
+import { searchSchema, querySchema, extractSchema, searchDescription, queryDescription, extractDescription, parseTargets } from './common.js';
 
 // LangChain tool for searching code
 export function createSearchTool() {
@@ -69,7 +69,8 @@ export function createExtractTool() {
 		schema: extractSchema,
 		func: async ({ targets, line, end_line, allow_tests, context_lines, format }) => {
 			try {
-				const files = [targets];
+				// Split targets on whitespace to support multiple targets in one call
+				const files = parseTargets(targets);
 
 				const results = await extract({
 					files,

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -8,7 +8,7 @@ import { search } from '../search.js';
 import { query } from '../query.js';
 import { extract } from '../extract.js';
 import { delegate } from '../delegate.js';
-import { searchSchema, querySchema, extractSchema, delegateSchema, searchDescription, queryDescription, extractDescription, delegateDescription } from './common.js';
+import { searchSchema, querySchema, extractSchema, delegateSchema, searchDescription, queryDescription, extractDescription, delegateDescription, parseTargets } from './common.js';
 
 /**
  * Search tool generator
@@ -191,7 +191,7 @@ export const extractTool = (options = {}) => {
 				} else if (targets) {
 					// Parse targets to handle line numbers and symbol names
 					// Split on whitespace to support multiple targets in one call
-					const files = targets.split(/\s+/).filter(f => f.length > 0);
+					const files = parseTargets(targets);
 
 					// Apply format mapping for outline-xml to xml
 					let effectiveFormat = format;

--- a/npm/tests/unit/extract-multiple-targets.test.js
+++ b/npm/tests/unit/extract-multiple-targets.test.js
@@ -1,62 +1,56 @@
 /**
- * Test for extractTool() function with multiple space-separated targets
+ * Test for parseTargets() utility and extract tool integration
  * This test verifies that the extract tool can handle multiple targets in one call
  */
 
-describe('extractTool() with multiple targets - unit tests for target splitting', () => {
+import { parseTargets } from '../../src/tools/common.js';
+
+describe('parseTargets() utility function', () => {
 	test('should split single target correctly', () => {
-		const targets = 'src/main.rs:10-20';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('src/main.rs:10-20');
 
 		expect(files).toEqual(['src/main.rs:10-20']);
 	});
 
 	test('should split multiple space-separated targets', () => {
-		const targets = 'src/main.rs:10-20 src/lib.rs:30-40';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('src/main.rs:10-20 src/lib.rs:30-40');
 
 		expect(files).toEqual(['src/main.rs:10-20', 'src/lib.rs:30-40']);
 	});
 
 	test('should handle three or more targets', () => {
-		const targets = 'file1.rs:1-10 file2.rs:20-30 file3.rs:40-50';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('file1.rs:1-10 file2.rs:20-30 file3.rs:40-50');
 
 		expect(files).toEqual(['file1.rs:1-10', 'file2.rs:20-30', 'file3.rs:40-50']);
 	});
 
 	test('should handle targets with symbol references', () => {
-		const targets = 'session.rs#AuthService.login auth.rs:2-100 config.rs#DatabaseConfig';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('session.rs#AuthService.login auth.rs:2-100 config.rs#DatabaseConfig');
 
 		expect(files).toEqual(['session.rs#AuthService.login', 'auth.rs:2-100', 'config.rs#DatabaseConfig']);
 	});
 
 	test('should handle targets with multiple spaces', () => {
-		const targets = 'file1.rs:1-10    file2.rs:20-30';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('file1.rs:1-10    file2.rs:20-30');
 
 		expect(files).toEqual(['file1.rs:1-10', 'file2.rs:20-30']);
 	});
 
 	test('should handle targets with tabs and mixed whitespace', () => {
-		const targets = 'file1.rs:1-10\tfile2.rs:20-30  file3.rs:40-50';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('file1.rs:1-10\tfile2.rs:20-30  file3.rs:40-50');
 
 		expect(files).toEqual(['file1.rs:1-10', 'file2.rs:20-30', 'file3.rs:40-50']);
 	});
 
 	test('should filter out empty strings from whitespace', () => {
-		const targets = '  file1.rs:1-10   file2.rs:20-30  ';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('  file1.rs:1-10   file2.rs:20-30  ');
 
 		expect(files).toEqual(['file1.rs:1-10', 'file2.rs:20-30']);
 	});
 
 	test('should handle the example from the bug report', () => {
 		// This is the exact example from the user's bug report
-		const targets = 'src/check-execution-engine.ts:283-469 src/check-execution-engine.ts:474-753';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('src/check-execution-engine.ts:283-469 src/check-execution-engine.ts:474-753');
 
 		expect(files).toEqual([
 			'src/check-execution-engine.ts:283-469',
@@ -65,17 +59,31 @@ describe('extractTool() with multiple targets - unit tests for target splitting'
 	});
 
 	test('should handle newlines as whitespace', () => {
-		const targets = 'file1.rs:1-10\nfile2.rs:20-30';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('file1.rs:1-10\nfile2.rs:20-30');
 
 		expect(files).toEqual(['file1.rs:1-10', 'file2.rs:20-30']);
 	});
 
 	test('should not split targets incorrectly - no spaces means single file', () => {
-		const targets = 'src/main.rs:10-20';
-		const files = targets.split(/\s+/).filter(f => f.length > 0);
+		const files = parseTargets('src/main.rs:10-20');
 
 		expect(files).toHaveLength(1);
 		expect(files[0]).toBe('src/main.rs:10-20');
+	});
+
+	test('should handle null or undefined input', () => {
+		expect(parseTargets(null)).toEqual([]);
+		expect(parseTargets(undefined)).toEqual([]);
+	});
+
+	test('should handle empty string', () => {
+		expect(parseTargets('')).toEqual([]);
+		expect(parseTargets('   ')).toEqual([]);
+	});
+
+	test('should handle non-string input gracefully', () => {
+		expect(parseTargets(123)).toEqual([]);
+		expect(parseTargets({})).toEqual([]);
+		expect(parseTargets([])).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes a bug in the extract tools (Vercel AI SDK and LangChain wrappers) where multiple space-separated targets were not being split correctly, causing the entire string to be treated as a single malformed file path.

## Problem

When calling the extract tool with multiple targets like:
```xml
<extract>
<targets>src/file1.ts:283-469 src/file2.ts:474-753</targets>
</extract>
```

The tool was passing `["src/file1.ts:283-469 src/file2.ts:474-753"]` as a single-element array instead of splitting it into separate targets.

## Root Causes

**Both tools had the same bug:**
- `npm/src/tools/vercel.js:193` - Wrapping targets in array
- `npm/src/tools/langchain.js:72` - Wrapping targets in array

```javascript
const files = [targets];  // ❌ Wrong
```

## Solution

### 1. Created Shared Utility Function (`npm/src/tools/common.js`)

```javascript
export function parseTargets(targets) {
  if (!targets || typeof targets !== 'string') {
    return [];
  }
  return targets.split(/\s+/).filter(f => f.length > 0);
}
```

### 2. Updated Both Tools

**Vercel tool:**
```javascript
const files = parseTargets(targets);  // ✅ Correct
```

**LangChain tool:**
```javascript
const files = parseTargets(targets);  // ✅ Correct
```

This matches the documented behavior in `npm/src/tools/common.js` which explicitly states:
> "Multiple Extraction: You can extract multiple symbols/files in one call by providing multiple file paths separated by spaces."

## Testing

Enhanced test suite (`npm/tests/unit/extract-multiple-targets.test.js`) with 13 test cases:
- ✅ Single targets
- ✅ Multiple space-separated targets  
- ✅ Targets with symbol references (`#`)
- ✅ Multiple spaces, tabs, and mixed whitespace
- ✅ The exact example from the bug report
- ✅ Edge cases: null, undefined, non-string inputs

All tests pass:
```
Test Suites: 1 passed
Tests:       13 passed
```

## Changes

### Commit 1: Initial Fix
- Fixed Vercel extract tool
- Added 10 test cases

### Commit 2: Refactoring & LangChain Fix  
- Created shared `parseTargets()` utility
- Fixed LangChain extract tool (same bug)
- Refactored Vercel tool to use shared utility
- Added 3 more test cases for edge cases

## Benefits

✅ **DRY Principle**: Single source of truth for target parsing  
✅ **Consistency**: Both tools behave identically  
✅ **Maintainability**: Future fixes only need to update one function  
✅ **Testability**: Utility function tested independently  
✅ **Robustness**: Handles edge cases (null, undefined, non-string)

## Impact

- **MCP Server** (`npm/src/mcp/index.ts`): No changes needed - already correct
- **Vercel AI SDK Tools** (`npm/src/tools/vercel.js`): Fixed ✅
- **LangChain Tools** (`npm/src/tools/langchain.js`): Fixed ✅
- **Core extract function** (`npm/src/extract.js`): No changes needed - already handles arrays correctly

## Notes

The underlying `extract()` function and Rust CLI already correctly handle multiple file specifications. This fix ensures the JavaScript wrappers properly parse the space-separated format before passing it down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)