### PR TITLE
Expose tool filtering options and systemPrompt alias

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -9,6 +9,8 @@ export interface ProbeAgentOptions {
   sessionId?: string;
   /** Custom system prompt to replace the default system message */
   customPrompt?: string;
+  /** Alias for customPrompt. More intuitive naming for system prompts. */
+  systemPrompt?: string;
   /** Predefined prompt type (persona) */
   promptType?: 'code-explorer' | 'engineer' | 'code-review' | 'support' | 'architect';
   /** Allow the use of the 'implement' tool for code editing */
@@ -35,6 +37,10 @@ export interface ProbeAgentOptions {
   storageAdapter?: StorageAdapter;
   /** Hook callbacks for event-driven integration */
   hooks?: Record<string, (data: any) => void | Promise<void>>;
+  /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
+  allowedTools?: string[] | null;
+  /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
+  disableTools?: boolean;
 }
 
 /**

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -11,6 +11,8 @@ export interface ProbeAgentOptions {
   sessionId?: string;
   /** Custom system prompt to replace the default system message */
   customPrompt?: string;
+  /** Alias for customPrompt. More intuitive naming for system prompts. */
+  systemPrompt?: string;
   /** Predefined prompt type (persona) */
   promptType?: 'code-explorer' | 'engineer' | 'code-review' | 'support' | 'architect';
   /** Allow the use of the 'implement' tool for code editing */
@@ -35,6 +37,10 @@ export interface ProbeAgentOptions {
   mcpConfig?: any;
   /** @deprecated Use mcpConfig instead */
   mcpServers?: any[];
+  /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
+  allowedTools?: string[] | null;
+  /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
+  disableTools?: boolean;
   /** Retry configuration for handling transient API failures */
   retry?: RetryOptions;
   /** Fallback configuration for multi-provider support */

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -90,6 +90,7 @@ export class ProbeAgent {
    * @param {Object} options - Configuration options
    * @param {string} [options.sessionId] - Optional session ID
    * @param {string} [options.customPrompt] - Custom prompt to replace the default system message
+   * @param {string} [options.systemPrompt] - Alias for customPrompt; takes precedence when both are provided
    * @param {string} [options.promptType] - Predefined prompt type (architect, code-review, support)
    * @param {boolean} [options.allowEdit=false] - Allow the use of the 'implement' tool
    * @param {boolean} [options.enableDelegate=false] - Enable the delegate tool for task distribution to subagents
@@ -126,7 +127,8 @@ export class ProbeAgent {
   constructor(options = {}) {
     // Basic configuration
     this.sessionId = options.sessionId || randomUUID();
-    this.customPrompt = options.customPrompt || null;
+    // Support systemPrompt alias (overrides customPrompt when both are provided)
+    this.customPrompt = options.systemPrompt || options.customPrompt || null;
     this.promptType = options.promptType || 'code-explorer';
     this.allowEdit = !!options.allowEdit;
     this.enableDelegate = !!options.enableDelegate;

--- a/npm/tests/unit/fallbackManager.test.js
+++ b/npm/tests/unit/fallbackManager.test.js
@@ -347,6 +347,25 @@ describe('FallbackManager', () => {
   });
 
   describe('buildFallbackProvidersFromEnv', () => {
+    const envKeys = [
+      'ANTHROPIC_API_KEY',
+      'ANTHROPIC_API_URL',
+      'OPENAI_API_KEY',
+      'OPENAI_API_URL',
+      'GOOGLE_API_KEY',
+      'AWS_ACCESS_KEY_ID',
+      'AWS_SECRET_ACCESS_KEY',
+      'AWS_REGION',
+      'AWS_BEDROCK_API_KEY'
+    ];
+
+    beforeEach(() => {
+      // Ensure tests in this block start with a predictable environment
+      for (const key of envKeys) {
+        delete process.env[key];
+      }
+    });
+
     test('should build providers from environment variables', () => {
       process.env.ANTHROPIC_API_KEY = 'ant-key';
       process.env.OPENAI_API_KEY = 'openai-key';

--- a/npm/tests/unit/system-prompt.test.js
+++ b/npm/tests/unit/system-prompt.test.js
@@ -1,0 +1,32 @@
+import { describe, test, expect } from '@jest/globals';
+import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
+
+describe('ProbeAgent systemPrompt alias', () => {
+  test('uses systemPrompt when provided', () => {
+    const agent = new ProbeAgent({
+      path: process.cwd(),
+      systemPrompt: 'system-level prompt'
+    });
+
+    expect(agent.customPrompt).toBe('system-level prompt');
+  });
+
+  test('systemPrompt takes precedence over customPrompt', () => {
+    const agent = new ProbeAgent({
+      path: process.cwd(),
+      systemPrompt: 'primary system prompt',
+      customPrompt: 'secondary custom prompt'
+    });
+
+    expect(agent.customPrompt).toBe('primary system prompt');
+  });
+
+  test('falls back to customPrompt when systemPrompt is absent', () => {
+    const agent = new ProbeAgent({
+      path: process.cwd(),
+      customPrompt: 'custom prompt only'
+    });
+
+    expect(agent.customPrompt).toBe('custom prompt only');
+  });
+});

--- a/npm/tests/unit/types-probe-agent-options.test.js
+++ b/npm/tests/unit/types-probe-agent-options.test.js
@@ -1,0 +1,42 @@
+import { describe, test, expect } from '@jest/globals';
+import ts from 'typescript';
+
+/**
+ * Regression test: ensure the public TypeScript surface exposes tool filtering
+ * and system prompt options. We compile a tiny snippet and assert no diagnostics.
+ */
+describe('Type definitions: ProbeAgentOptions', () => {
+  const compile = (source) => {
+    const result = ts.transpileModule(source, {
+      compilerOptions: {
+        target: ts.ScriptTarget.ES2020,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.Node16,
+        strict: true,
+        skipLibCheck: true,
+        isolatedModules: true,
+        allowImportingTsExtensions: true,
+        types: [],
+      }
+    });
+    return result.diagnostics || [];
+  };
+
+  test('accepts systemPrompt, allowedTools, and disableTools', () => {
+    const diagnostics = compile(`
+      import { ProbeAgent, type ProbeAgentOptions } from '../..';
+
+      const options: ProbeAgentOptions = {
+        systemPrompt: 'hello',
+        customPrompt: 'fallback',
+        allowedTools: ['search', '!bash'],
+        disableTools: false,
+      };
+
+      const agent = new ProbeAgent(options);
+      void agent;
+    `);
+
+    expect(diagnostics.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expose allowedTools/disableTools/systemPrompt in ProbeAgent TypeScript definitions
- make systemPrompt alias override customPrompt in constructor
- add regression tests for alias and typings; clean env-sensitive fallbackManager test setup

## Testing
- npm test