### PR TITLE
feat: add searchAll() and maxTokens parameter to DSL search

### DIFF
--- a/docs/llm-script.md
+++ b/docs/llm-script.md
@@ -150,11 +150,18 @@ return report
 
 | Function | Description | Returns |
 |----------|-------------|---------|
-| `search(query)` | Semantic code search with Elasticsearch-like syntax | `string` — code snippets with file paths |
+| `search(query)` | Semantic code search with Elasticsearch-like syntax. Returns up to 20K tokens by default. | `string` — code snippets with file paths |
+| `search(query, path, {maxTokens})` | Search with custom token limit. Use `{maxTokens: null}` for unlimited results. | `string` — code snippets |
+| `searchAll(query)` | **Exhaustive search** — auto-paginates to retrieve ALL matching results. Use for bulk analysis when you need complete coverage. | `string` — all matching code snippets |
 | `query(pattern)` | AST-based structural code search (tree-sitter) | `string` — matching code elements |
 | `extract(targets)` | Extract code by file path + line number | `string` — extracted code content |
 | `listFiles(pattern)` | List files matching a glob pattern | `array` — array of file path strings |
 | `bash(command)` | Execute a shell command | `string` — command output |
+
+**search vs searchAll:**
+- `search(query)` — Returns first 20K tokens. Fast, good for targeted queries.
+- `search(query, ".", {maxTokens: null})` — Returns all results in one call (may be large).
+- `searchAll(query)` — Auto-paginates, concatenating all pages. Best for comprehensive analysis.
 
 ### AI (async, auto-awaited)
 

--- a/docs/probe-agent/sdk/tools-reference.md
+++ b/docs/probe-agent/sdk/tools-reference.md
@@ -33,6 +33,7 @@ Semantic code search using Elasticsearch-style queries.
 | `limit` | number | No | Maximum results (default: 20) |
 | `exact` | boolean | No | Exact match mode (default: false) |
 | `allowTests` | boolean | No | Include test files (default: false) |
+| `maxTokens` | number/null | No | Max tokens to return. Default 20000. Set to `null` for unlimited. |
 
 **Example AI Usage:**
 ```xml
@@ -42,6 +43,39 @@ Semantic code search using Elasticsearch-style queries.
   <limit>10</limit>
 </search>
 ```
+
+---
+
+### searchAll
+
+Exhaustive search that auto-paginates to retrieve ALL matching results. Use when you need complete coverage for bulk analysis.
+
+**Parameters:**
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query (supports AND, OR, NOT, wildcards) |
+| `path` | string | No | Directory to search (default: workspace root) |
+| `exact` | boolean | No | Exact match mode (default: false) |
+| `maxTokensPerPage` | number | No | Tokens per page (default: 20000) |
+| `maxPages` | number | No | Maximum pages to retrieve (default: 50, safety limit) |
+
+**Example DSL Usage:**
+```javascript
+// Get ALL matching results across the entire codebase
+const allResults = searchAll("authentication")
+
+// With options
+const results = searchAll({
+  query: "API endpoint",
+  path: "./src",
+  maxPages: 100
+})
+```
+
+**When to use:**
+- Use `search()` for targeted queries where first results are sufficient
+- Use `searchAll()` when you need complete coverage (e.g., "find ALL usages of X")
 
 **Searching Dependencies:**
 

--- a/npm/src/agent/dsl/environment.js
+++ b/npm/src/agent/dsl/environment.js
@@ -8,6 +8,7 @@
 
 import {
   searchSchema,
+  searchAllSchema,
   querySchema,
   extractSchema,
   bashSchema,
@@ -16,6 +17,7 @@ import {
 // Map of native tool names to their Zod schemas
 const NATIVE_TOOL_SCHEMAS = {
   search: searchSchema,
+  searchAll: searchAllSchema,
   query: querySchema,
   extract: extractSchema,
   bash: bashSchema,
@@ -23,7 +25,7 @@ const NATIVE_TOOL_SCHEMAS = {
 
 // Tools that are inherently async (make network/LLM calls)
 const ALWAYS_ASYNC = new Set([
-  'search', 'query', 'extract', 'listFiles', 'searchFiles', 'bash',
+  'search', 'searchAll', 'query', 'extract', 'listFiles', 'searchFiles', 'bash',
   'LLM', 'map',
 ]);
 

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -13,8 +13,17 @@ export const searchSchema = z.object({
 	query: z.string().describe('Search query with Elasticsearch syntax. Use quotes for exact matches, AND/OR for boolean logic, - for negation.'),
 	path: z.string().optional().default('.').describe('Path to search in. For dependencies use "go:github.com/owner/repo", "js:package_name", or "rust:cargo_name" etc.'),
 	exact: z.boolean().optional().default(false).describe('Default (false) enables stemming and keyword splitting for exploratory search - "getUserData" matches "get", "user", "data", etc. Set true for precise symbol lookup where "getUserData" matches only "getUserData". Use true when you know the exact symbol name.'),
+	maxTokens: z.number().nullable().optional().describe('Maximum tokens to return. Default is 20000. Set to null for unlimited results.'),
 	session: z.string().optional().describe('Session ID for result caching and pagination. Pass the session ID from a previous search to get additional results (next page). Results already shown in a session are automatically excluded. Omit for a fresh search.'),
 	nextPage: z.boolean().optional().default(false).describe('Set to true when requesting the next page of results. Requires passing the same session ID from the previous search output.')
+});
+
+export const searchAllSchema = z.object({
+	query: z.string().describe('Search query with Elasticsearch syntax. Use quotes for exact matches, AND/OR for boolean logic, - for negation.'),
+	path: z.string().optional().default('.').describe('Path to search in.'),
+	exact: z.boolean().optional().default(false).describe('Use exact matching instead of stemming.'),
+	maxTokensPerPage: z.number().optional().default(20000).describe('Tokens per page when paginating. Default 20000.'),
+	maxPages: z.number().optional().default(50).describe('Maximum pages to retrieve. Default 50 (safety limit).')
 });
 
 export const querySchema = z.object({


### PR DESCRIPTION
## Summary

Extends the `execute_plan` DSL with two new capabilities for bulk codebase analysis:

1. **`maxTokens` parameter for `search()`**
   - Pass `{maxTokens: 50000}` to increase the token limit
   - Pass `{maxTokens: null}` for unlimited results (like `analyze_all` uses internally)
   - Default remains 20,000 tokens for backward compatibility

2. **`searchAll()` function** 
   - Auto-paginates by calling `search()` repeatedly with the same session ID
   - Each call returns the next page (session-based pagination)
   - Concatenates all pages until "All results retrieved"
   - Safety limit of 50 pages by default (configurable via `maxPages`)

## Usage

```javascript
// Search with custom token limit
const results = search({query: "authentication", maxTokens: 50000})

// Unlimited results in one call
const all = search({query: "API endpoint", maxTokens: null})

// Auto-paginating exhaustive search
const everything = searchAll("error handling")

// With options
const results = searchAll({query: "TODO", maxPages: 100})
```

## Motivation

DSL scripts previously could only get the first 20K tokens of search results. For bulk analysis workflows (like finding ALL usages of a pattern), this was insufficient. The new features enable:

- Complete codebase coverage for comprehensive analysis
- Parity with `analyze_all`'s internal capabilities
- User control over token limits for different use cases

## Changes

- `npm/src/tools/executePlan.js`: Add maxTokens passthrough and searchAll tool implementation
- `npm/src/tools/common.js`: Add searchAllSchema, update searchSchema with maxTokens
- `npm/src/agent/dsl/environment.js`: Register searchAll in NATIVE_TOOL_SCHEMAS and ALWAYS_ASYNC
- `docs/llm-script.md`: Document searchAll and maxTokens in Available Functions
- `docs/probe-agent/sdk/tools-reference.md`: Add searchAll tool documentation

## Test plan

- [x] Added tests for search with maxTokens parameter
- [x] Added tests for search with maxTokens: null
- [x] Added tests for searchAll basic usage
- [x] Added tests for searchAll with options
- [x] All 2115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)