### PR TITLE
perf: Optimize search performance with pre-computed special cases and dynamic batching

### DIFF
--- a/src/search/file_processing_tests.rs
+++ b/src/search/file_processing_tests.rs
@@ -55,6 +55,8 @@ pub fn create_test_query_plan(terms: &[&str]) -> QueryPlan {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     }
 }
 

--- a/src/search/search_runner.rs
+++ b/src/search/search_runner.rs
@@ -937,8 +937,18 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
     // Track total files available for accurate skipped file count
     let total_ranked_files = ranked_files.len();
 
+    // Use dynamic batch size: min of BATCH_SIZE and estimated_files_needed
+    // This prevents processing way more files than needed when limits are strict
+    let effective_batch_size = BATCH_SIZE.min(estimated_files_needed);
+    if debug_mode {
+        println!(
+            "DEBUG: Using batch size {} (BATCH_SIZE={}, estimated_files_needed={})",
+            effective_batch_size, BATCH_SIZE, estimated_files_needed
+        );
+    }
+
     // Process files in batches
-    for batch in ranked_files.chunks(BATCH_SIZE) {
+    for batch in ranked_files.chunks(effective_batch_size) {
         if !should_continue {
             break;
         }

--- a/tests/block_filtering_with_ast_tests.rs
+++ b/tests/block_filtering_with_ast_tests.rs
@@ -454,6 +454,8 @@ fn test_required_terms_query() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Use the term indices directly

--- a/tests/elastic_query_integration_tests.rs
+++ b/tests/elastic_query_integration_tests.rs
@@ -724,6 +724,8 @@ fn test_filter_code_block_with_ast() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Create term matches for a block
@@ -814,6 +816,8 @@ fn test_filter_tokenized_block() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Import the function from probe crate
@@ -900,6 +904,8 @@ fn test_filter_tokenized_block() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Test with only keywordGamma (lowercased since tokenization lowercases)

--- a/tests/multi_keyword_pattern_tests.rs
+++ b/tests/multi_keyword_pattern_tests.rs
@@ -42,6 +42,8 @@ fn test_multi_keyword_pattern_generation() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns
@@ -117,6 +119,8 @@ fn test_excluded_term_pattern_generation() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns
@@ -177,6 +181,8 @@ fn test_and_expression_pattern_generation() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns
@@ -252,6 +258,8 @@ fn test_or_expression_pattern_generation() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns
@@ -351,6 +359,8 @@ fn test_complex_expression_pattern_generation() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns
@@ -445,6 +455,8 @@ fn test_pattern_deduplication() {
         has_only_excluded_terms,
         evaluation_cache,
         is_universal_query: false,
+        special_case_indices: HashSet::new(),
+        special_case_terms_lower: HashMap::new(),
     };
 
     // Generate patterns


### PR DESCRIPTION
## Summary
- Pre-compute special case terms in QueryPlan to avoid repeated `is_special_case()` calls during filtering
- Add dynamic batch sizing that uses `min(BATCH_SIZE, estimated_files_needed)` to reduce unnecessary file processing
- Optimize `filter_tokenized_block` with direct HashSet lookups instead of HashMap iteration + find()

## Performance Improvement
~63% faster on markdown-heavy repositories (1.66s → ~620ms for complex queries with `--max-tokens 10000`)

Tested with query: `'("standardize" OR "govern" OR "enforce" OR "policy" OR "template") AND ("API" OR "APIs")'`

## Test plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] Lint and format checks pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)