### PR TITLE
Fix agent bundle require for Node v24

### DIFF
--- a/npm/scripts/build-agent.cjs
+++ b/npm/scripts/build-agent.cjs
@@ -46,7 +46,11 @@ async function buildAgent() {
         // Will bundle: glob, zod
       ],
       banner: {
-        js: '#!/usr/bin/env node'
+        js: [
+          '#!/usr/bin/env node',
+          'import { createRequire } from "node:module";',
+          'const require = createRequire(import.meta.url);'
+        ].join('\n')
       },
       minify: false, // Keep readable for debugging
       sourcemap: false,


### PR DESCRIPTION
## Summary
- inject createRequire banner into ESM agent bundle build
- avoid Node v24 dynamic require crash (while staying compatible with Node v20+)

## Testing
- not run (local deps missing)