### PR TITLE
fix: MCP extract_code tool path resolution and publish rc as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,8 @@ jobs:
         shell: bash
         run: |
           cd npm
-          if [[ "$VERSION" == *-rc* ]] || [[ "$VERSION" == *-alpha* ]] || [[ "$VERSION" == *-beta* ]]; then
+          # Publish alpha/beta as 'next', but rc and stable as 'latest'
+          if [[ "$VERSION" == *-alpha* ]] || [[ "$VERSION" == *-beta* ]]; then
             npm publish --access public --provenance --tag next
           else
             npm publish --access public --provenance
@@ -330,7 +331,8 @@ jobs:
         shell: bash
         run: |
           cd examples/chat
-          if [[ "$VERSION" == *-rc* ]] || [[ "$VERSION" == *-alpha* ]] || [[ "$VERSION" == *-beta* ]]; then
+          # Publish alpha/beta as 'next', but rc and stable as 'latest'
+          if [[ "$VERSION" == *-alpha* ]] || [[ "$VERSION" == *-beta* ]]; then
             npm publish --access public --provenance --tag next
           else
             npm publish --access public --provenance

--- a/npm/src/agent/index.js
+++ b/npm/src/agent/index.js
@@ -440,9 +440,10 @@ class ProbeAgentMcpServer {
           }
 
           // Build options with smart defaults
+          // Use 'cwd' instead of 'path' - the extract function uses cwd for resolving relative file paths
           const options = {
             files: args.files,
-            path: args.path,
+            cwd: args.path,
             format: 'xml',
             allowTests: true,  // Include test files by default
           };

--- a/npm/src/mcp/index.ts
+++ b/npm/src/mcp/index.ts
@@ -385,9 +385,10 @@ class ProbeServer {
       }
 
       // Build options with smart defaults
+      // Use 'cwd' instead of 'path' - the extract function uses cwd for resolving relative file paths
       const options: any = {
         files: args.files,
-        path: args.path,
+        cwd: args.path,
         format: 'xml',
         allowTests: true,  // Include test files by default
       };

--- a/npm/tests/unit/mcp-extract-code-path.test.js
+++ b/npm/tests/unit/mcp-extract-code-path.test.js
@@ -1,0 +1,121 @@
+/**
+ * Tests for MCP extract_code tool path resolution
+ * Verifies that the 'path' parameter is correctly used as 'cwd' for resolving relative file paths
+ */
+
+import { extract } from '../../src/index.js';
+import path from 'path';
+
+// Get the project root directory
+const projectRoot = path.resolve(process.cwd(), '..');
+
+describe('MCP extract_code path resolution', () => {
+	describe('path parameter maps to cwd', () => {
+		test('should resolve relative file paths using path as cwd', async () => {
+			// This simulates what the MCP extract_code tool does after the fix
+			// path parameter is passed as cwd option to extract()
+			const options = {
+				files: ['npm/src/extract.js:1-10'],
+				cwd: projectRoot,  // MCP's 'path' parameter
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+			expect(result.length).toBeGreaterThan(0);
+		});
+
+		test('should work with multiple relative file paths', async () => {
+			const options = {
+				files: ['npm/src/extract.js:1-5', 'npm/src/search.js:1-5'],
+				cwd: projectRoot,
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+			// Should contain content from both files
+			expect(result.length).toBeGreaterThan(0);
+		});
+
+		test('should work with file:line format relative paths', async () => {
+			const options = {
+				files: ['npm/src/extract.js:42'],
+				cwd: projectRoot,
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+		});
+
+		test('should work with file#symbol format relative paths', async () => {
+			const options = {
+				files: ['npm/src/extract.js#extract'],
+				cwd: projectRoot,
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+		});
+
+		test('should return empty result when cwd does not match file paths', async () => {
+			// Using a different cwd that doesn't contain the files
+			const options = {
+				files: ['npm/src/extract.js:1-10'],
+				cwd: '/tmp',
+				format: 'xml',
+				allowTests: true,
+			};
+
+			// Should return empty result (count: 0) when files not found
+			const result = await extract(options);
+			expect(result).toBeDefined();
+			expect(result).toContain('<count>0</count>');
+		});
+	});
+
+	describe('backward compatibility', () => {
+		test('should work without cwd (uses process.cwd)', async () => {
+			// Without cwd, should use process.cwd() which is npm/
+			const options = {
+				files: ['src/extract.js:1-10'],
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+		});
+
+		test('should work with absolute paths regardless of cwd', async () => {
+			const absolutePath = path.join(projectRoot, 'npm/src/extract.js');
+			const options = {
+				files: [`${absolutePath}:1-10`],
+				cwd: '/tmp',  // Different cwd
+				format: 'xml',
+				allowTests: true,
+			};
+
+			const result = await extract(options);
+
+			expect(result).toBeDefined();
+			expect(typeof result).toBe('string');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Fix MCP `extract_code` tool to correctly resolve relative file paths against the `path` parameter by mapping it to `cwd` option
- Update release workflow to publish rc versions as `latest` instead of `next` tag

## Changes
1. **MCP extract_code path fix** (Fixes #340)
   - `npm/src/agent/index.js`: Changed `path: args.path` to `cwd: args.path` when calling `extract()`
   - `npm/src/mcp/index.ts`: Same fix for TypeScript MCP server
   - The `extract()` function expects `cwd` for working directory resolution, not `path`

2. **Release workflow update**
   - `.github/workflows/release.yml`: rc versions now publish as `latest` (only alpha/beta use `next` tag)

## Test plan
- [x] All 7 new MCP extract_code path tests pass
- [x] All 21 cwd-path-options tests pass
- [x] All 178 MCP-related tests pass
- [x] YAML syntax validated with yaml-lint

🤖 Generated with [Claude Code](https://claude.ai/code)