### PR TITLE
fix: Detect and accept repeated identical responses

### DIFF
--- a/npm/tests/integration/repeated-response-integration.test.js
+++ b/npm/tests/integration/repeated-response-integration.test.js
@@ -100,7 +100,15 @@ This is the actual answer that should be preserved and is long enough to pass th
 
       if (isExistingReminder && sameResponseCount > 1) {
         const prevAssistantIndex = prevUserMsgIndex - 1;
-        if (prevAssistantIndex >= 0 && messages[prevAssistantIndex].role === 'assistant') {
+        // Validate bounds before splicing
+        const hasSystemMessage = messages.length > 0 && messages[0].role === 'system';
+        const minValidIndex = hasSystemMessage ? 1 : 0;
+        const canSafelyRemove = prevAssistantIndex >= minValidIndex &&
+          messages[prevAssistantIndex] &&
+          messages[prevAssistantIndex].role === 'assistant' &&
+          (messages.length - 2) >= (hasSystemMessage ? 2 : 1);
+
+        if (canSafelyRemove) {
           // Remove duplicate assistant and old reminder
           messages.splice(prevAssistantIndex, 2);
         }
@@ -136,7 +144,15 @@ This is the actual answer that should be preserved and is long enough to pass th
 
       if (isExistingReminder && sameResponseCount > 1) {
         const prevAssistantIndex = prevUserMsgIndex - 1;
-        if (prevAssistantIndex >= 0 && messages[prevAssistantIndex].role === 'assistant') {
+        // Validate bounds before splicing
+        const hasSystemMessage = messages.length > 0 && messages[0].role === 'system';
+        const minValidIndex = hasSystemMessage ? 1 : 0;
+        const canSafelyRemove = prevAssistantIndex >= minValidIndex &&
+          messages[prevAssistantIndex] &&
+          messages[prevAssistantIndex].role === 'assistant' &&
+          (messages.length - 2) >= (hasSystemMessage ? 2 : 1);
+
+        if (canSafelyRemove) {
           messages.splice(prevAssistantIndex, 2);
         }
         messages.push({ role: 'user', content: 'New reminder' });


### PR DESCRIPTION
## Summary

Fixed the tool loop reminder issue by implementing two improvements:

1. **Repeated Response Detection** - When the AI gives the same response 3 times without tools, accept it as final
2. **Message Deduplication** - Replace previous reminders instead of appending to prevent context bloat

This fixes the production issue where iterations 42-44 had identical responses but continued looping until max iterations.

## Testing

- 45 unit tests covering detection, cleaning, validation, and message deduplication
- 8 integration tests simulating the exact production log scenario
- All 192 related tests pass

## Changes

- Modified `npm/src/agent/ProbeAgent.js` (74 lines)
- Added `npm/tests/unit/repeated-response-handling.test.js` (805 lines)
- Added `npm/tests/integration/repeated-response-integration.test.js` (309 lines)

🤖 Generated with Claude Code