### PR TITLE
fix: pass configured timeout to MCP SDK callTool

### DIFF
--- a/npm/src/agent/mcp/client.js
+++ b/npm/src/agent/mcp/client.js
@@ -288,11 +288,12 @@ export class MCPClientManager {
       });
 
       // Race between the actual call and timeout
+      // Pass timeout to SDK's callTool to override its default 60s timeout
       const result = await Promise.race([
         clientInfo.client.callTool({
           name: tool.originalName,
           arguments: args
-        }),
+        }, undefined, { timeout }),
         timeoutPromise
       ]);
 


### PR DESCRIPTION
## Summary
- Pass server-configured timeout to MCP SDK's `callTool()` to override its 60-second default
- Fixes issue where custom timeouts (e.g., 10 minutes for workflow tools) were being ignored

## Test plan
- [x] Existing MCP client manager tests pass (41/41)
- [ ] Manual test with a long-running MCP tool (>60 seconds)

Fixes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)