### PR TITLE
fix: consolidate tool lists to fix bash tool parsing with unclosed thinking tags

### DIFF
--- a/npm/src/agent/xmlParsingUtils.js
+++ b/npm/src/agent/xmlParsingUtils.js
@@ -3,6 +3,8 @@
  * This module contains the core logic for thinking tag removal and attempt_complete recovery
  */
 
+import { DEFAULT_VALID_TOOLS, buildToolTagPattern } from '../tools/common.js';
+
 /**
  * Remove thinking tags and their content from XML string
  * Handles both closed and unclosed thinking tags
@@ -24,7 +26,8 @@ export function removeThinkingTags(xmlString) {
     const afterThinking = result.substring(thinkingIndex + '<thinking>'.length);
 
     // Look for any tool tags in the remaining content
-    const toolPattern = /<(search|query|extract|listFiles|searchFiles|implement|attempt_completion|attempt_complete)>/;
+    // Use the shared tool list to build the pattern dynamically
+    const toolPattern = buildToolTagPattern(DEFAULT_VALID_TOOLS);
     const toolMatch = afterThinking.match(toolPattern);
 
     if (toolMatch) {
@@ -148,8 +151,8 @@ export function checkAttemptCompleteRecovery(cleanedXmlString, validTools = []) 
  * @returns {boolean} - True if other tool tags are found
  */
 function hasOtherToolTags(xmlString, validTools = []) {
-  const defaultTools = ['search', 'query', 'extract', 'listFiles', 'searchFiles', 'implement', 'attempt_completion'];
-  const toolsToCheck = validTools.length > 0 ? validTools : defaultTools;
+  // Use the shared canonical tool list as default
+  const toolsToCheck = validTools.length > 0 ? validTools : DEFAULT_VALID_TOOLS;
   
   // Check for any tool tags other than attempt_complete variants
   for (const tool of toolsToCheck) {

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -325,7 +325,8 @@ export const delegateDescription = 'Automatically delegate big distinct tasks to
 export const bashDescription = 'Execute bash commands for system exploration and development tasks. Secure by default with built-in allow/deny lists.';
 
 // Valid tool names that should be parsed as tool calls
-const DEFAULT_VALID_TOOLS = [
+// This is the canonical list - all other tool lists should reference this
+export const DEFAULT_VALID_TOOLS = [
 	'search',
 	'query',
 	'extract',
@@ -333,8 +334,24 @@ const DEFAULT_VALID_TOOLS = [
 	'listFiles',
 	'searchFiles',
 	'implement',
+	'bash',
 	'attempt_completion'
 ];
+
+/**
+ * Build a regex pattern to match any tool tag from the valid tools list
+ * @param {string[]} tools - List of tool names (defaults to DEFAULT_VALID_TOOLS)
+ * @returns {RegExp} - Regex pattern to match tool opening tags
+ */
+export function buildToolTagPattern(tools = DEFAULT_VALID_TOOLS) {
+	// Also include attempt_complete as an alias for attempt_completion
+	const allTools = [...tools];
+	if (allTools.includes('attempt_completion') && !allTools.includes('attempt_complete')) {
+		allTools.push('attempt_complete');
+	}
+	const escaped = allTools.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+	return new RegExp(`<(${escaped.join('|')})>`);
+}
 
 /**
  * Get valid parameter names for a specific tool from its schema

--- a/npm/src/tools/index.js
+++ b/npm/src/tools/index.js
@@ -25,7 +25,9 @@ export {
 	attemptCompletionSchema,
 	attemptCompletionToolDefinition,
 	parseAndResolvePaths,
-	resolveTargetPath
+	resolveTargetPath,
+	DEFAULT_VALID_TOOLS,
+	buildToolTagPattern
 } from './common.js';
 
 // Export edit and create schemas


### PR DESCRIPTION
## Summary

- Fixed a bug where `<bash>` tool calls were not being detected when the AI generated them inside unclosed `<thinking>` blocks
- Root cause: multiple hardcoded tool lists existed in different files and got out of sync - `bash` was missing from the regex pattern used to detect tools after unclosed thinking tags
- Created a single source of truth (`DEFAULT_VALID_TOOLS`) that all tool parsing code now references

## Changes

- **npm/src/tools/common.js**: Export `DEFAULT_VALID_TOOLS` as canonical list, add `bash` to it, add `buildToolTagPattern()` helper
- **npm/src/agent/xmlParsingUtils.js**: Import and use shared tool list instead of hardcoded regex/arrays
- **npm/src/tools/index.js**: Export new functions for external use
- **npm/tests/unit/xmlParsing.test.js**: Add tests for shared tool list and bash tool parsing scenarios

## Test plan

- [x] All 55 XML parsing tests pass (including 7 new tests)
- [x] All 156 bash-related tests pass
- [x] Test specifically covers the exact bug scenario from logs (bash inside unclosed thinking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)