### PR TITLE
fix: add analyze_all to validTools for XML parsing

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2832,6 +2832,10 @@ Follow these instructions carefully:
           if (this.enableDelegate && this.allowedTools.isEnabled('delegate')) {
             validTools.push('delegate');
           }
+          // Analyze All tool (for bulk data processing with map-reduce)
+          if (this.allowedTools.isEnabled('analyze_all')) {
+            validTools.push('analyze_all');
+          }
           // Task tool (require both enableTasks flag AND allowedTools permission)
           if (this.enableTasks && this.allowedTools.isEnabled('task')) {
             validTools.push('task');


### PR DESCRIPTION
## Summary
The `analyze_all` tool was added in #377 but was missing from the `validTools` array used for XML parsing. This caused the tool to appear in the system prompt but be rejected when the AI tried to use it ("No tool call detected").

## The Bug
When the AI calls `<analyze_all>...</analyze_all>`, the XML parser checks if `analyze_all` is in the `validTools` array. Since it wasn't added there, the parser returns "No tool call detected" even though the tool is properly defined and implemented.

## The Fix
Add `analyze_all` to the `validTools` array alongside the other tools (search, query, extract, delegate, etc.).

## Test Plan
- Run existing tests
- Verify analyze_all can be called successfully in code exploration

🤖 Generated with [Claude Code](https://claude.com/claude-code)