### PR TITLE
feat: make analyze_all planning phase a full exploration agent

### DIFF
--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -47,7 +47,7 @@ export const bashSchema = z.object({
 });
 
 export const analyzeAllSchema = z.object({
-	question: z.string().min(1).describe('Free-form question to answer (e.g., "What features are customers using?", "List all API endpoints"). The AI will automatically plan the search strategy, process all matching data, and synthesize a comprehensive answer.'),
+	question: z.string().min(1).describe('Free-form question to answer (e.g., "What features are customers using?", "List all API endpoints"). The AI will automatically explore the repository, test search strategies, and synthesize a comprehensive answer.'),
 	path: z.string().optional().default('.').describe('Directory path to search in')
 });
 


### PR DESCRIPTION
## Summary
The planning phase was just guessing keywords without understanding the repository structure. This caused failures when document naming conventions differed from expectations (e.g., files named "Playbook" instead of "use case").

## The Problem
```
SEARCH_QUERY: "use case" AND (authentication OR rate limiting...)
Search Results: No results found.
```
The AI guessed `"use case"` but documents were actually named `"Playbook"` and `"Debrief"`.

## The Solution
Make the planning phase a **full exploration agent** that:

1. **EXPLORES**: Uses `listFiles` to discover file types, naming patterns, directories
2. **EXPERIMENTS**: Runs multiple test searches to find what actually returns data
3. **ITERATES**: Tries different keyword combinations until finding working queries
4. **PLANS**: Creates final strategy based on real experiments, not guesses

## Changes
- Remove `allowedTools: []` restriction - full tool access for exploration
- Increase `maxIterations` from 3 to 15 for proper experimentation
- Increase `timeout` from 60s to 180s
- Update prompt to guide explore→experiment→plan workflow

## Example Flow
```
1. listFiles("customer-insights") 
   → Discovers: Playbook.md, Debrief.md, Meeting Notes/

2. search("customer") → 0 results
3. search("playbook") → 47 results ✓
4. search("playbook AND authentication") → 12 results ✓

5. Final Plan:
   SEARCH_QUERY: (playbook OR debrief) AND (authentication OR rate limiting)
   REASONING: Tested multiple queries, found documents use "playbook" naming
```

## Test Plan
- Existing tests should pass
- Manual test with customer-insights repository should now find documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)