### PR TITLE
fix: Remove implicit image attachment and add SVG filtering for Gemini

### DIFF
--- a/npm/src/agent/imageConfig.js
+++ b/npm/src/agent/imageConfig.js
@@ -21,6 +21,12 @@ export const IMAGE_MIME_TYPES = {
   'svg': 'image/svg+xml'
 };
 
+// Provider-specific unsupported image formats
+// These providers do not support certain MIME types and will crash if they receive them
+export const PROVIDER_UNSUPPORTED_FORMATS = {
+  'google': ['svg'],  // Google Gemini doesn't support image/svg+xml
+};
+
 /**
  * Generate a regex pattern string for matching image file extensions
  * @param {string[]} extensions - Array of extensions (without dots)
@@ -37,4 +43,55 @@ export function getExtensionPattern(extensions = SUPPORTED_IMAGE_EXTENSIONS) {
  */
 export function getMimeType(extension) {
   return IMAGE_MIME_TYPES[extension.toLowerCase()];
+}
+
+/**
+ * Check if an image extension is supported by a specific provider
+ * @param {string} extension - File extension (without dot)
+ * @param {string} provider - Provider name (e.g., 'google', 'anthropic', 'openai')
+ * @returns {boolean} True if the format is supported by the provider
+ */
+export function isFormatSupportedByProvider(extension, provider) {
+  // Validate extension parameter - must be a non-empty string without path separators
+  if (!extension || typeof extension !== 'string') {
+    return false;
+  }
+  // Sanitize: reject extensions containing path traversal characters
+  if (extension.includes('/') || extension.includes('\\') || extension.includes('..')) {
+    return false;
+  }
+
+  const ext = extension.toLowerCase();
+
+  // First check if it's a generally supported format
+  if (!SUPPORTED_IMAGE_EXTENSIONS.includes(ext)) {
+    return false;
+  }
+
+  // Handle null/undefined provider gracefully (treat as no restrictions)
+  if (!provider || typeof provider !== 'string') {
+    return true;
+  }
+
+  // Check provider-specific restrictions
+  const unsupportedFormats = PROVIDER_UNSUPPORTED_FORMATS[provider];
+  if (unsupportedFormats && unsupportedFormats.includes(ext)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Get supported image extensions for a specific provider
+ * @param {string} provider - Provider name (e.g., 'google', 'anthropic', 'openai')
+ * @returns {string[]} Array of supported extensions for this provider
+ */
+export function getSupportedExtensionsForProvider(provider) {
+  // Handle null/undefined/non-string provider gracefully (return all extensions)
+  if (!provider || typeof provider !== 'string') {
+    return [...SUPPORTED_IMAGE_EXTENSIONS];
+  }
+  const unsupportedFormats = PROVIDER_UNSUPPORTED_FORMATS[provider] || [];
+  return SUPPORTED_IMAGE_EXTENSIONS.filter(ext => !unsupportedFormats.includes(ext));
 }

--- a/npm/tests/unit/imageConfig.test.js
+++ b/npm/tests/unit/imageConfig.test.js
@@ -1,0 +1,149 @@
+import { describe, test, expect } from '@jest/globals';
+import {
+  SUPPORTED_IMAGE_EXTENSIONS,
+  IMAGE_MIME_TYPES,
+  PROVIDER_UNSUPPORTED_FORMATS,
+  getMimeType,
+  isFormatSupportedByProvider,
+  getSupportedExtensionsForProvider,
+  getExtensionPattern
+} from '../../src/agent/imageConfig.js';
+
+describe('imageConfig', () => {
+  describe('Constants', () => {
+    test('SUPPORTED_IMAGE_EXTENSIONS should include standard formats', () => {
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('png');
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('jpg');
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('jpeg');
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('webp');
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('bmp');
+      expect(SUPPORTED_IMAGE_EXTENSIONS).toContain('svg');
+    });
+
+    test('IMAGE_MIME_TYPES should map extensions to correct MIME types', () => {
+      expect(IMAGE_MIME_TYPES.png).toBe('image/png');
+      expect(IMAGE_MIME_TYPES.jpg).toBe('image/jpeg');
+      expect(IMAGE_MIME_TYPES.jpeg).toBe('image/jpeg');
+      expect(IMAGE_MIME_TYPES.webp).toBe('image/webp');
+      expect(IMAGE_MIME_TYPES.bmp).toBe('image/bmp');
+      expect(IMAGE_MIME_TYPES.svg).toBe('image/svg+xml');
+    });
+
+    test('PROVIDER_UNSUPPORTED_FORMATS should have google provider restrictions', () => {
+      expect(PROVIDER_UNSUPPORTED_FORMATS.google).toBeDefined();
+      expect(PROVIDER_UNSUPPORTED_FORMATS.google).toContain('svg');
+    });
+  });
+
+  describe('getMimeType', () => {
+    test('should return correct MIME type for supported extensions', () => {
+      expect(getMimeType('png')).toBe('image/png');
+      expect(getMimeType('jpg')).toBe('image/jpeg');
+      expect(getMimeType('svg')).toBe('image/svg+xml');
+    });
+
+    test('should handle case-insensitive extensions', () => {
+      expect(getMimeType('PNG')).toBe('image/png');
+      expect(getMimeType('JPG')).toBe('image/jpeg');
+      expect(getMimeType('SVG')).toBe('image/svg+xml');
+    });
+
+    test('should return undefined for unsupported extensions', () => {
+      expect(getMimeType('gif')).toBeUndefined();
+      expect(getMimeType('tiff')).toBeUndefined();
+      expect(getMimeType('pdf')).toBeUndefined();
+    });
+  });
+
+  describe('isFormatSupportedByProvider', () => {
+    test('should return true for formats supported by all providers', () => {
+      expect(isFormatSupportedByProvider('png', 'google')).toBe(true);
+      expect(isFormatSupportedByProvider('jpg', 'google')).toBe(true);
+      expect(isFormatSupportedByProvider('jpeg', 'google')).toBe(true);
+      expect(isFormatSupportedByProvider('webp', 'google')).toBe(true);
+    });
+
+    test('should return false for SVG with Google provider (GitHub issue #305)', () => {
+      expect(isFormatSupportedByProvider('svg', 'google')).toBe(false);
+      expect(isFormatSupportedByProvider('SVG', 'google')).toBe(false);
+    });
+
+    test('should return true for SVG with providers that support it', () => {
+      expect(isFormatSupportedByProvider('svg', 'anthropic')).toBe(true);
+      expect(isFormatSupportedByProvider('svg', 'openai')).toBe(true);
+    });
+
+    test('should return true for SVG with unknown providers (permissive default)', () => {
+      expect(isFormatSupportedByProvider('svg', 'unknown-provider')).toBe(true);
+    });
+
+    test('should return false for completely unsupported formats', () => {
+      expect(isFormatSupportedByProvider('gif', 'google')).toBe(false);
+      expect(isFormatSupportedByProvider('tiff', 'anthropic')).toBe(false);
+    });
+
+    test('should handle case-insensitive extensions', () => {
+      expect(isFormatSupportedByProvider('PNG', 'google')).toBe(true);
+      expect(isFormatSupportedByProvider('SVG', 'google')).toBe(false);
+    });
+
+    test('should handle null/undefined provider gracefully', () => {
+      expect(isFormatSupportedByProvider('png', null)).toBe(true);
+      expect(isFormatSupportedByProvider('png', undefined)).toBe(true);
+      expect(isFormatSupportedByProvider('svg', null)).toBe(true);
+    });
+
+    test('should reject invalid extension parameters', () => {
+      expect(isFormatSupportedByProvider(null, 'google')).toBe(false);
+      expect(isFormatSupportedByProvider(undefined, 'google')).toBe(false);
+      expect(isFormatSupportedByProvider('', 'google')).toBe(false);
+    });
+
+    test('should reject path traversal attempts in extension', () => {
+      expect(isFormatSupportedByProvider('../../../etc/passwd', 'google')).toBe(false);
+      expect(isFormatSupportedByProvider('png/../../../etc/passwd', 'google')).toBe(false);
+      expect(isFormatSupportedByProvider('..\\..\\windows\\system32', 'google')).toBe(false);
+    });
+  });
+
+  describe('getSupportedExtensionsForProvider', () => {
+    test('should return all extensions for providers without restrictions', () => {
+      const anthropicExtensions = getSupportedExtensionsForProvider('anthropic');
+      expect(anthropicExtensions).toEqual(SUPPORTED_IMAGE_EXTENSIONS);
+    });
+
+    test('should exclude SVG for Google provider', () => {
+      const googleExtensions = getSupportedExtensionsForProvider('google');
+      expect(googleExtensions).not.toContain('svg');
+      expect(googleExtensions).toContain('png');
+      expect(googleExtensions).toContain('jpg');
+    });
+
+    test('should return all extensions for unknown providers', () => {
+      const unknownExtensions = getSupportedExtensionsForProvider('unknown');
+      expect(unknownExtensions).toEqual(SUPPORTED_IMAGE_EXTENSIONS);
+    });
+
+    test('should handle null/undefined provider gracefully', () => {
+      const nullExtensions = getSupportedExtensionsForProvider(null);
+      const undefinedExtensions = getSupportedExtensionsForProvider(undefined);
+      expect(nullExtensions).toEqual(SUPPORTED_IMAGE_EXTENSIONS);
+      expect(undefinedExtensions).toEqual(SUPPORTED_IMAGE_EXTENSIONS);
+    });
+  });
+
+  describe('getExtensionPattern', () => {
+    test('should generate regex pattern for default extensions', () => {
+      const pattern = getExtensionPattern();
+      expect(pattern).toContain('png');
+      expect(pattern).toContain('jpg');
+      expect(pattern).toContain('svg');
+      expect(pattern).toBe('png|jpg|jpeg|webp|bmp|svg');
+    });
+
+    test('should generate pattern for custom extensions', () => {
+      const pattern = getExtensionPattern(['png', 'jpg']);
+      expect(pattern).toBe('png|jpg');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Remove automatic image processing after tool results - images are now only loaded when the AI explicitly calls the `readImage` tool
- Add provider-specific format filtering to prevent SVG crashes on Google Gemini
- Add comprehensive tests for the fix

## Changes

### 1. Remove automatic image processing (`ProbeAgent.js:2600-2603`)
Images were being implicitly attached to user messages by scanning tool outputs for image paths. This caused:
- Unexpected behavior - users didn't know images were being attached
- Crashes when SVG files were found and sent to Google Gemini (which doesn't support `image/svg+xml` MIME type)

### 2. Add provider-specific format filtering (`imageConfig.js`)
- `PROVIDER_UNSUPPORTED_FORMATS` - configuration for provider restrictions
- `isFormatSupportedByProvider()` - check if format works with provider
- `getSupportedExtensionsForProvider()` - get allowed formats for provider

### 3. Update `loadImageIfValid` method
Added check for provider-specific format support before loading images.

### 4. Enhanced `readImage` tool error messages
Clear error when format is not supported by current provider, suggesting PNG/JPEG alternatives.

## Test plan

- [x] All 1201 existing tests pass
- [x] Added 17 new tests for `imageConfig.js` functions
- [x] Added 3 new tests for provider-specific format restrictions
- [x] Updated existing test descriptions for clarity

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)