### PR TITLE
Fix npm package to include bundled binaries

### DIFF
--- a/npm/bin/.gitignore
+++ b/npm/bin/.gitignore
@@ -5,3 +5,7 @@
 !.gitkeep
 !README.md
 !probe
+!binaries/
+!binaries/*.tar.gz
+!binaries/*.zip
+!binaries/README.md


### PR DESCRIPTION
## Summary

Fixes the issue where `npm install @probelabs/probe` was falling back to downloading binaries from GitHub instead of using bundled binaries, causing installation failures on Linux systems.

## Problem

The npm package's `postinstall.js` script attempts to extract bundled binaries from `npm/bin/binaries/*.tar.gz` files. However, these files were never included in the published npm package, causing the installation to fail with:

```
Bundled binary not found, downloading from GitHub...
```

## Root Cause

The `.gitignore` file at `npm/bin/.gitignore` was configured to ignore all files (`*`) except a whitelist. The `binaries/` directory was not in that whitelist, so:

1. Git ignored the `bin/binaries/` directory and its contents
2. Even though the CI workflow (`.github/workflows/release.yml` lines 228-254) correctly downloaded and copied binaries to `npm/bin/binaries/` before publishing
3. npm uses git's file tree when packing, so the binaries were excluded from the published package

## Solution

Updated `npm/bin/.gitignore` to explicitly allow the `binaries/` directory and its contents:
- `!binaries/`
- `!binaries/*.tar.gz`
- `!binaries/*.zip`
- `!binaries/README.md`

## Verification

- ✅ Verified with `npm pack` that binaries are now included in the tarball
- ✅ Confirmed the release workflow already handles bundling binaries correctly
- ✅ No changes needed to CI workflow or postinstall script

## Test Plan

After this PR is merged and a new release is published:
1. The CI workflow will bundle binaries as usual
2. The published npm package will now include them
3. Users installing via `npm install @probelabs/probe` will use bundled binaries
4. No more unnecessary GitHub downloads during postinstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)