### PR TITLE
Update default model in ProbeAgent.js

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -384,7 +384,7 @@ export class ProbeAgent {
       apiKey: apiKey,
       ...(apiUrl && { baseURL: apiUrl }),
     });
-    this.model = modelName || 'claude-opus-4-1-20250805';
+    this.model = modelName || 'claude-sonnet-4-5-20250929';
     this.apiType = 'anthropic';
     
     if (this.debug) {


### PR DESCRIPTION
## Background
The default model in `ProbeAgent.js` was set to an older version of Opus. This change updates it to the newer `claude-sonnet-4-5-20250929` as requested.

## Changes
- `npm/src/agent/ProbeAgent.js`: Changed the default model from `'claude-opus-4-1-20250805'` to `'claude-sonnet-4-5-20250929'`.

## Testing
- [ ] Verify the default model in `ProbeAgent.js` is now `claude-sonnet-4-5-20250929`.
- [ ] Confirm that other model configurations still function correctly.
