### PR TITLE
feat: Forward MCP tools to delegate sessions

### DIFF
--- a/npm/src/delegate.js
+++ b/npm/src/delegate.js
@@ -186,6 +186,9 @@ const delegationManager = new DelegationManager();
  * @param {boolean} [options.searchDelegate] - Use delegated search in the subagent
  * @param {Object|string} [options.schema] - Optional JSON schema to enforce response format
  * @param {boolean} [options.enableTasks=false] - Enable task management for the subagent (isolated instance)
+ * @param {boolean} [options.enableMcp=false] - Enable MCP tool integration (inherited from parent)
+ * @param {Object} [options.mcpConfig] - MCP configuration object (inherited from parent)
+ * @param {string} [options.mcpConfigPath] - Path to MCP configuration file (inherited from parent)
  * @returns {Promise<string>} The response from the delegate agent
  */
 export async function delegate({
@@ -208,7 +211,10 @@ export async function delegate({
 	disableTools = false,
 	searchDelegate = undefined,
 	schema = null,
-	enableTasks = false
+	enableTasks = false,
+	enableMcp = false,
+	mcpConfig = null,
+	mcpConfigPath = null
 }) {
 	if (!task || typeof task !== 'string') {
 		throw new Error('Task parameter is required and must be a string');
@@ -270,7 +276,10 @@ export async function delegate({
 			allowedTools,
 			disableTools,
 			searchDelegate,
-			enableTasks // Inherit from parent (subagent gets isolated TaskManager)
+			enableTasks, // Inherit from parent (subagent gets isolated TaskManager)
+			enableMcp,   // Inherit from parent (subagent creates own MCPXmlBridge)
+			mcpConfig,   // Inherit from parent
+			mcpConfigPath // Inherit from parent
 		});
 
 		if (debug) {

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -469,7 +469,7 @@ export const extractTool = (options = {}) => {
  * @returns {Object} Configured delegate tool
  */
 export const delegateTool = (options = {}) => {
-	const { debug = false, timeout = 300, cwd, allowedFolders, enableBash = false, bashConfig, architectureFileName } = options;
+	const { debug = false, timeout = 300, cwd, allowedFolders, enableBash = false, bashConfig, architectureFileName, enableMcp = false, mcpConfig = null, mcpConfigPath = null } = options;
 
 	return tool({
 		name: 'delegate',
@@ -558,7 +558,10 @@ export const delegateTool = (options = {}) => {
 				enableBash,
 				bashConfig,
 				architectureFileName,
-				searchDelegate
+				searchDelegate,
+				enableMcp,
+				mcpConfig,
+				mcpConfigPath
 			});
 
 			return result;

--- a/npm/tests/delegate-config.test.js
+++ b/npm/tests/delegate-config.test.js
@@ -49,11 +49,17 @@ describe('Delegate Tool Configuration', () => {
         maxIterations: 30,
         parentSessionId: undefined,
         path: undefined, // No cwd or allowedFolders configured
+        allowedFolders: undefined,
         provider: undefined,
         model: undefined,
         tracer: undefined,
         enableBash: false,
-        bashConfig: undefined
+        bashConfig: undefined,
+        architectureFileName: undefined,
+        searchDelegate: undefined,
+        enableMcp: false,
+        mcpConfig: null,
+        mcpConfigPath: null
       });
 
       expect(result).toBe('Mock delegate response');

--- a/npm/tests/delegate-integration.test.js
+++ b/npm/tests/delegate-integration.test.js
@@ -92,11 +92,17 @@ describe('Delegate Tool Integration', () => {
         maxIterations: 30,
         parentSessionId: undefined,
         path: undefined,
+        allowedFolders: undefined,
         provider: undefined,
         model: undefined,
         tracer: undefined,
         enableBash: false,
-        bashConfig: undefined
+        bashConfig: undefined,
+        architectureFileName: undefined,
+        searchDelegate: undefined,
+        enableMcp: false,
+        mcpConfig: null,
+        mcpConfigPath: null
       });
 
       expect(result).toBe('Security analysis complete: Found 3 vulnerabilities');


### PR DESCRIPTION
## Summary
Subagents created via delegation now inherit MCP configuration from their parent, allowing them to access MCP-provided tools. This matches the pattern used for other tools like bash and allowedTools.

## Details
- Added `enableMcp`, `mcpConfig`, and `mcpConfigPath` parameters to the delegate function signature
- Forward these parameters from `delegateTool` to the `delegate()` function
- Each subagent creates its own MCPXmlBridge instance, maintaining isolation while enabling full MCP functionality in delegates
- Updated tests to include new parameters in expectations

## Test Results
All 113 delegate-related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)