### PR TITLE
fix: address task tool and attempt_completion issues (#407, #409, #410)

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2496,10 +2496,9 @@ ${extractGuidance}
       toolDefinitions += `${taskToolDefinition}\n`;
     }
 
-    // Always include attempt_completion (unless explicitly disabled in raw AI mode)
-    if (isToolAllowed('attempt_completion')) {
-      toolDefinitions += `${attemptCompletionToolDefinition}\n`;
-    }
+    // Always include attempt_completion unconditionally - it's a completion signal, not a tool
+    // This ensures agents can always complete their work, regardless of tool restrictions
+    toolDefinitions += `${attemptCompletionToolDefinition}\n`;
 
     // Delegate tool (require both enableDelegate flag AND allowedTools permission)
     // Place after attempt_completion as it's an optional tool
@@ -3304,8 +3303,9 @@ Follow these instructions carefully:
           if (this.enableSkills && this.allowedTools.isEnabled('listSkills')) validTools.push('listSkills');
           if (this.enableSkills && this.allowedTools.isEnabled('useSkill')) validTools.push('useSkill');
           if (this.allowedTools.isEnabled('readImage')) validTools.push('readImage');
-          // Always allow attempt_completion - it's a completion signal, not a tool
+          // Always allow attempt_completion in validTools - it's a completion signal, not a tool
           // This ensures agents can complete even when disableTools: true is set (fixes #333)
+          // The tool DEFINITION may be hidden in raw AI mode, but we still need to recognize it
           validTools.push('attempt_completion');
 
           // Edit tools (require both allowEdit flag AND allowedTools permission)


### PR DESCRIPTION
## Summary

- **#407**: Parse `tasks` param as JSON string - AI models sometimes serialize arrays as strings
- **#409**: Add task granularity guidance to prevent over-granular task creation  
- **#410**: Make `attempt_completion` always available - it's a completion signal, not a tool

## Changes

### Issue #407 - Task batch operations fail with JSON string
- AI models sometimes pass `tasks` as `"[{...}]"` instead of `[{...}]`
- Updated Zod schema to accept both array and string
- Added JSON parsing before Array.isArray check

### Issue #409 - Task granularity guidance
- Added "Task Granularity" section to `taskSystemPrompt`
- Guidance: "Fix 8 similar files" = ONE task, not 8
- Included anti-patterns (one task per file ❌) and good patterns (one task per deliverable ✓)

### Issue #410 - attempt_completion always available
- Removed all `isToolAllowed()` filtering for `attempt_completion`
- It's a completion signal, not a tool - agents always need it
- Works regardless of `allowedTools` or `disableTools` settings

## Test plan
- [x] Existing `allowed-tools.test.js` tests pass (36 tests)
- [x] Task tool accepts both array and JSON string for `tasks` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)