### PR TITLE
fix: include bundled binaries in npm package

### DIFF
--- a/npm/bin/.gitignore
+++ b/npm/bin/.gitignore
@@ -5,3 +5,5 @@
 !.gitkeep
 !README.md
 !probe
+!binaries
+!binaries/**


### PR DESCRIPTION
## Summary
- Fix npm package not including pre-baked probe binaries
- Add `!binaries` and `!binaries/**` exceptions to `npm/bin/.gitignore`

## Problem
The `npm/bin/.gitignore` file was configured to ignore everything (`*`) except a small allowlist. When npm publishes without an `.npmignore` file, it falls back to using `.gitignore` for exclusions.

This caused the bundled binaries (26MB of `.tar.gz` and `.zip` files copied during CI) to be excluded from the published package, even though they were specified in the `files` array of `package.json`.

**Evidence from workflow logs:**
```
npm warn gitignore-fallback No .npmignore file found, using .gitignore for file exclusion.
```

## Solution
Add exceptions for the `binaries` directory to the `.gitignore`:
```
!binaries
!binaries/**
```

This allows the bundled binary archives to be included in the npm package while still preventing accidental commits of downloaded binaries during local development.

## Test plan
- [ ] Verify next release includes binaries by checking `npm pack --dry-run` output
- [ ] Confirm package size increases from ~5MB to ~30MB after fix
- [ ] Test that `extractBundledBinary()` successfully extracts binaries on install

🤖 Generated with [Claude Code](https://claude.com/claude-code)