### PR TITLE
fix: add missing exact, session, nextPage params to all search tool interfaces

### DIFF
--- a/npm/src/agent/acp/tools.js
+++ b/npm/src/agent/acp/tools.js
@@ -287,6 +287,18 @@ export class ACPToolManager {
             allow_tests: {
               type: 'boolean',
               description: 'Include test files in results (default: true)'
+            },
+            exact: {
+              type: 'boolean',
+              description: 'Default (false) enables stemming and keyword splitting for exploratory search. Set true for precise symbol lookup where the query matches only the exact term. Use true when you know the exact symbol name.'
+            },
+            session: {
+              type: 'string',
+              description: 'Session ID for result caching and pagination. Pass the session ID from a previous search to get additional results (next page). Results already shown in a session are automatically excluded.'
+            },
+            nextPage: {
+              type: 'boolean',
+              description: 'Set to true when requesting the next page of results. Requires passing the same session ID from the previous search output.'
             }
           },
           required: ['query']

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -11,7 +11,10 @@ import { taskSchema } from '../agent/tasks/taskTool.js';
 // Common schemas for tool parameters (used for internal execution after XML parsing)
 export const searchSchema = z.object({
 	query: z.string().describe('Search query with Elasticsearch syntax. Use quotes for exact matches, AND/OR for boolean logic, - for negation.'),
-	path: z.string().optional().default('.').describe('Path to search in. For dependencies use "go:github.com/owner/repo", "js:package_name", or "rust:cargo_name" etc.')
+	path: z.string().optional().default('.').describe('Path to search in. For dependencies use "go:github.com/owner/repo", "js:package_name", or "rust:cargo_name" etc.'),
+	exact: z.boolean().optional().default(false).describe('Default (false) enables stemming and keyword splitting for exploratory search - "getUserData" matches "get", "user", "data", etc. Set true for precise symbol lookup where "getUserData" matches only "getUserData". Use true when you know the exact symbol name.'),
+	session: z.string().optional().describe('Session ID for result caching and pagination. Pass the session ID from a previous search to get additional results (next page). Results already shown in a session are automatically excluded. Omit for a fresh search.'),
+	nextPage: z.boolean().optional().default(false).describe('Set to true when requesting the next page of results. Requires passing the same session ID from the previous search output.')
 });
 
 export const querySchema = z.object({
@@ -130,6 +133,9 @@ You need to focus on main keywords when constructing the query, and always use e
 Parameters:
 - query: (required) Search query. Free-form questions are accepted, but for best results prefer Elasticsearch-style syntax with quotes for exact matches ("functionName"), AND/OR for boolean logic, - for negation, + for important terms.
 - path: (optional, default: '.') Path to search in. All dependencies located in /dep folder, under language sub folders, like this: "/dep/go/github.com/owner/repo", "/dep/js/package_name", or "/dep/rust/cargo_name" etc.
+- exact: (optional, default: false) Set to true for precise symbol lookup without stemming/tokenization. Use when you know the exact symbol name (e.g., "getUserData" matches only "getUserData", not "get", "user", "data").
+- session: (optional) Session ID for pagination. Pass the session ID returned from a previous search to get the next page of results. Results already shown are automatically excluded.
+- nextPage: (optional, default: false) Set to true when requesting the next page of results. Requires passing the same session ID from the previous search.
 
 **Workflow:** Always start with search, then use extract for detailed context when needed.
 

--- a/npm/src/tools/langchain.js
+++ b/npm/src/tools/langchain.js
@@ -16,7 +16,7 @@ export function createSearchTool(options = {}) {
 		name: 'search',
 		description: searchDescription,
 		schema: searchSchema,
-		func: async ({ query: searchQuery, path, allow_tests, exact, maxResults, maxTokens = 20000, language }) => {
+		func: async ({ query: searchQuery, path, allow_tests, exact, maxResults, maxTokens = 20000, language, session, nextPage }) => {
 			try {
 				const results = await search({
 					query: searchQuery,
@@ -27,7 +27,9 @@ export function createSearchTool(options = {}) {
 					json: false,
 					maxResults,
 					maxTokens,
-					language
+					language,
+					session,
+					nextPage
 				});
 
 				return results;

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -169,7 +169,7 @@ export const searchTool = (options = {}) => {
 			? `${searchDescription} (delegates code search to a subagent and returns extracted code blocks)`
 			: searchDescription,
 		inputSchema: searchSchema,
-		execute: async ({ query: searchQuery, path, allow_tests, exact, maxTokens: paramMaxTokens, language }) => {
+		execute: async ({ query: searchQuery, path, allow_tests, exact, maxTokens: paramMaxTokens, language, session, nextPage }) => {
 			// Use parameter maxTokens if provided, otherwise use the default
 			const effectiveMaxTokens = paramMaxTokens || maxTokens;
 
@@ -195,7 +195,8 @@ export const searchTool = (options = {}) => {
 				exact,
 				json: false,
 				maxTokens: effectiveMaxTokens,
-				session: sessionId, // Pass session ID if provided
+				session: session || sessionId, // Use explicit session param, or fall back to options sessionId
+				nextPage, // Pass nextPage parameter for pagination
 				language // Pass language parameter if provided
 			};
 


### PR DESCRIPTION
## Summary

- Adds `exact`, `session`, and `nextPage` parameters to all search tool interfaces
- These parameters were only available in the MCP server but missing from Agent ACP tools, common schema, LangChain, and Vercel AI SDK

## Problem

The MCP server (`npm/src/mcp/index.ts`) had these search parameters:
- `exact` - for precise symbol lookup without stemming
- `session` - for result caching and pagination
- `nextPage` - for requesting additional results

But they were missing from other tool interfaces, causing inconsistent behavior reported in #386 and #387.

## Changes

| File | Changes |
|------|---------|
| `npm/src/tools/common.js` | Added params to `searchSchema` and documented in `searchToolDefinition` |
| `npm/src/agent/acp/tools.js` | Added params to agent search tool definition |
| `npm/src/tools/langchain.js` | Updated to pass `session` and `nextPage` parameters |
| `npm/src/tools/vercel.js` | Updated to pass `session` and `nextPage` parameters |

## Test plan

- [x] All 1774 existing tests pass
- [x] Parameters now consistent across all interfaces

Fixes #386, Fixes #387

🤖 Generated with [Claude Code](https://claude.ai/code)