### PR TITLE
fix: add bash tool support to execute_plan DSL sandbox

### DIFF
--- a/npm/src/tools/executePlan.js
+++ b/npm/src/tools/executePlan.js
@@ -13,6 +13,7 @@ import { query } from '../query.js';
 import { extract } from '../extract.js';
 import { delegate } from '../delegate.js';
 import { glob } from 'glob';
+import { bashTool } from './bash.js';
 
 export { executePlanSchema };
 
@@ -155,6 +156,27 @@ function buildToolImplementations(configOptions) {
       }
     },
   };
+
+  // Add bash tool if enabled
+  if (configOptions.enableBash) {
+    const bashToolInstance = bashTool({
+      bashConfig: configOptions.bashConfig || {},
+      debug: configOptions.debug || false,
+      cwd: cwd,
+      allowedFolders: configOptions.allowedFolders || [],
+      workspaceRoot: configOptions.workspaceRoot || cwd,
+      tracer: configOptions.tracer || null,
+    });
+    tools.bash = {
+      execute: async (params) => {
+        try {
+          return await bashToolInstance.execute(params);
+        } catch (e) {
+          return `Bash error: ${e.message}`;
+        }
+      },
+    };
+  }
 
   return tools;
 }

--- a/npm/tests/unit/dsl-runtime.test.js
+++ b/npm/tests/unit/dsl-runtime.test.js
@@ -141,6 +141,29 @@ describe('DSL Runtime', () => {
       expect(result.status).toBe('success');
       expect(result.result).toContain('LLM processed: summarize');
     });
+
+    test('calls bash tool when available', async () => {
+      const bashRuntime = createDSLRuntime({
+        toolImplementations: {
+          ...createMockTools(),
+          bash: {
+            execute: async (params) => `command output: ${params.command}`,
+          },
+        },
+        llmCall: createMockLLM(),
+      });
+
+      const result = await bashRuntime.execute('const r = bash("ls -la"); return r;');
+      expect(result.status).toBe('success');
+      expect(result.result).toContain('command output: ls -la');
+    });
+
+    test('bash tool is not available when not provided', async () => {
+      // The default runtime doesn't include bash
+      const result = await runtime.execute('const r = bash("ls -la"); return r;');
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('bash is not defined');
+    });
   });
 
   describe('map() with concurrency', () => {


### PR DESCRIPTION
## Summary

- Adds bash tool support to the `execute_plan` DSL sandbox when `enableBash` is true
- Previously only `search`, `query`, `extract`, and `listFiles` were available, causing "bash is not defined" errors

## Problem

When an AI agent used `execute_plan` with a script containing `bash()` calls, it would fail with:
```
Execution failed: bash is not defined
```

This forced the AI to fall back to making individual tool calls in a loop, which is significantly slower.

## Solution

Modified `buildToolImplementations()` in `executePlan.js` to conditionally create a bash tool when `configOptions.enableBash` is true. The bash tool uses the same security configuration (allow/deny patterns, working directory restrictions) as the agent's main bash tool.

## Test plan

- [x] Added unit tests for bash tool availability in DSL runtime
- [x] All 2105 existing tests pass
- [x] Build succeeds

Fixes #428

🤖 Generated with [Claude Code](https://claude.ai/code)