### PR TITLE
fix: Follow symlinks in file traversal operations

### DIFF
--- a/npm/src/agent/probeTool.js
+++ b/npm/src/agent/probeTool.js
@@ -8,6 +8,7 @@ import fs from 'fs';
 import { promises as fsPromises } from 'fs';
 import path from 'path';
 import { glob } from 'glob';
+import { getEntryType } from '../utils/symlink-utils.js';
 
 // Create an event emitter for tool calls (simplified for single-shot operations)
 export const toolCallEmitter = new EventEmitter();
@@ -287,23 +288,13 @@ export const listFilesTool = {
 
       // Format the results as ls-style output
       const entries = await Promise.all(files.map(async (file) => {
-        const isDirectory = file.isDirectory();
         const fullPath = path.join(targetDir, file.name);
-
-        let size = 0;
-        try {
-          const stats = await fsPromises.stat(fullPath);
-          size = stats.size;
-        } catch (statError) {
-          if (debug) {
-            console.log(`[DEBUG] Could not stat file ${file.name}:`, statError.message);
-          }
-        }
+        const entryType = await getEntryType(file, fullPath);
 
         return {
           name: file.name,
-          isDirectory,
-          size
+          isDirectory: entryType.isDirectory,
+          size: entryType.size
         };
       }));
 

--- a/npm/src/downloader.js
+++ b/npm/src/downloader.js
@@ -14,6 +14,7 @@ import os from 'os';
 import { fileURLToPath } from 'url';
 import { ensureBinDirectory } from './utils.js';
 import { getPackageBinDir } from './directory-resolver.js';
+import { getEntryType } from './utils/symlink-utils.js';
 
 const exec = promisify(execCallback);
 
@@ -770,10 +771,13 @@ async function extractBinary(assetPath, outputDir) {
 			for (const entry of entries) {
 				const fullPath = path.join(dir, entry.name);
 
-				if (entry.isDirectory()) {
+				// Use shared utility to follow symlinks and get actual target type
+				const entryType = await getEntryType(entry, fullPath);
+
+				if (entryType.isDirectory) {
 					const result = await findBinary(fullPath);
 					if (result) return result;
-				} else if (entry.isFile()) {
+				} else if (entryType.isFile) {
 					// Check if this is the binary we're looking for
 					if (entry.name === binaryName ||
 						entry.name === BINARY_NAME ||

--- a/npm/src/extractor.js
+++ b/npm/src/extractor.js
@@ -9,6 +9,7 @@ import tar from 'tar';
 import AdmZip from 'adm-zip';
 import os from 'os';
 import { fileURLToPath } from 'url';
+import { getEntryType } from './utils/symlink-utils.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -148,10 +149,13 @@ async function findBinary(dir, baseDir, binaryName, isWindows) {
 			continue;
 		}
 
-		if (entry.isDirectory()) {
+		// Use shared utility to follow symlinks and get actual target type
+		const entryType = await getEntryType(entry, fullPath);
+
+		if (entryType.isDirectory) {
 			const result = await findBinary(fullPath, baseDir, binaryName, isWindows);
 			if (result) return result;
-		} else if (entry.isFile()) {
+		} else if (entryType.isFile) {
 			// Check if this is the binary we're looking for
 			if (entry.name === binaryName ||
 				entry.name === BINARY_NAME ||

--- a/npm/src/utils/file-lister.js
+++ b/npm/src/utils/file-lister.js
@@ -7,6 +7,7 @@ import fs from 'fs';
 import path from 'path';
 import { promisify } from 'util';
 import { exec } from 'child_process';
+import { getEntryTypeSync } from './symlink-utils.js';
 
 const execAsync = promisify(exec);
 
@@ -101,7 +102,10 @@ async function listFilesByLevelManually(directory, maxFiles, respectGitignore) {
 			const entries = fs.readdirSync(dir, { withFileTypes: true });
 
 			// Process files first (at current level)
-			const files = entries.filter(entry => entry.isFile());
+			const files = entries.filter(entry => {
+				const fullPath = path.join(dir, entry.name);
+				return getEntryTypeSync(entry, fullPath).isFile;
+			});
 			for (const file of files) {
 				if (result.length >= maxFiles) break;
 
@@ -115,7 +119,10 @@ async function listFilesByLevelManually(directory, maxFiles, respectGitignore) {
 			}
 
 			// Then add directories to queue for next level
-			const dirs = entries.filter(entry => entry.isDirectory());
+			const dirs = entries.filter(entry => {
+				const fullPath = path.join(dir, entry.name);
+				return getEntryTypeSync(entry, fullPath).isDirectory;
+			});
 			for (const subdir of dirs) {
 				const subdirPath = path.join(dir, subdir.name);
 				const relativeSubdirPath = path.relative(directory, subdirPath);

--- a/npm/src/utils/symlink-utils.js
+++ b/npm/src/utils/symlink-utils.js
@@ -1,0 +1,63 @@
+/**
+ * Symlink resolution utilities for the probe package
+ * @module utils/symlink-utils
+ */
+
+import fs from 'fs';
+import { promises as fsPromises } from 'fs';
+
+/**
+ * Get entry type following symlinks (async version)
+ *
+ * Uses fs.stat() which follows symlinks to get the actual target type.
+ * Falls back to dirent type if stat fails (e.g., broken symlink).
+ *
+ * @param {fs.Dirent} entry - Directory entry from readdir
+ * @param {string} fullPath - Full path to the entry
+ * @returns {Promise<{isFile: boolean, isDirectory: boolean, size: number}>}
+ */
+export async function getEntryType(entry, fullPath) {
+	try {
+		const stats = await fsPromises.stat(fullPath);
+		return {
+			isFile: stats.isFile(),
+			isDirectory: stats.isDirectory(),
+			size: stats.size
+		};
+	} catch {
+		// Fall back to dirent type if stat fails (e.g., broken symlink)
+		return {
+			isFile: entry.isFile(),
+			isDirectory: entry.isDirectory(),
+			size: 0
+		};
+	}
+}
+
+/**
+ * Get entry type following symlinks (sync version)
+ *
+ * Uses fs.statSync() which follows symlinks to get the actual target type.
+ * Falls back to dirent type if stat fails (e.g., broken symlink).
+ *
+ * @param {fs.Dirent} entry - Directory entry from readdir
+ * @param {string} fullPath - Full path to the entry
+ * @returns {{isFile: boolean, isDirectory: boolean, size: number}}
+ */
+export function getEntryTypeSync(entry, fullPath) {
+	try {
+		const stats = fs.statSync(fullPath);
+		return {
+			isFile: stats.isFile(),
+			isDirectory: stats.isDirectory(),
+			size: stats.size
+		};
+	} catch {
+		// Fall back to dirent type if stat fails (e.g., broken symlink)
+		return {
+			isFile: entry.isFile(),
+			isDirectory: entry.isDirectory(),
+			size: 0
+		};
+	}
+}


### PR DESCRIPTION
## Summary
Fix symlink handling across file traversal operations by extracting logic into a shared utility to eliminate code duplication.

## Changes
| File | Change |
|------|--------|
| `npm/src/utils/symlink-utils.js` | **NEW** - Shared utility with `getEntryType()` and `getEntryTypeSync()` |
| `npm/src/agent/probeTool.js` | Use shared utility in `listFiles` |
| `npm/src/extractor.js` | Use shared utility in `findBinary()` |
| `npm/src/downloader.js` | Use shared utility in `findBinary()` |
| `npm/src/utils/file-lister.js` | Use shared utility in `listFiles()` |

## Root Cause
`readdir({ withFileTypes: true })` returns dirent objects where `isDirectory()` and `isFile()` report the symlink type itself, not the target type. The shared utility uses `fs.stat()`/`fs.statSync()` which follow symlinks to get actual target type.

## Test plan
- [x] All 1218 npm tests pass
- [x] Manual test: Symlinked directories correctly shown as `dir`
- [x] Manual test: Can list/traverse contents inside symlinked directories

Fixes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)