### PR TITLE
feat: Follow symlinks by default in all file traversals

### DIFF
--- a/src/extract/file_paths.rs
+++ b/src/extract/file_paths.rs
@@ -870,6 +870,8 @@ pub fn parse_file_with_line(input: &str, allow_tests: bool) -> Vec<FilePathInfo>
                     // Use WalkBuilder to respect .gitignore
                     let base_dir = std::path::Path::new(".");
                     let mut builder = WalkBuilder::new(base_dir);
+                    // Follow symlinks by default. Loop detection is handled by walkdir internally.
+                    builder.follow_links(true);
                     builder.git_ignore(true);
                     builder.git_global(true);
                     builder.git_exclude(true);

--- a/src/grep.rs
+++ b/src/grep.rs
@@ -430,6 +430,9 @@ fn build_walker_parallel(
     let mut walker_builder = WalkBuilder::new(path);
     walker_builder
         .hidden(false)
+        // Follow symlinks by default. Loop detection is handled by walkdir internally -
+        // it detects and reports symlink loops as errors, preventing infinite traversal.
+        .follow_links(true)
         .git_ignore(!no_gitignore)
         .git_global(!no_gitignore)
         .git_exclude(!no_gitignore)

--- a/src/query.rs
+++ b/src/query.rs
@@ -259,6 +259,10 @@ pub fn perform_query(options: &QueryOptions) -> Result<Vec<AstMatch>> {
     // Collect file paths using WalkBuilder to conditionally respect gitignore
     let mut builder = WalkBuilder::new(&resolved_path);
 
+    // Follow symlinks by default. Loop detection is handled by walkdir internally -
+    // it detects and reports symlink loops as errors, preventing infinite traversal.
+    builder.follow_links(true);
+
     // Configure gitignore handling based on the no_gitignore option
     if !options.no_gitignore {
         builder.git_ignore(true);

--- a/src/search/file_list_cache.rs
+++ b/src/search/file_list_cache.rs
@@ -154,6 +154,10 @@ fn build_file_list(
     let builder_start = Instant::now();
     let mut builder = WalkBuilder::new(path);
 
+    // Follow symlinks by default. Loop detection is handled by walkdir internally -
+    // it detects and reports symlink loops as errors, preventing infinite traversal.
+    builder.follow_links(true);
+
     // Configure the builder to conditionally respect gitignore files
     if !no_gitignore {
         builder.git_ignore(true);


### PR DESCRIPTION
## Summary
- Enable symlink following by default in all WalkBuilder configurations
- Supports workspace setups using symlinks (e.g., visor workspaces with git worktrees)
- Added `follow_links(true)` to all 4 file traversal locations

## Changes
- `src/grep.rs`: Add follow_links(true) to parallel walker
- `src/query.rs`: Add follow_links(true) to AST query walker
- `src/search/file_list_cache.rs`: Add follow_links(true) to file list builder
- `src/extract/file_paths.rs`: Add follow_links(true) to glob pattern walker

## Test plan
- [x] All 249 library unit tests pass
- [x] Integration tests pass
- [x] Manual test verified: created test directory with symlinks, confirmed search finds files through both real and symlinked paths

Fixes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)