### PR TITLE
fix: strip <result> XML wrapper from schema responses

### DIFF
--- a/npm/src/agent/schemaUtils.js
+++ b/npm/src/agent/schemaUtils.js
@@ -253,6 +253,14 @@ export function cleanSchemaResponse(response) {
 
   const trimmed = response.trim();
 
+  // Strip <result>...</result> wrapper if present (legacy XML format from some AI models)
+  // Some models like Google Gemini wrap JSON in <result> tags despite instructions not to
+  const resultWrapperMatch = trimmed.match(/^<result>\s*([\s\S]*?)\s*<\/result>$/);
+  if (resultWrapperMatch) {
+    // Recursively clean the inner content in case there are nested patterns
+    return cleanSchemaResponse(resultWrapperMatch[1]);
+  }
+
   // First, look for JSON after code block markers - similar to mermaid extraction
   // Try with json language specifier
   const jsonBlockMatch = trimmed.match(/```json\s*\n([\s\S]*?)\n```/);


### PR DESCRIPTION
## Summary
- Adds `<result>` tag stripping to `cleanSchemaResponse()` in `schemaUtils.js`
- Some AI models (e.g., Google Gemini 2.5 Pro) wrap JSON responses in `<result>...</result>` XML tags despite explicit instructions not to
- This causes downstream JSON parsing to fail because the response is treated as plain text

## Changes
- Added regex matching for `<result>...</result>` wrapper at the start of `cleanSchemaResponse()`
- Recursively cleans inner content to handle nested patterns (e.g., `<result>` wrapping a code block)
- Added 9 comprehensive tests covering various edge cases

## Test plan
- [x] All 962 unit tests pass
- [x] All 105 schemaUtils tests pass including 9 new tests for `<result>` tag stripping
- [x] Tests cover: basic stripping, whitespace handling, multiline JSON, nested patterns, partial tags (not stripped), embedded tags (not stripped), array JSON, and preserving `<result>` inside JSON string values

Fixes #336

🤖 Generated with [Claude Code](https://claude.ai/code)