### PR TITLE
Fix ProbeAgent model option precedence

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2208,7 +2208,7 @@ Convert your previous response content into actual JSON data that follows this s
       path: this.allowedFolders[0], // Use first allowed folder as primary path
       allowedFolders: [...this.allowedFolders],
       provider: this.clientApiProvider,
-      model: this.model,
+      model: this.clientApiModel,
       debug: this.debug,
       outline: this.outline,
       maxResponseTokens: this.maxResponseTokens,

--- a/npm/tests/unit/probe-agent-model-option.test.js
+++ b/npm/tests/unit/probe-agent-model-option.test.js
@@ -67,10 +67,27 @@ describe('ProbeAgent model option', () => {
 
     const cloned = baseAgent.clone();
 
-    // The clone should preserve the model from the original agent
-    // Note: In test mode, the actual model will be 'original-model' since we pass it through
-    expect(cloned.model).toBe(baseAgent.model);
+    // The clone should preserve the user's model preference (clientApiModel)
+    expect(cloned.clientApiModel).toBe(baseAgent.clientApiModel);
+    expect(cloned.clientApiModel).toBe('original-model');
+    // Both should resolve to the same actual model
     expect(cloned.model).toBe('original-model');
+  });
+
+  test('should preserve absence of model option in clone', () => {
+    const baseAgent = new ProbeAgent({
+      path: process.cwd()
+      // No model specified
+    });
+
+    const cloned = baseAgent.clone();
+
+    // The clone should not have a model preference either
+    expect(cloned.clientApiModel).toBeNull();
+    expect(baseAgent.clientApiModel).toBeNull();
+    // Both should use the default mock model
+    expect(cloned.model).toBe('mock-model');
+    expect(baseAgent.model).toBe('mock-model');
   });
 
   test('should allow override of model option in clone', () => {


### PR DESCRIPTION
## Background
The `ProbeAgent` constructor was not correctly storing the `options.model` parameter, causing it to be ignored in favor of the `MODEL_NAME` environment variable. This prevented users from specifying a custom model when initializing the agent.

## Changes
- **`npm/src/agent/ProbeAgent.js`**:
  - Added `this.clientApiModel = options.model || null;` to store the model option passed during instantiation.
  - Modified the `modelName` determination to prioritize `this.clientApiModel` over `process.env.MODEL_NAME`.
- **`npm/tests/unit/probe-agent-model-option.test.js`**:
  - Added a new test suite to verify the correct behavior of the `model` option.
  - Tests cover constructor storage, environment variable precedence, cloning behavior, and edge cases like empty strings.

## Testing
- [ ] Verify that passing `model` to the `ProbeAgent` constructor correctly sets the model.
- [ ] Ensure `options.model` takes precedence over `MODEL_NAME` environment variable.
- [ ] Confirm that `MODEL_NAME` is used as a fallback when `options.model` is not provided.
- [ ] Test model option handling during agent cloning.
