### PR TITLE
fix: prevent removeThinkingTags from destroying JSON output (issue #439)

### DIFF
--- a/npm/tests/unit/jsonValidationInfiniteLoopFix.test.js
+++ b/npm/tests/unit/jsonValidationInfiniteLoopFix.test.js
@@ -134,7 +134,9 @@ describe('JSON Validation Infinite Loop Fix', () => {
       expect(sourceCode).toContain('!this.disableMermaidValidation && !options._schemaFormatted');
 
       // 3. Thinking tag removal should check !options._schemaFormatted
-      const thinkingTagRemovalPattern = /if \(!options\._schemaFormatted\) \{[^}]*removeThinkingTags/s;
+      // The pattern was updated to allow for the JSON-safe check added in issue #439
+      // which wraps removeThinkingTags in a try-catch to skip for valid JSON
+      const thinkingTagRemovalPattern = /if \(!options\._schemaFormatted\) \{[\s\S]*?removeThinkingTags/;
       expect(sourceCode).toMatch(thinkingTagRemovalPattern);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #439 - `removeThinkingTags()` was destroying JSON output when `<thinking>` tag fragments appeared inside string values.

- **Bug**: When Gemini 2.5 Pro (and potentially other models) produces nested `<thinking>` tags, `extractThinkingContent` captures content starting with `<thinking>`. This content flows through `__PREVIOUS_RESPONSE__` → `tryAutoWrapForSimpleSchema` (which embeds it in JSON) → final `removeThinkingTags` (which truncates everything from the embedded `<thinking>` onwards), producing garbage like `{"text":"` instead of the full response.

- **Production impact**: Trace `e9e3c96871b9dc3868170be0dccd8b8a` - user received literal `{"text":"` as Slack message instead of ~2000 char explanation

## Root Cause Chain

1. **AI produces nested `<thinking>` tags** (Gemini 2.5 Pro behavior)
2. **`extractThinkingContent` captures inner `<thinking>`** due to non-greedy regex matching outer → first closing
3. **`__PREVIOUS_RESPONSE__` uses extracted content without sanitizing** residual tags
4. **`tryAutoWrapForSimpleSchema` embeds the tag inside JSON** (`{"text":"<thinking>content"}`)
5. **Final `removeThinkingTags` destroys the JSON** by truncating at the embedded tag

## Fixes

1. **`extractThinkingContent`**: Now recursively strips nested thinking tags from extracted content
2. **`__PREVIOUS_RESPONSE__` handler**: Applies `removeThinkingTags` as extra safety layer after extraction
3. **Final `removeThinkingTags`**: Skips valid JSON to avoid destroying structure when tags appear inside string values

## Test plan

- [x] New tests for `extractThinkingContent` with nested thinking tags (6 tests)
- [x] New tests for JSON-safe `removeThinkingTags` behavior (3 tests)
- [x] New test for complete flow: nested thinking → extract → auto-wrap → preserve content
- [x] New tests for `__PREVIOUS_RESPONSE__` length heuristic edge cases (3 tests)
- [x] All 2147 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)