### PR TITLE
fix: Check tracer.createDelegationSpan is a function before calling

### DIFF
--- a/npm/src/delegate.js
+++ b/npm/src/delegate.js
@@ -200,8 +200,10 @@ export async function delegate({
 	// Calculate remaining iterations for subagent
 	const remainingIterations = Math.max(1, maxIterations - currentIteration);
 
-	// Create delegation span for telemetry if tracer is available
-	const delegationSpan = tracer ? tracer.createDelegationSpan(sessionId, task) : null;
+	// Create delegation span for telemetry if tracer is available and has the method
+	const delegationSpan = typeof tracer?.createDelegationSpan === 'function'
+		? tracer.createDelegationSpan(sessionId, task)
+		: null;
 
 	let timeoutId = null;
 	let acquired = false;


### PR DESCRIPTION
## Summary
- Fix runtime error "tracer.createDelegationSpan is not a function" when tracer object lacks the method
- Changed `tracer ?` check to `typeof tracer?.createDelegationSpan === 'function'`
- Added 4 tests for tracer handling edge cases (incomplete tracer, empty object, null, undefined)

## Test plan
- [x] Run `npm test -- --testPathPattern="probe-agent-delegate"` - all 36 tests pass
- [ ] Verify in production with tracers that don't implement `createDelegationSpan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)