### PR TITLE
fix: add initialize() method to ProbeAgent TypeScript definitions

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -270,6 +270,14 @@ export declare class ProbeAgent {
   constructor(options?: ProbeAgentOptions);
 
   /**
+   * Initialize the agent asynchronously (must be called after constructor)
+   * This method initializes MCP, merges MCP tools, loads history from storage,
+   * and performs CLI fallback detection (claude-code/codex) when no API keys are set.
+   * @returns Promise that resolves when initialization is complete
+   */
+  initialize(): Promise<void>;
+
+  /**
    * Answer a question with optional image attachments
    * @param message - The question or prompt
    * @param images - Optional array of image data or paths

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -199,6 +199,14 @@ export declare class ProbeAgent {
   constructor(options?: ProbeAgentOptions);
 
   /**
+   * Initialize the agent asynchronously (must be called after constructor)
+   * This method initializes MCP, merges MCP tools, loads history from storage,
+   * and performs CLI fallback detection (claude-code/codex) when no API keys are set.
+   * @returns Promise that resolves when initialization is complete
+   */
+  initialize(): Promise<void>;
+
+  /**
    * Answer a question with optional image attachments
    * @param message - The question or prompt
    * @param images - Optional array of image data or paths


### PR DESCRIPTION
## Summary
- Added the `initialize()` method to ProbeAgent TypeScript type definitions
- This method was already implemented in JavaScript but missing from the `.d.ts` files

## Problem
SDK consumers like visor that use TypeScript couldn't call `agent.initialize()` because the type definitions didn't include this method. This is required for enabling CLI fallback detection (claude-code/codex) when no API keys are set.

## Test plan
- [x] Verified TypeScript compilation in visor after updating node_modules with these type definitions
- [x] Ran visor test suite (222/223 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)