### PR TITLE
fix: Pass string provider identifier to delegate tool instead of function

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2504,7 +2504,7 @@ When troubleshooting:
                       maxIterations,
                       parentSessionId: this.sessionId,  // Pass parent session ID for tracking
                       path: this.searchPath,            // Inherit search path
-                      provider: this.provider,          // Inherit AI provider
+                      provider: this.apiType,           // Inherit AI provider (string identifier)
                       model: this.model,                // Inherit model
                       debug: this.debug,
                       tracer: this.tracer
@@ -2513,7 +2513,7 @@ When troubleshooting:
                     if (this.debug) {
                       console.log(`[DEBUG] Executing delegate tool at iteration ${currentIteration}/${maxIterations}`);
                       console.log(`[DEBUG] Parent session: ${this.sessionId}`);
-                      console.log(`[DEBUG] Inherited config: path=${this.searchPath}, provider=${this.provider}, model=${this.model}`);
+                      console.log(`[DEBUG] Inherited config: path=${this.searchPath}, provider=${this.apiType}, model=${this.model}`);
                       console.log(`[DEBUG] Delegate task: ${toolParams.task?.substring(0, 100)}...`);
                     }
                     


### PR DESCRIPTION
## Summary

- Fixed delegate tool failing with `TypeError: provider must be a string, null, or undefined` when using Google (and other) providers
- Pass `this.apiType` (string identifier) instead of `this.provider` (AI SDK factory function) to the delegate tool
- Added comprehensive tests for provider inheritance during delegation

## Root Cause

When delegating tasks, `this.provider` was being passed which contains the AI SDK provider factory function (e.g., `createGoogleGenerativeAI()`). The delegate tool validation correctly expects a string, null, or undefined.

## Solution

Changed `ProbeAgent.js` line 2507 from:
```javascript
provider: this.provider,          // Inherit AI provider
```
to:
```javascript
provider: this.apiType,           // Inherit AI provider (string identifier)
```

This ensures all provider types work correctly:
| Provider | `this.apiType` | Delegate receives |
|----------|---------------|-------------------|
| google | 'google' | 'google' ✓ |
| anthropic | 'anthropic' | 'anthropic' ✓ |
| openai | 'openai' | 'openai' ✓ |
| bedrock | 'bedrock' | 'bedrock' ✓ |
| claude-code | 'claude-code' | 'claude-code' ✓ |
| codex | 'codex' | 'codex' ✓ |

## Test plan

- [x] All existing tests pass (1181 tests)
- [x] Added tests for provider inheritance with all provider types
- [x] Added tests for delegate tool validation (rejects functions, objects, numbers, arrays)
- [x] Verified `clientApiProvider` correctly stores the string provider input

Fixes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)