### PR TITLE
Add schema validation and strict mode

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -76,14 +76,15 @@
     "@ai-sdk/openai": "^2.0.10",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@probelabs/maid": "^0.0.16",
+    "adm-zip": "^0.5.16",
     "ai": "^5.0.0",
+    "ajv": "^8.17.1",
     "axios": "^1.8.3",
     "dotenv": "^16.4.7",
     "fs-extra": "^11.1.1",
     "glob": "^10.3.10",
     "gpt-tokenizer": "^3.0.1",
     "tar": "^6.2.0",
-    "adm-zip": "^0.5.16",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1831,7 +1831,7 @@ Convert your previous response content into actual JSON data that follows this s
               });
             }
 
-            let validation = validateJsonResponse(finalResult, { debug: this.debug });
+            let validation = validateJsonResponse(finalResult, { debug: this.debug, schema: options.schema });
             let retryCount = 0;
             const maxRetries = 3;
 
@@ -1882,7 +1882,7 @@ Convert your previous response content into actual JSON data that follows this s
                   );
 
                   // Validate the corrected response
-                  currentValidation = validateJsonResponse(currentResult, { debug: this.debug });
+                  currentValidation = validateJsonResponse(currentResult, { debug: this.debug, schema: options.schema });
                   retryCount++;
 
                   if (this.debug) {


### PR DESCRIPTION
This PR introduces robust JSON schema validation for probe agent responses, ensuring data integrity and compliance. It leverages the `ajv` library to validate responses against provided schemas, rejecting invalid data and enabling auto-correction.

## Background
Previously, the probe agent would only check for basic JSON parsability. It did not enforce schema constraints like required fields, correct data types, or prohibit unknown fields. This led to unreliable data outputs.

## Changes
- **`npm/package.json`**: Added `ajv` dependency for JSON schema validation.
- **`npm/src/agent/schemaUtils.js`**:
    - Introduced `validateJsonResponse` function that accepts an optional `schema` parameter.
    - Integrated `ajv` for schema validation.
    - Implemented `strictSchema` option (defaulting to `true`) which recursively enforces `additionalProperties: false` on all object schemas, ensuring no unknown fields are present at any nesting level.
    - Enhanced error reporting with crisp messages, including dot notation paths, actual values, and actionable suggestions.
    - Added `enforceNoAdditionalProperties` helper function for recursive schema modification.
- **`npm/src/agent/ProbeAgent.js`**:
    - Modified `validateJsonResponse` calls to pass the `options.schema` to the validator, enabling schema validation during initial response processing and retries.
- **`npm/tests/unit/schemaUtils.test.js`**:
    - Added extensive unit tests (over 80 tests total) covering:
        - Basic schema validation (required fields, types)
        - `additionalProperties` enforcement (root and nested)
        - Strict mode behavior and opt-out (`strictSchema: false`)
        - Validation of complex schema constructs (`oneOf`, `anyOf`, `allOf`, `definitions`, `$defs`, tuples)
        - Enhanced error message clarity and detail
        - Backward compatibility

## Testing
- [x] Verify JSON responses with missing required fields are rejected and corrected.
- [x] Verify JSON responses with incorrect data types are rejected and corrected.
- [x] Verify JSON responses with extra fields (at root and nested) are rejected and corrected when `strictSchema` is true.
- [x] Verify JSON responses with extra fields are accepted when `strictSchema` is false.
- [x] Verify responses against schemas with `additionalProperties: true` are accepted.
- [x] Test nested and deeply nested schema structures.
- [x] Test array item validation.
- [x] Confirm error messages are clear, include dot notation paths, actual values, and actionable suggestions.
