### PR TITLE
Add search tip for general queries

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -364,6 +364,12 @@ fn handle_search(params: SearchParams) -> Result<()> {
         }
     }
 
+    // Add helpful tip at the very bottom of output (but not for JSON/XML formats)
+    if params.format != "json" && params.format != "xml" {
+        println!();
+        println!("💡 Tip: Try using synonyms or making your search more general if you don't find what you're looking for");
+    }
+
     Ok(())
 }
 

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -465,6 +465,12 @@ struct SearchConfig {
         "Should show guidance message about using session ID"
     );
 
+    // Check that the tip message appears at the bottom
+    assert!(
+        stdout.contains("💡 Tip: Try using synonyms or making your search more general if you don't find what you're looking for"),
+        "Should show tip about using synonyms or more general search"
+    );
+
     // Should only report 1 result in the summary
     assert!(
         stdout.contains("Found 1 search results"),


### PR DESCRIPTION
## Background
The previous tip guiding users to use synonyms or more general search terms was removed. This PR reintroduces a similar tip with updated wording.

## Changes
- `src/main.rs`: Added a conditional print statement to display a helpful tip at the end of search results, excluding JSON and XML formats. The tip reads: "💡 Tip: Try using synonyms or making your search more general if you don't find what you're looking for".
- `tests/cli_tests.rs`: Added an assertion to the `test_cli_limit_message` test to ensure the new tip message is present in the standard output for non-JSON/XML formats.

## Testing
- [ ] Run `cargo test` to ensure all tests pass.
- [ ] Execute the CLI search command with text output and verify the tip appears at the end.
- [ ] Execute the CLI search command with JSON output and verify the tip does not appear.
- [ ] Execute the CLI search command with XML output and verify the tip does not appear.
