### PR TITLE
fix: Prevent tools from triggering during JSON schema correction

### DIFF
--- a/npm/src/agent/index.js
+++ b/npm/src/agent/index.js
@@ -520,7 +520,7 @@ class ProbeAgentMcpServer {
                 // Retry once with correction prompt
                 const correctionPrompt = createJsonCorrectionPrompt(result, schema, validation.error);
                 try {
-                  result = await agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true });
+                  result = await agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true, _disableTools: true });
                   result = cleanSchemaResponse(result);
                   
                   // Validate again after correction
@@ -863,11 +863,11 @@ async function main() {
             try {
               if (appTracer) {
                 result = await appTracer.withSpan('agent.json_correction',
-                  () => agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true }),
+                  () => agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true, _disableTools: true }),
                   { 'original_error': validation.error }
                 );
               } else {
-                result = await agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true });
+                result = await agent.answer(correctionPrompt, [], { schema, _schemaFormatted: true, _disableTools: true });
               }
               result = cleanSchemaResponse(result);
               

--- a/npm/src/agent/schemaUtils.js
+++ b/npm/src/agent/schemaUtils.js
@@ -787,21 +787,22 @@ export function createJsonCorrectionPrompt(invalidResponse, schema, errorOrValid
   }
 
   // Create increasingly stronger prompts based on retry attempt
+  // These prompts explicitly instruct the AI to use attempt_completion with the JSON result
   const strengthLevels = [
     {
       prefix: "CRITICAL JSON ERROR:",
-      instruction: "You MUST fix this and return ONLY valid JSON.",
-      emphasis: "Return ONLY the corrected JSON, with no additional text or markdown formatting."
+      instruction: "You MUST fix this and respond using attempt_completion with ONLY valid JSON as the result.",
+      emphasis: "Use attempt_completion with ONLY the corrected JSON in the result field. No explanatory text, no markdown, no code blocks."
     },
     {
       prefix: "URGENT - JSON PARSING FAILED:",
-      instruction: "This is your second chance. Return ONLY valid JSON that can be parsed by JSON.parse().",
-      emphasis: "ABSOLUTELY NO explanatory text, greetings, or formatting. ONLY JSON."
+      instruction: "This is your second chance. Use attempt_completion with valid JSON that can be parsed by JSON.parse().",
+      emphasis: "ABSOLUTELY NO explanatory text or formatting. Use attempt_completion with ONLY raw JSON in the result."
     },
     {
       prefix: "FINAL ATTEMPT - CRITICAL JSON ERROR:",
-      instruction: "This is the final retry. You MUST return ONLY raw JSON without any other content.",
-      emphasis: "EXAMPLE: {\"key\": \"value\"} NOT: ```json{\"key\": \"value\"}``` NOT: Here is the JSON: {\"key\": \"value\"}"
+      instruction: "This is the final retry. You MUST use attempt_completion with ONLY raw JSON in the result field.",
+      emphasis: "CORRECT: <attempt_completion><result>{\"key\": \"value\"}</result></attempt_completion>\nWRONG: Here is the JSON: {\"key\": \"value\"}\nWRONG: ```json{\"key\": \"value\"}```"
     }
   ];
 

--- a/npm/tests/integration/schemaRetryLogic.test.js
+++ b/npm/tests/integration/schemaRetryLogic.test.js
@@ -26,19 +26,19 @@ describe('Schema Validation Retry Logic Integration Tests', () => {
     // Test the first retry (retryCount 0)
     const prompt0 = schemaUtils.createJsonCorrectionPrompt(invalidResponse, schema, error, 0);
     expect(prompt0).toContain('CRITICAL JSON ERROR:');
-    expect(prompt0).toContain('Return ONLY the corrected JSON');
-    
-    // Test the second retry (retryCount 1)  
+    expect(prompt0).toContain('attempt_completion with ONLY valid JSON');
+
+    // Test the second retry (retryCount 1)
     const prompt1 = schemaUtils.createJsonCorrectionPrompt(invalidResponse, schema, error, 1);
     expect(prompt1).toContain('URGENT - JSON PARSING FAILED:');
     expect(prompt1).toContain('second chance');
     expect(prompt1).toContain('ABSOLUTELY NO explanatory text');
-    
+
     // Test the third retry (retryCount 2)
     const prompt2 = schemaUtils.createJsonCorrectionPrompt(invalidResponse, schema, error, 2);
     expect(prompt2).toContain('FINAL ATTEMPT - CRITICAL JSON ERROR:');
     expect(prompt2).toContain('final retry');
-    expect(prompt2).toContain('EXAMPLE:');
+    expect(prompt2).toContain('CORRECT:');
   });
 
   test('should simulate retry logic behavior with real functions', () => {

--- a/npm/tests/unit/attemptCompletionJsonFix.test.js
+++ b/npm/tests/unit/attemptCompletionJsonFix.test.js
@@ -223,7 +223,7 @@ describe('attempt_completion JSON schema fix', () => {
       );
 
       expect(correctionPrompt).toContain('CRITICAL JSON ERROR:');
-      expect(correctionPrompt).toContain('You MUST fix this and return ONLY valid JSON');
+      expect(correctionPrompt).toContain('attempt_completion with ONLY valid JSON');
       expect(correctionPrompt).toContain(schema);
       expect(correctionPrompt).toContain(attemptCompletionResult.substring(0, 100));
 

--- a/npm/tests/unit/schemaUtils.test.js
+++ b/npm/tests/unit/schemaUtils.test.js
@@ -1009,16 +1009,16 @@ describe('Schema Utilities', () => {
       expect(prompt).toContain(schema);
       expect(prompt).toContain(error);
       expect(prompt).toContain('CRITICAL JSON ERROR:');
-      expect(prompt).toContain('Return ONLY the corrected JSON');
+      expect(prompt).toContain('attempt_completion with ONLY valid JSON');
     });
 
     test('should create more urgent prompt for second retry (retryCount 1)', () => {
       const invalidResponse = '{"test": value}';
       const schema = '{"test": "string"}';
       const error = 'Unexpected token v in JSON';
-      
+
       const prompt = createJsonCorrectionPrompt(invalidResponse, schema, error, 1);
-      
+
       expect(prompt).toContain('URGENT - JSON PARSING FAILED:');
       expect(prompt).toContain('second chance');
       expect(prompt).toContain('ABSOLUTELY NO explanatory text');
@@ -1028,13 +1028,13 @@ describe('Schema Utilities', () => {
       const invalidResponse = '{"test": value}';
       const schema = '{"test": "string"}';
       const error = 'Unexpected token v in JSON';
-      
+
       const prompt = createJsonCorrectionPrompt(invalidResponse, schema, error, 2);
-      
+
       expect(prompt).toContain('FINAL ATTEMPT - CRITICAL JSON ERROR:');
       expect(prompt).toContain('final retry');
-      expect(prompt).toContain('EXAMPLE:');
-      expect(prompt).toContain('NOT:');
+      expect(prompt).toContain('CORRECT:');
+      expect(prompt).toContain('WRONG:');
     });
 
     test('should cap at highest strength level for retryCount > 2', () => {


### PR DESCRIPTION
## Summary
- Fixes JSON schema correction triggering full agentic flow with tools enabled
- When `_disableTools` flag is set, only `attempt_completion` tool is available
- Correction prompts now explicitly instruct using `attempt_completion` with JSON result

## Problem
When JSON schema validation failed, the correction prompt was sent via `answer()` with full access to all tools. The AI would interpret the correction as a new question and start using search/query tools instead of simply reformatting the JSON.

## Solution
Reuses existing AI loop but restricts available tools during correction:
1. Added `_disableTools` flag check when building `validTools` array
2. When flag is set, only `attempt_completion` is available as a tool
3. MCP tools are also skipped when this flag is set
4. Updated correction prompts to explicitly instruct using `attempt_completion`

Fixes #331

## Test plan
- [x] Run existing JSON correction tests (`npm test -- tests/unit/schemaUtils.test.js tests/unit/attemptCompletionJsonFix.test.js tests/integration/schemaRetryLogic.test.js`)
- [x] Run full test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)