### PR TITLE
fix: clear outputBuffer after formatSuccess to prevent accumulation

### DIFF
--- a/npm/src/tools/executePlan.js
+++ b/npm/src/tools/executePlan.js
@@ -525,6 +525,9 @@ function formatSuccess(result, description, attempt, outputBuffer) {
     const rawContent = outputBuffer.items.join('\n');
     output += `\n\n${RAW_OUTPUT_START}\n${rawContent}\n${RAW_OUTPUT_END}`;
     output += `\n\n[The above raw output (${rawContent.length} chars) will be passed directly to the final response. Do NOT repeat, summarize, or modify it.]`;
+    // Clear the buffer after reading to prevent re-wrapping on subsequent execute_plan calls
+    // Without this, extractRawOutputBlocks pushes content back to buffer, causing exponential duplication
+    outputBuffer.items = [];
   }
 
   return output;


### PR DESCRIPTION
## Summary

- Fixes #430: outputBuffer accumulation causes exponential duplication of RAW_OUTPUT content across execute_plan calls
- Clear `outputBuffer.items` after `formatSuccess` reads and wraps its content
- Without this fix, `extractRawOutputBlocks` pushes content back to the shared buffer, and subsequent `execute_plan` calls re-wrap accumulated content

## Root Cause

In `formatSuccess` (executePlan.js), the buffer was read and wrapped in `<<<RAW_OUTPUT>>>` delimiters but never cleared:

```javascript
if (outputBuffer && outputBuffer.items && outputBuffer.items.length > 0) {
    const rawContent = outputBuffer.items.join('\n');
    output += `\n\n${RAW_OUTPUT_START}\n${rawContent}\n${RAW_OUTPUT_END}`;
    // BUG: buffer was never cleared here
}
```

## Fix

Added buffer clearing after reading:

```javascript
    outputBuffer.items = [];  // Clear to prevent re-wrapping on next execute_plan call
```

## Test plan

- [x] Added test: `outputBuffer is cleared after formatSuccess to prevent accumulation`
- [x] Added test: `execute_plan without output() does not include stale buffer content`
- [x] All 2107 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)