### PR TITLE
feat: Disable agent skills by default

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -49,9 +49,11 @@ export interface ProbeAgentOptions {
   disableMermaidValidation?: boolean;
   /** Disable automatic JSON validation and fixing (prevents infinite recursion in JsonFixingAgent) */
   disableJsonValidation?: boolean;
-  /** Enable agent skills discovery and activation */
+  /** Enable agent skills discovery and activation (disabled by default) */
+  allowSkills?: boolean;
+  /** @deprecated Use allowSkills instead. Enable agent skills discovery and activation (disabled by default) */
   enableSkills?: boolean;
-  /** Disable agent skills (overrides enableSkills) */
+  /** Disable agent skills (overrides allowSkills/enableSkills) */
   disableSkills?: boolean;
   /** Skill directories to scan relative to repo root */
   skillDirs?: string[];

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -68,9 +68,11 @@ export interface ProbeAgentOptions {
   disableMermaidValidation?: boolean;
   /** Disable automatic JSON validation and fixing (prevents infinite recursion in JsonFixingAgent) */
   disableJsonValidation?: boolean;
-  /** Enable agent skills discovery and activation */
+  /** Enable agent skills discovery and activation (disabled by default) */
+  allowSkills?: boolean;
+  /** @deprecated Use allowSkills instead. Enable agent skills discovery and activation (disabled by default) */
   enableSkills?: boolean;
-  /** Disable agent skills (overrides enableSkills) */
+  /** Disable agent skills (overrides allowSkills/enableSkills) */
   disableSkills?: boolean;
   /** Skill directories to scan relative to repo root */
   skillDirs?: string[];

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -210,7 +210,8 @@ export class ProbeAgent {
     this.maxIterations = options.maxIterations || null;
     this.disableMermaidValidation = !!options.disableMermaidValidation;
     this.disableJsonValidation = !!options.disableJsonValidation;
-    this.enableSkills = options.disableSkills ? false : (options.enableSkills !== undefined ? !!options.enableSkills : true);
+    // Skills are disabled by default; enable via allowSkills or enableSkills
+    this.enableSkills = options.disableSkills ? false : !!(options.allowSkills || options.enableSkills);
     if (Array.isArray(options.skillDirs)) {
       this.skillDirs = options.skillDirs;
     } else if (typeof options.skillDirs === 'string') {

--- a/npm/src/agent/index.js
+++ b/npm/src/agent/index.js
@@ -138,7 +138,7 @@ function parseArgs() {
     noMermaidValidation: false, // New flag to disable mermaid validation
     allowedTools: null, // Tool filtering: ['*'] = all, [] = none, ['tool1', 'tool2'] = specific
     disableTools: false, // Convenience flag to disable all tools
-    disableSkills: false, // Disable skill discovery and activation
+    allowSkills: false, // Enable skill discovery and activation (disabled by default)
     skillDirs: null, // Comma-separated list of repo-relative skill directories
     // Task management
     enableTasks: false, // Enable task tracking for progress management
@@ -212,8 +212,8 @@ function parseArgs() {
     } else if (arg === '--disable-tools') {
       // Convenience flag to disable all tools (raw AI mode)
       config.disableTools = true;
-    } else if (arg === '--no-skills') {
-      config.disableSkills = true;
+    } else if (arg === '--allow-skills') {
+      config.allowSkills = true;
     } else if (arg === '--skills-dir' && i + 1 < args.length) {
       config.skillDirs = args[++i].split(',').map(dir => dir.trim()).filter(Boolean);
     } else if (arg === '--allow-tasks') {
@@ -280,8 +280,8 @@ Options:
                                    Supports exclusion: '*,!bash' (all except bash)
   --disable-tools                  Disable all tools (raw AI mode, no code analysis)
                                    Convenience flag equivalent to --allowed-tools none
+  --allow-skills                   Enable skill discovery and activation (disabled by default)
   --skills-dir <dirs>              Comma-separated list of repo-relative skill directories to scan
-  --no-skills                      Disable skill discovery and activation
   --allow-tasks                    Enable task management for tracking multi-step progress
   --verbose                        Enable verbose output
   --outline                        Use outline-xml format for code search results
@@ -841,7 +841,7 @@ async function main() {
       disableMermaidValidation: config.noMermaidValidation,
       allowedTools: config.allowedTools,
       disableTools: config.disableTools,
-      enableSkills: !config.disableSkills,
+      allowSkills: config.allowSkills,
       skillDirs: config.skillDirs,
       enableBash: config.enableBash,
       bashConfig: bashConfig,

--- a/npm/tests/unit/skills/skills-config.test.js
+++ b/npm/tests/unit/skills/skills-config.test.js
@@ -1,0 +1,141 @@
+import { describe, test, expect } from '@jest/globals';
+import { ProbeAgent } from '../../../src/agent/ProbeAgent.js';
+
+describe('ProbeAgent skills configuration', () => {
+  describe('skills disabled by default', () => {
+    test('should have skills disabled when no options provided', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd()
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+
+    test('should have skills disabled when enableSkills is not set', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowedTools: ['*']
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+  });
+
+  describe('enabling skills with allowSkills', () => {
+    test('should enable skills when allowSkills is true', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: true
+      });
+
+      expect(agent.enableSkills).toBe(true);
+    });
+
+    test('should keep skills disabled when allowSkills is false', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: false
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+  });
+
+  describe('enabling skills with enableSkills (deprecated)', () => {
+    test('should enable skills when enableSkills is true', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        enableSkills: true
+      });
+
+      expect(agent.enableSkills).toBe(true);
+    });
+
+    test('should keep skills disabled when enableSkills is false', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        enableSkills: false
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+  });
+
+  describe('disableSkills override', () => {
+    test('should disable skills when disableSkills is true even if allowSkills is true', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: true,
+        disableSkills: true
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+
+    test('should disable skills when disableSkills is true even if enableSkills is true', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        enableSkills: true,
+        disableSkills: true
+      });
+
+      expect(agent.enableSkills).toBe(false);
+    });
+
+    test('should respect allowSkills when disableSkills is false', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: true,
+        disableSkills: false
+      });
+
+      expect(agent.enableSkills).toBe(true);
+    });
+  });
+
+  describe('skill tools not initialized when disabled', () => {
+    test('should not initialize skill tools when skills are disabled', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd()
+      });
+
+      expect(agent.toolImplementations.listSkills).toBeUndefined();
+      expect(agent.toolImplementations.useSkill).toBeUndefined();
+    });
+
+    test('should initialize skill tools when allowSkills is true', () => {
+      const agent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: true
+      });
+
+      // Note: The actual tool implementations depend on whether skills are found
+      // We just verify enableSkills is set correctly
+      expect(agent.enableSkills).toBe(true);
+    });
+  });
+
+  describe('clone preserves skills configuration', () => {
+    test('should preserve allowSkills in clone', () => {
+      const baseAgent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: true
+      });
+
+      const cloned = baseAgent.clone();
+
+      expect(cloned.enableSkills).toBe(true);
+    });
+
+    test('should preserve disabled skills in clone', () => {
+      const baseAgent = new ProbeAgent({
+        path: process.cwd(),
+        allowSkills: false
+      });
+
+      const cloned = baseAgent.clone();
+
+      expect(cloned.enableSkills).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Skills are now disabled by default and must be explicitly enabled
- Added `allowSkills` option to SDK (deprecated `enableSkills` still works)
- Changed CLI flag from `--no-skills` to `--allow-skills`
- Added comprehensive tests for skills configuration

## Test plan
- [x] Unit tests pass for new skills configuration behavior
- [x] Existing allowed-tools tests pass
- [x] Clone tests pass