### PR TITLE
fix: Respect allowedTools configuration in validTools array

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1706,16 +1706,25 @@ When troubleshooting:
         }
 
         // Parse tool call from response with valid tools list
-        const validTools = [
-          'search', 'query', 'extract', 'listFiles', 'searchFiles', 'attempt_completion'
-        ];
-        if (this.allowEdit) {
+        // Build validTools based on allowedTools configuration (same pattern as getSystemMessage)
+        const validTools = [];
+        if (this.allowedTools.isEnabled('search')) validTools.push('search');
+        if (this.allowedTools.isEnabled('query')) validTools.push('query');
+        if (this.allowedTools.isEnabled('extract')) validTools.push('extract');
+        if (this.allowedTools.isEnabled('listFiles')) validTools.push('listFiles');
+        if (this.allowedTools.isEnabled('searchFiles')) validTools.push('searchFiles');
+        if (this.allowedTools.isEnabled('attempt_completion')) validTools.push('attempt_completion');
+
+        // Edit tools (require both allowEdit flag AND allowedTools permission)
+        if (this.allowEdit && this.allowedTools.isEnabled('implement')) {
           validTools.push('implement', 'edit', 'create');
         }
-        if (this.enableBash) {
+        // Bash tool (require both enableBash flag AND allowedTools permission)
+        if (this.enableBash && this.allowedTools.isEnabled('bash')) {
           validTools.push('bash');
         }
-        if (this.enableDelegate) {
+        // Delegate tool (require both enableDelegate flag AND allowedTools permission)
+        if (this.enableDelegate && this.allowedTools.isEnabled('delegate')) {
           validTools.push('delegate');
         }
         


### PR DESCRIPTION
## Summary

Fixes #293 - The `disableTools: true` option was not fully respected. Tool definitions were correctly filtered from the system message, but the agentic loop still accepted and executed tool calls because the `validTools` array was hardcoded and didn't respect the `allowedTools` configuration.

## Changes

### Core Fix (`npm/src/agent/ProbeAgent.js` lines 1708-1729)
- Replaced hardcoded `validTools` array with dynamic filtering using `allowedTools.isEnabled()` pattern
- This matches the same pattern used in `getSystemMessage()` for consistency
- **Core tools** (search, query, extract, listFiles, searchFiles, attempt_completion) now check `allowedTools.isEnabled()`
- **Edit tools** now require BOTH `allowEdit` flag AND `allowedTools` permission
- **Bash tool** requires BOTH `enableBash` flag AND `allowedTools` permission  
- **Delegate tool** requires BOTH `enableDelegate` flag AND `allowedTools` permission

### Tests (`npm/tests/unit/allowed-tools.test.js`)
Added 6 comprehensive tests for the `validTools` array behavior:
- ✅ Verify `validTools` respects `allowedTools` whitelist mode
- ✅ Verify empty `validTools` when `disableTools: true`
- ✅ Verify bash tool requires both flag AND permission
- ✅ Verify bash excluded when not in `allowedTools`
- ✅ Verify edit tools excluded when not in `allowedTools`
- ✅ Verify edit tools included when permitted

## Impact

### Before
```javascript
const agent = new ProbeAgent({ disableTools: true });
await agent.answer("What is the capital of France?");
// ❌ AI could still attempt tool calls
// ❌ Tool calls were parsed and executed despite disableTools: true
```

### After  
```javascript
const agent = new ProbeAgent({ disableTools: true });
await agent.answer("What is the capital of France?");
// ✅ No tools available in validTools array
// ✅ AI responds with plain text immediately
// ✅ Tool calls are not parsed or executed
```

## Testing

- ✅ All 33 tests in `allowed-tools.test.js` pass
- ✅ All 67 ProbeAgent unit tests pass
- ✅ 1103 total tests pass (1 unrelated MCP build test failure)

## References

- Fixes issue: #293
- Related code pattern: `getSystemMessage()` at line 1157 (already implements correct filtering)
- Root cause location: Lines 1709-1720 (hardcoded validTools array)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>