### PR TITLE
feat(agent): RAW_OUTPUT passthrough for schema responses

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -4765,12 +4765,19 @@ Convert your previous response content into actual JSON data that follows this s
       // Append DSL output buffer directly to response (bypasses LLM rewriting)
       if (this._outputBuffer && this._outputBuffer.items.length > 0 && !options._schemaFormatted) {
         const outputContent = this._outputBuffer.items.join('\n\n');
-        finalResult = (finalResult || '') + '\n\n' + outputContent;
+        if (options.schema) {
+          // Schema response — the finalResult is JSON. Wrap output in RAW_OUTPUT
+          // delimiters so clients (visor, etc.) can extract and propagate the
+          // content separately from the JSON.
+          finalResult = (finalResult || '') + '\n<<<RAW_OUTPUT>>>\n' + outputContent + '\n<<<END_RAW_OUTPUT>>>';
+        } else {
+          finalResult = (finalResult || '') + '\n\n' + outputContent;
+        }
         if (options.onStream) {
           options.onStream('\n\n' + outputContent);
         }
         if (this.debug) {
-          console.log(`[DEBUG] Appended ${this._outputBuffer.items.length} output buffer items (${outputContent.length} chars) to final result`);
+          console.log(`[DEBUG] Appended ${this._outputBuffer.items.length} output buffer items (${outputContent.length} chars) to final result${options.schema ? ' (with RAW_OUTPUT delimiters)' : ''}`);
         }
         this._outputBuffer.items = [];
       }

--- a/npm/tests/unit/raw-output-schema-passthrough.test.js
+++ b/npm/tests/unit/raw-output-schema-passthrough.test.js
@@ -1,0 +1,491 @@
+/**
+ * Tests for RAW_OUTPUT passthrough with schema-formatted responses.
+ *
+ * Verifies that:
+ * 1. output() content in execute_plan is wrapped in <<<RAW_OUTPUT>>> when agent has a schema
+ * 2. RAW_OUTPUT blocks are extracted from tool results BEFORE the LLM sees them
+ * 3. Main agent → subagent chain: raw output cascades through without hitting any LLM
+ */
+
+import { jest, describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+
+// Set environment to use mock AI provider
+process.env.USE_MOCK_AI = 'true';
+
+import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
+import {
+  extractRawOutputBlocks,
+  RAW_OUTPUT_START,
+  RAW_OUTPUT_END,
+  createExecutePlanTool,
+} from '../../src/tools/executePlan.js';
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. Unit: output buffer appended with RAW_OUTPUT delimiters for schema
+// ─────────────────────────────────────────────────────────────────────
+
+describe('ProbeAgent output buffer with schema', () => {
+  let agent;
+  let mockCallCount;
+  let mockResponses;
+
+  beforeEach(() => {
+    mockCallCount = 0;
+    mockResponses = [];
+
+    agent = new ProbeAgent({
+      sessionId: 'test-raw-output-schema',
+      path: process.cwd(),
+      debug: false,
+      enableExecutePlan: true,
+    });
+
+    agent.provider = (modelName) => `mock-${modelName}`;
+
+    // Mock streaming to return controlled responses
+    agent.streamTextWithRetryAndFallback = jest.fn(async () => {
+      const response = mockResponses[mockCallCount] ||
+        { text: '<attempt_completion>\n<result>{"answer":"done"}</result>\n</attempt_completion>' };
+      mockCallCount++;
+
+      const textParts = [response.text];
+      let index = 0;
+      return {
+        textStream: {
+          [Symbol.asyncIterator]: () => ({
+            next: async () => {
+              if (index < textParts.length) {
+                return { value: textParts[index++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          }),
+        },
+        text: Promise.resolve(response.text),
+        usage: Promise.resolve({ promptTokens: 100, completionTokens: 50 }),
+      };
+    });
+  });
+
+  afterEach(async () => {
+    agent = null;
+  });
+
+  test('output buffer items are wrapped in RAW_OUTPUT delimiters when schema is provided', async () => {
+    // Simulate: LLM calls execute_plan, which populates outputBuffer, then completes with JSON
+    const csvData = 'customer,revenue\nAcme,50000\nBeta,30000';
+
+    // Intercept native tool execution — replace execute_plan with a fake that populates outputBuffer
+    agent.toolImplementations = {
+      execute_plan: {
+        execute: async () => {
+          // Simulate what DSL output() does: writes to agent's outputBuffer
+          // and formatSuccess wraps it in RAW_OUTPUT delimiters
+          return `Plan executed successfully\n\n${RAW_OUTPUT_START}\n${csvData}\n${RAW_OUTPUT_END}\n\n[The above raw output (${csvData.length} chars) will be passed directly to the final response. Do NOT repeat, summarize, or modify it.]`;
+        },
+      },
+    };
+
+    // LLM iteration 1: call execute_plan
+    // LLM iteration 2: return schema-compliant JSON
+    mockResponses = [
+      { text: '<execute_plan>\n<code>output("' + csvData.replace(/\n/g, '\\n') + '"); return "done";</code>\n<description>Generate report</description>\n</execute_plan>' },
+      { text: '<attempt_completion>\n<result>{"answer":"Report generated","summary":"2 customers"}</result>\n</attempt_completion>' },
+    ];
+
+    agent.history = [{ role: 'system', content: 'You are a helpful assistant.' }];
+
+    const result = await agent.answer('Generate customer report', [], {
+      maxIterations: 5,
+      schema: '{"answer":"string","summary":"string"}',
+    });
+
+    // The result should contain the JSON AND the RAW_OUTPUT block
+    expect(result).toContain('"answer"');
+    expect(result).toContain(RAW_OUTPUT_START);
+    expect(result).toContain(csvData);
+    expect(result).toContain(RAW_OUTPUT_END);
+  });
+
+  test('output buffer items are NOT wrapped in RAW_OUTPUT delimiters without schema', async () => {
+    const csvData = 'customer,revenue\nAcme,50000';
+
+    agent.toolImplementations = {
+      execute_plan: {
+        execute: async () => {
+          return `Done\n\n${RAW_OUTPUT_START}\n${csvData}\n${RAW_OUTPUT_END}`;
+        },
+      },
+    };
+
+    mockResponses = [
+      { text: '<execute_plan>\n<code>output("data"); return "done";</code>\n<description>Test</description>\n</execute_plan>' },
+      { text: '<attempt_completion>\n<result>Here is the report</result>\n</attempt_completion>' },
+    ];
+
+    agent.history = [{ role: 'system', content: 'You are a helpful assistant.' }];
+
+    // No schema → plain text response
+    const result = await agent.answer('Generate report', [], {
+      maxIterations: 5,
+    });
+
+    // The result should contain the output directly (no RAW_OUTPUT delimiters)
+    expect(result).toContain(csvData);
+    // Should NOT have RAW_OUTPUT delimiters (they are only for schema responses)
+    expect(result).not.toContain(RAW_OUTPUT_START);
+    expect(result).not.toContain(RAW_OUTPUT_END);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. RAW_OUTPUT is extracted from tool results BEFORE LLM sees them
+// ─────────────────────────────────────────────────────────────────────
+
+describe('RAW_OUTPUT never reaches LLM', () => {
+  let agent;
+  let mockCallCount;
+  let mockResponses;
+  let llmReceivedMessages;
+
+  beforeEach(() => {
+    mockCallCount = 0;
+    mockResponses = [];
+    llmReceivedMessages = [];
+
+    agent = new ProbeAgent({
+      sessionId: 'test-raw-output-no-llm',
+      path: process.cwd(),
+      debug: false,
+      enableExecutePlan: true,
+    });
+
+    agent.provider = (modelName) => `mock-${modelName}`;
+
+    // Capture what the LLM actually receives
+    agent.streamTextWithRetryAndFallback = jest.fn(async (opts) => {
+      // Record the messages the LLM would receive
+      if (opts && opts.messages) {
+        llmReceivedMessages.push(...opts.messages.map(m => ({
+          role: m.role,
+          content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        })));
+      }
+
+      const response = mockResponses[mockCallCount] ||
+        { text: '<attempt_completion>\n<result>Done</result>\n</attempt_completion>' };
+      mockCallCount++;
+
+      const textParts = [response.text];
+      let index = 0;
+      return {
+        textStream: {
+          [Symbol.asyncIterator]: () => ({
+            next: async () => {
+              if (index < textParts.length) {
+                return { value: textParts[index++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          }),
+        },
+        text: Promise.resolve(response.text),
+        usage: Promise.resolve({ promptTokens: 100, completionTokens: 50 }),
+      };
+    });
+  });
+
+  afterEach(async () => {
+    agent = null;
+  });
+
+  test('RAW_OUTPUT blocks from execute_plan are stripped before LLM sees tool result', async () => {
+    const secretData = 'SENSITIVE_CSV_DATA_THAT_LLM_MUST_NOT_SEE';
+
+    agent.toolImplementations = {
+      execute_plan: {
+        execute: async () => {
+          return `Plan completed\n\n${RAW_OUTPUT_START}\n${secretData}\n${RAW_OUTPUT_END}\n\n[The above raw output (${secretData.length} chars) will be passed directly to the final response. Do NOT repeat, summarize, or modify it.]`;
+        },
+      },
+    };
+
+    mockResponses = [
+      { text: '<execute_plan>\n<code>output("data"); return "done";</code>\n<description>Test</description>\n</execute_plan>' },
+      { text: '<attempt_completion>\n<result>Report ready</result>\n</attempt_completion>' },
+    ];
+
+    agent.history = [{ role: 'system', content: 'You are a helpful assistant.' }];
+
+    await agent.answer('Generate report', [], { maxIterations: 5 });
+
+    // Check that no message sent to the LLM contains the raw data
+    for (const msg of llmReceivedMessages) {
+      expect(msg.content).not.toContain(secretData);
+      expect(msg.content).not.toContain(RAW_OUTPUT_START);
+      expect(msg.content).not.toContain(RAW_OUTPUT_END);
+    }
+
+    // Also verify via history — the tool result in history should be cleaned
+    const toolResultMessages = agent.history.filter(
+      m => m.role === 'user' && m.content && m.content.includes('<tool_result>')
+    );
+    for (const msg of toolResultMessages) {
+      expect(msg.content).not.toContain(secretData);
+      expect(msg.content).not.toContain(RAW_OUTPUT_START);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. Subagent (MCP tool) returning schema JSON + RAW_OUTPUT
+//    → parent extracts RAW_OUTPUT before LLM, cascades to parent buffer
+// ─────────────────────────────────────────────────────────────────────
+
+describe('Main agent → subagent RAW_OUTPUT cascade', () => {
+  test('parent extracts RAW_OUTPUT from subagent schema response before LLM sees it', () => {
+    // Simulate subagent returning schema JSON + appended RAW_OUTPUT
+    // (this is what ProbeAgent.answer() now produces for schema responses)
+    const subagentResponse = [
+      '{"answer":{"text":"Found 3 customers using JWT"},"references":[]}',
+      `${RAW_OUTPUT_START}`,
+      '--- report.csv ---',
+      'customer,auth_type,api_count',
+      'Acme Corp,JWT,50',
+      'Beta Inc,HMAC,12',
+      'Gamma LLC,API Key,5',
+      '--- report.csv ---',
+      `${RAW_OUTPUT_END}`,
+    ].join('\n');
+
+    // Parent agent has its own output buffer
+    const parentOutputBuffer = { items: [] };
+
+    // Parent's tool result processing extracts RAW_OUTPUT
+    const { cleanedContent, extractedBlocks } = extractRawOutputBlocks(
+      subagentResponse,
+      parentOutputBuffer
+    );
+
+    // RAW_OUTPUT content should be in parent's buffer
+    expect(extractedBlocks).toHaveLength(1);
+    expect(parentOutputBuffer.items).toHaveLength(1);
+    expect(parentOutputBuffer.items[0]).toContain('Acme Corp,JWT,50');
+    expect(parentOutputBuffer.items[0]).toContain('--- report.csv ---');
+
+    // Cleaned content (what the LLM sees) should only have the JSON
+    expect(cleanedContent).toContain('"answer"');
+    expect(cleanedContent).toContain('Found 3 customers using JWT');
+    expect(cleanedContent).not.toContain('Acme Corp,JWT,50');
+    expect(cleanedContent).not.toContain(RAW_OUTPUT_START);
+    expect(cleanedContent).not.toContain(RAW_OUTPUT_END);
+
+    // The cleaned content should be valid JSON
+    expect(() => JSON.parse(cleanedContent)).not.toThrow();
+  });
+
+  test('multi-hop cascade: grandchild → child → parent, raw output survives all hops', () => {
+    const reportData = '# Customer Auth Report\n\n| Customer | Type |\n|---|---|\n| Acme | JWT |';
+
+    // Step 1: Grandchild agent runs execute_plan with output()
+    // formatSuccess wraps in RAW_OUTPUT:
+    const grandchildToolResult = `Plan: done\n\n${RAW_OUTPUT_START}\n${reportData}\n${RAW_OUTPUT_END}\n\n[The above raw output...]`;
+
+    // Step 2: Child agent extracts grandchild's RAW_OUTPUT into its own buffer
+    const childOutputBuffer = { items: [] };
+    const { cleanedContent: childClean } = extractRawOutputBlocks(
+      grandchildToolResult,
+      childOutputBuffer
+    );
+    expect(childOutputBuffer.items).toHaveLength(1);
+    expect(childClean).not.toContain(reportData);
+
+    // Step 3: Child agent's answer() returns schema JSON + RAW_OUTPUT (our new behavior)
+    // Simulate what ProbeAgent.answer() does when outputBuffer has items and schema is set
+    const childSchemaResult =
+      '{"answer":{"text":"Analysis complete"},"references":[]}' +
+      `\n${RAW_OUTPUT_START}\n${childOutputBuffer.items.join('\n\n')}\n${RAW_OUTPUT_END}`;
+
+    // Step 4: Parent agent processes child's response as a tool result
+    const parentOutputBuffer = { items: [] };
+    const { cleanedContent: parentClean } = extractRawOutputBlocks(
+      childSchemaResult,
+      parentOutputBuffer
+    );
+
+    // Parent's buffer now has the original report data
+    expect(parentOutputBuffer.items).toHaveLength(1);
+    expect(parentOutputBuffer.items[0]).toContain('# Customer Auth Report');
+    expect(parentOutputBuffer.items[0]).toContain('Acme | JWT');
+
+    // Parent's cleaned content is just the JSON (what its LLM sees)
+    expect(parentClean).not.toContain(reportData);
+    expect(parentClean).not.toContain(RAW_OUTPUT_START);
+    expect(() => JSON.parse(parentClean)).not.toThrow();
+  });
+
+  test('full ProbeAgent integration: MCP subagent returns RAW_OUTPUT, parent schema preserves it', async () => {
+    const csvReport = 'customer,value\nAcme,100\nBeta,200';
+    let llmReceivedMessages = [];
+    let mockCallCount = 0;
+
+    // Simulate subagent response (what a child ProbeAgent.answer() with schema would return)
+    const subagentJsonResponse = '{"answer":{"text":"Found 2 customers"},"references":[]}';
+    const subagentFullResponse =
+      subagentJsonResponse +
+      `\n${RAW_OUTPUT_START}\n${csvReport}\n${RAW_OUTPUT_END}`;
+
+    const agent = new ProbeAgent({
+      sessionId: 'test-subagent-cascade',
+      path: process.cwd(),
+      debug: false,
+    });
+
+    // Mock MCP bridge with a "subagent" tool that returns schema JSON + RAW_OUTPUT
+    const mockMcpBridge = {
+      isMcpTool: jest.fn((name) => name === 'explore_code'),
+      getToolNames: jest.fn(() => ['explore_code']),
+      getToolDefinitions: jest.fn(() => ({
+        explore_code: {
+          description: 'Explore code',
+          inputSchema: { type: 'object', properties: { question: { type: 'string' } } },
+        },
+      })),
+      getXmlToolDefinitions: jest.fn(() => `
+## explore_code
+Description: Explore code
+Parameters:
+- question: string
+
+Example:
+<explore_code>
+<params>
+{"question": "example"}
+</params>
+</explore_code>
+`),
+      mcpTools: {
+        explore_code: {
+          execute: jest.fn(async () => subagentFullResponse),
+        },
+      },
+      cleanup: jest.fn(),
+    };
+
+    agent.mcpBridge = mockMcpBridge;
+    agent.provider = (modelName) => `mock-${modelName}`;
+
+    const mockResponses = [
+      { text: '<explore_code>\n<params>\n{"question":"list customers"}\n</params>\n</explore_code>' },
+      { text: '<attempt_completion>\n<result>{"text":"Here are the customers","summary":"2 customers found"}</result>\n</attempt_completion>' },
+    ];
+
+    agent.streamTextWithRetryAndFallback = jest.fn(async (opts) => {
+      // Capture what the LLM receives
+      if (opts && opts.messages) {
+        llmReceivedMessages.push(...opts.messages.map(m => ({
+          role: m.role,
+          content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+        })));
+      }
+
+      const response = mockResponses[mockCallCount] ||
+        { text: '<attempt_completion>\n<result>Done</result>\n</attempt_completion>' };
+      mockCallCount++;
+
+      const textParts = [response.text];
+      let index = 0;
+      return {
+        textStream: {
+          [Symbol.asyncIterator]: () => ({
+            next: async () => {
+              if (index < textParts.length) {
+                return { value: textParts[index++], done: false };
+              }
+              return { value: undefined, done: true };
+            },
+          }),
+        },
+        text: Promise.resolve(response.text),
+        usage: Promise.resolve({ promptTokens: 100, completionTokens: 50 }),
+      };
+    });
+
+    agent.history = [{ role: 'system', content: 'You are a helpful assistant.' }];
+
+    // Call with schema — this is the parent agent
+    const result = await agent.answer('List customers', [], {
+      maxIterations: 5,
+      schema: '{"text":"string","summary":"string"}',
+    });
+
+    // Verify: MCP tool was called
+    expect(mockMcpBridge.mcpTools.explore_code.execute).toHaveBeenCalled();
+
+    // Verify: the raw CSV data NEVER appeared in any LLM message
+    for (const msg of llmReceivedMessages) {
+      expect(msg.content).not.toContain(csvReport);
+      expect(msg.content).not.toContain(RAW_OUTPUT_START);
+    }
+
+    // Verify: the final result contains RAW_OUTPUT with the CSV data
+    expect(result).toContain(RAW_OUTPUT_START);
+    expect(result).toContain(csvReport);
+    expect(result).toContain(RAW_OUTPUT_END);
+
+    // Verify: the JSON part is still there
+    expect(result).toContain('"text"');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. createExecutePlanTool: output() wraps in RAW_OUTPUT delimiters
+// ─────────────────────────────────────────────────────────────────────
+
+describe('createExecutePlanTool output() → RAW_OUTPUT', () => {
+  test('output() in DSL writes to buffer and formatSuccess wraps in RAW_OUTPUT', async () => {
+    const outputBuffer = { items: [] };
+    const tool = createExecutePlanTool({
+      toolImplementations: {
+        search: { execute: async () => 'search results' },
+      },
+      llmCall: async () => 'ok',
+      outputBuffer,
+      maxRetries: 0,
+    });
+
+    const result = await tool.execute({
+      code: 'output("customer,value\\nAcme,100"); return "done";',
+      description: 'Test output',
+    });
+
+    // The tool result should contain RAW_OUTPUT delimiters
+    expect(result).toContain(RAW_OUTPUT_START);
+    expect(result).toContain('customer,value\nAcme,100');
+    expect(result).toContain(RAW_OUTPUT_END);
+  });
+
+  test('multiple output() calls are joined in a single RAW_OUTPUT block', async () => {
+    const outputBuffer = { items: [] };
+    const tool = createExecutePlanTool({
+      toolImplementations: {
+        search: { execute: async () => 'results' },
+      },
+      llmCall: async () => 'ok',
+      outputBuffer,
+      maxRetries: 0,
+    });
+
+    const result = await tool.execute({
+      code: 'output("line1"); output("line2"); return "done";',
+      description: 'Test multi-output',
+    });
+
+    expect(result).toContain(RAW_OUTPUT_START);
+    expect(result).toContain('line1');
+    expect(result).toContain('line2');
+    // Should have exactly one RAW_OUTPUT block
+    const starts = result.split(RAW_OUTPUT_START).length - 1;
+    expect(starts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- When `ProbeAgent.answer()` has a schema, the DSL output buffer was previously skipped entirely — `output()` content from `execute_plan` was lost
- Now wraps output buffer in `<<<RAW_OUTPUT>>>` / `<<<END_RAW_OUTPUT>>>` delimiters after schema JSON, so clients can extract and propagate raw data to the user
- Enables the full chain: `execute_plan` → `output()` → subagent schema response → parent agent extraction → user, with raw data never touching any LLM

## Changes
- `npm/src/agent/ProbeAgent.js`: When `options.schema` is set, wrap output buffer in `<<<RAW_OUTPUT>>>` delimiters instead of appending directly
- `npm/tests/unit/raw-output-schema-passthrough.test.js`: 8 new tests covering:
  - Output buffer wrapped in RAW_OUTPUT with schema
  - Output buffer appended directly without schema
  - RAW_OUTPUT extracted from tool results before LLM sees them
  - Parent→subagent cascade: RAW_OUTPUT survives all hops
  - Multi-hop grandchild→child→parent passthrough
  - Full ProbeAgent integration with MCP subagent
  - `createExecutePlanTool` output() → RAW_OUTPUT delimiters

## Test plan
- [x] `npm test -- tests/unit/raw-output-schema-passthrough.test.js` — all 8 tests pass
- [ ] Verify existing tests still pass
- [ ] Test with visor end-to-end (visor-side extraction already implemented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)