### PR TITLE
fix: prevent path doubling in delegation by prioritizing workspace root

### DIFF
--- a/npm/src/delegate.js
+++ b/npm/src/delegate.js
@@ -229,6 +229,9 @@ export async function delegate({
 			console.error(`[DELEGATE] Using ProbeAgent SDK with code-researcher prompt`);
 		}
 		// Create a new ProbeAgent instance for the delegated task
+		// IMPORTANT: We pass both path and cwd set to the same value (workspace root)
+		// to prevent path doubling issues. The parent's navigation context should not
+		// affect the subagent's path resolution - subagents always work from workspace root.
 		const subagent = new ProbeAgent({
 			sessionId,
 			promptType: 'code-researcher',  // Clean prompt, not inherited from parent
@@ -238,7 +241,8 @@ export async function delegate({
 			maxIterations: remainingIterations,
 			debug,
 			tracer,
-			path,       // Inherit from parent
+			path,       // Workspace root (from delegateTool)
+			cwd: path,  // Explicitly set cwd to workspace root to prevent path doubling
 			provider,   // Inherit from parent
 			model,      // Inherit from parent
 			enableBash, // Inherit from parent

--- a/npm/tests/delegate-config.test.js
+++ b/npm/tests/delegate-config.test.js
@@ -114,21 +114,24 @@ describe('Delegate Tool Configuration', () => {
       );
     });
 
-    it('should prioritize cwd over allowedFolders', async () => {
+    it('should prioritize allowedFolders[0] (workspace root) over cwd (navigation context)', async () => {
+      // Issue #348 fix: workspace root should take priority over navigation cwd
+      // to prevent path doubling when parent navigates to subdirectories
       const tool = delegateTool({
         debug: false,
         timeout: 300,
-        cwd: '/default/path',
-        allowedFolders: ['/allowed/folder']
+        cwd: '/workspace/project/deep/nested',  // Navigation context (subdirectory)
+        allowedFolders: ['/workspace/project']  // Workspace root
       });
-      const task = 'Use cwd priority';
+      const task = 'Use workspace root priority';
 
       await tool.execute({ task });
 
+      // Subagent should receive workspace root, not the navigation subdirectory
       expect(mockDelegate).toHaveBeenCalledWith(
         expect.objectContaining({
           task,
-          path: '/default/path'
+          path: '/workspace/project'
         })
       );
     });


### PR DESCRIPTION
## Summary

Fixes #348

When parent agents navigate to subdirectories and delegate tasks, subagents could receive incorrect `cwd` values causing "path doubling" issues where paths like `/workspace/tyk/internal/build/tyk/internal/build/version.go` were incorrectly constructed.

### Root Cause

1. **delegateTool** calculated `effectivePath` as `path || cwd || allowedFolders[0]`
2. When parent's `cwd` was a subdirectory (from navigation), it took priority over workspace root
3. Subagent's tools resolved relative paths against this subdirectory, causing doubled paths

### Changes

- **`src/tools/vercel.js`**: Changed `effectivePath` priority from `path || cwd || allowedFolders[0]` to `path || allowedFolders[0] || cwd`, ensuring workspace root takes precedence over navigation context
- **`src/delegate.js`**: Explicitly pass `cwd` to subagent set to workspace root to prevent fallback issues

## Test plan

- [x] Added 12 new tests for path inheritance behavior in `tests/unit/probe-agent-delegate.test.js`
- [x] Updated existing test in `tests/delegate-config.test.js` to reflect new priority order
- [x] All 180 delegation/path-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)