### PR TITLE
feat: Add tool output truncation for large responses

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2890,12 +2890,20 @@ Follow these instructions carefully:
                 let toolResultContent = typeof executionResult === 'string' ? executionResult : JSON.stringify(executionResult, null, 2);
 
                 // Truncate if output exceeds token limit
-                const truncateResult = await truncateIfNeeded(toolResultContent, this.tokenCounter, this.sessionId, this.maxOutputTokens);
-                if (truncateResult.truncated) {
-                  toolResultContent = truncateResult.content;
-                  if (this.debug) {
-                    console.log(`[DEBUG] Tool output truncated: ${truncateResult.originalTokens} tokens -> saved to ${truncateResult.tempFilePath}`);
+                try {
+                  const truncateResult = await truncateIfNeeded(toolResultContent, this.tokenCounter, this.sessionId, this.maxOutputTokens);
+                  if (truncateResult.truncated) {
+                    toolResultContent = truncateResult.content;
+                    if (this.debug) {
+                      console.log(`[DEBUG] Tool output truncated: ${truncateResult.originalTokens} tokens -> saved to ${truncateResult.tempFilePath || 'N/A'}`);
+                      if (truncateResult.error) {
+                        console.log(`[DEBUG] Truncation file error: ${truncateResult.error}`);
+                      }
+                    }
                   }
+                } catch (truncateError) {
+                  // If truncation fails entirely, log and continue with original content
+                  console.error(`[WARN] Tool output truncation failed: ${truncateError.message}`);
                 }
 
                 // Log MCP tool result in debug mode
@@ -3077,12 +3085,20 @@ Follow these instructions carefully:
                 let toolResultContent = typeof toolResult === 'string' ? toolResult : JSON.stringify(toolResult, null, 2);
 
                 // Truncate if output exceeds token limit
-                const truncateResult = await truncateIfNeeded(toolResultContent, this.tokenCounter, this.sessionId, this.maxOutputTokens);
-                if (truncateResult.truncated) {
-                  toolResultContent = truncateResult.content;
-                  if (this.debug) {
-                    console.log(`[DEBUG] Tool output truncated: ${truncateResult.originalTokens} tokens -> saved to ${truncateResult.tempFilePath}`);
+                try {
+                  const truncateResult = await truncateIfNeeded(toolResultContent, this.tokenCounter, this.sessionId, this.maxOutputTokens);
+                  if (truncateResult.truncated) {
+                    toolResultContent = truncateResult.content;
+                    if (this.debug) {
+                      console.log(`[DEBUG] Tool output truncated: ${truncateResult.originalTokens} tokens -> saved to ${truncateResult.tempFilePath || 'N/A'}`);
+                      if (truncateResult.error) {
+                        console.log(`[DEBUG] Truncation file error: ${truncateResult.error}`);
+                      }
+                    }
                   }
+                } catch (truncateError) {
+                  // If truncation fails entirely, log and continue with original content
+                  console.error(`[WARN] Tool output truncation failed: ${truncateError.message}`);
                 }
 
                 const toolResultMessage = `<tool_result>\n${toolResultContent}\n</tool_result>`;

--- a/npm/src/agent/outputTruncator.js
+++ b/npm/src/agent/outputTruncator.js
@@ -7,19 +7,37 @@ const DEFAULT_MAX_OUTPUT_TOKENS = 20000;
 const CHARS_PER_TOKEN = 4; // Conservative approximation
 
 /**
+ * Validate and normalize a token limit value.
+ * Returns the default if the value is invalid (NaN, negative, zero).
+ * @param {any} value - The value to validate
+ * @returns {number} A valid positive token limit
+ */
+function validateTokenLimit(value) {
+  const num = Number(value);
+  if (isNaN(num) || num <= 0) {
+    return DEFAULT_MAX_OUTPUT_TOKENS;
+  }
+  return num;
+}
+
+/**
  * Get the maximum output tokens limit based on priority:
- * 1. Constructor value (if provided)
- * 2. Environment variable PROBE_MAX_OUTPUT_TOKENS
+ * 1. Constructor value (if provided and valid)
+ * 2. Environment variable PROBE_MAX_OUTPUT_TOKENS (if valid)
  * 3. Default (20000)
  * @param {number|undefined} constructorValue - Value passed to ProbeAgent constructor
- * @returns {number} The maximum output tokens limit
+ * @returns {number} The maximum output tokens limit (always a valid positive number)
  */
 export function getMaxOutputTokens(constructorValue) {
   if (constructorValue !== undefined && constructorValue !== null) {
-    return Number(constructorValue);
+    const validated = validateTokenLimit(constructorValue);
+    // Only use constructor value if it was valid; otherwise fall through to env/default
+    if (validated !== DEFAULT_MAX_OUTPUT_TOKENS || Number(constructorValue) === DEFAULT_MAX_OUTPUT_TOKENS) {
+      return validated;
+    }
   }
   if (process.env.PROBE_MAX_OUTPUT_TOKENS) {
-    return Number(process.env.PROBE_MAX_OUTPUT_TOKENS);
+    return validateTokenLimit(process.env.PROBE_MAX_OUTPUT_TOKENS);
   }
   return DEFAULT_MAX_OUTPUT_TOKENS;
 }
@@ -27,38 +45,64 @@ export function getMaxOutputTokens(constructorValue) {
 /**
  * Truncate tool output if it exceeds the token limit.
  * When truncated, saves full output to a temp file and returns a message with the file path.
+ * If file system operations fail, returns truncated content without file reference.
  *
  * @param {string} content - The tool output content to potentially truncate
  * @param {Object} tokenCounter - TokenCounter instance with countTokens method
  * @param {string} sessionId - Session ID for naming temp files
  * @param {number} maxTokens - Maximum tokens allowed (defaults to 20000)
- * @returns {Promise<{truncated: boolean, content: string, tempFilePath?: string, originalTokens?: number}>}
+ * @returns {Promise<{truncated: boolean, content: string, tempFilePath?: string, originalTokens?: number, error?: string}>}
  */
 export async function truncateIfNeeded(content, tokenCounter, sessionId, maxTokens) {
-  const limit = maxTokens || DEFAULT_MAX_OUTPUT_TOKENS;
+  const limit = validateTokenLimit(maxTokens);
   const tokenCount = tokenCounter.countTokens(content);
 
   if (tokenCount <= limit) {
     return { truncated: false, content };
   }
 
-  // Write full output to temp file
-  const tempDir = join(tmpdir(), 'probe-output');
-  await mkdir(tempDir, { recursive: true });
-  const tempFilePath = join(tempDir, `tool-output-${sessionId || 'unknown'}-${randomUUID()}.txt`);
-  await writeFile(tempFilePath, content, 'utf8');
-
   // Truncate to approximately maxTokens worth of characters
   const maxChars = limit * CHARS_PER_TOKEN;
   const truncatedContent = content.substring(0, maxChars);
 
-  const message = `Output exceeded maximum size (${tokenCount} tokens, limit: ${limit}).
+  // Try to write full output to temp file
+  let tempFilePath = null;
+  let fileError = null;
+
+  try {
+    const tempDir = join(tmpdir(), 'probe-output');
+    await mkdir(tempDir, { recursive: true });
+    tempFilePath = join(tempDir, `tool-output-${sessionId || 'unknown'}-${randomUUID()}.txt`);
+    await writeFile(tempFilePath, content, 'utf8');
+  } catch (err) {
+    fileError = err.message || 'Unknown file system error';
+    tempFilePath = null;
+  }
+
+  let message;
+  if (tempFilePath) {
+    message = `Output exceeded maximum size (${tokenCount} tokens, limit: ${limit}).
 Full output saved to: ${tempFilePath}
 
 --- Truncated Output (first ${limit} tokens approx) ---
 ${truncatedContent}
 ...
 --- End of Truncated Output ---`;
+  } else {
+    message = `Output exceeded maximum size (${tokenCount} tokens, limit: ${limit}).
+Warning: Could not save full output to file (${fileError}).
 
-  return { truncated: true, content: message, tempFilePath, originalTokens: tokenCount };
+--- Truncated Output (first ${limit} tokens approx) ---
+${truncatedContent}
+...
+--- End of Truncated Output ---`;
+  }
+
+  return {
+    truncated: true,
+    content: message,
+    tempFilePath: tempFilePath || undefined,
+    originalTokens: tokenCount,
+    error: fileError || undefined
+  };
 }


### PR DESCRIPTION
## Summary
Implement automatic truncation of tool call outputs exceeding 20k tokens (configurable). When output exceeds the limit, the full result is saved to a temporary file and an error message is returned pointing to that file.

## Features
- Configurable token limit via constructor option or `PROBE_MAX_OUTPUT_TOKENS` environment variable
- Full output saved to `{tmpdir}/probe-output/tool-output-{sessionId}-{uuid}.txt`
- Applies to both MCP and native tool results
- Debug logging when truncation occurs

## Test plan
- [x] 13 unit tests covering configuration priority, truncation logic, and boundary cases
- [x] All existing tests still pass (1545/1547)
- [x] Manual verification of temp file creation and truncation message format

🤖 Generated with [Claude Code](https://claude.com/claude-code)