### PR TITLE
fix: always allow attempt_completion even when disableTools is true

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2387,7 +2387,9 @@ When troubleshooting:
           if (this.allowedTools.isEnabled('listFiles')) validTools.push('listFiles');
           if (this.allowedTools.isEnabled('searchFiles')) validTools.push('searchFiles');
           if (this.allowedTools.isEnabled('readImage')) validTools.push('readImage');
-          if (this.allowedTools.isEnabled('attempt_completion')) validTools.push('attempt_completion');
+          // Always allow attempt_completion - it's a completion signal, not a tool
+          // This ensures agents can complete even when disableTools: true is set (fixes #333)
+          validTools.push('attempt_completion');
 
           // Edit tools (require both allowEdit flag AND allowedTools permission)
           if (this.allowEdit && this.allowedTools.isEnabled('implement')) {


### PR DESCRIPTION
## Summary

- Always include `attempt_completion` in `validTools` regardless of `disableTools` setting
- `attempt_completion` is a completion signal, not a tool, so it should always be available

Fixes #333

## Root Cause

When `disableTools: true` was set:
1. `_parseAllowedTools([])` returned `{ mode: 'none', isEnabled: () => false }`
2. `allowedTools.isEnabled('attempt_completion')` returned `false`
3. `attempt_completion` was not added to `validTools`
4. The agent never recognized completion responses, causing infinite loops

## Test plan

- [x] Added test case: "should always allow attempt_completion in validTools even when disableTools is true (fixes #333)"
- [x] All 1351 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)