### PR TITLE
fix: delegate tool inherits MCP, bash, and allowedTools from parent

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -3680,6 +3680,17 @@ Follow these instructions carefully:
                 const executeToolCall = async () => {
                   // For delegate tool, pass current iteration, max iterations, session ID, and config
                   if (toolName === 'delegate') {
+                    // Reconstruct allowedTools array preserving all modes (same logic as clone())
+                    let allowedToolsForDelegate = null;
+                    if (this.allowedTools.mode === 'whitelist') {
+                      allowedToolsForDelegate = [...this.allowedTools.allowed];
+                    } else if (this.allowedTools.mode === 'none') {
+                      allowedToolsForDelegate = [];
+                    } else if (this.allowedTools.mode === 'all' && this.allowedTools.exclusions?.length > 0) {
+                      allowedToolsForDelegate = ['*', ...this.allowedTools.exclusions.map(t => '!' + t)];
+                    }
+                    // If mode is 'all' with no exclusions, leave as null (default)
+
                     const enhancedParams = {
                       ...toolParams,
                       currentIteration,
@@ -3695,7 +3706,7 @@ Follow these instructions carefully:
                       mcpConfigPath: this.mcpConfigPath, // Inherit MCP config path
                       enableBash: this.enableBash,      // Inherit bash enablement
                       bashConfig: this.bashConfig,      // Inherit bash configuration
-                      allowedTools: this.allowedTools.allowed || null,  // Inherit allowed tools whitelist
+                      allowedTools: allowedToolsForDelegate,  // Inherit allowed tools from parent
                       debug: this.debug,
                       tracer: this.tracer
                     };


### PR DESCRIPTION
## Summary

- Delegate sub-agents now inherit `enableMcp`, `mcpConfig`, `mcpConfigPath` from the parent agent, so MCP tools (e.g., workflow-based tools like `code-explorer`) are available in delegated tasks
- Delegate sub-agents now inherit `enableBash` and `bashConfig`, so bash access and command restrictions carry over
- Delegate sub-agents now inherit `allowedTools` whitelist from the parent, so tool restrictions are enforced consistently — sub-agents can no longer bypass the parent's tool policy by falling back to unrestricted default tools like `search`

## Context

When a parent ProbeAgent has `allowedTools` configured (e.g., `['delegate', 'readImage', 'code-explorer']`) and MCP tools available, delegated sub-agents were created without these settings. This caused:

1. Sub-agents had no MCP tools — they couldn't call `code-explorer` or other workflow tools
2. Sub-agents had unrestricted access to all default Probe tools (`search`, `query`, `extract`) even when the parent deliberately excluded them
3. Sub-agents fell back to raw code search instead of using the proper MCP-based tools

The `delegate.js` function already accepts all these parameters — they just weren't being passed from `ProbeAgent.js`.

## Test plan

- [ ] Verify delegate sub-agent respects parent's `allowedTools` whitelist
- [ ] Verify delegate sub-agent can use MCP tools inherited from parent
- [ ] Verify delegate sub-agent inherits bash enablement and config
- [ ] Verify existing delegation tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)