### PR TITLE
fix: unescape XML entities in tool call parameters

### DIFF
--- a/npm/src/agent/mcp/xmlBridge.js
+++ b/npm/src/agent/mcp/xmlBridge.js
@@ -6,6 +6,7 @@
 import { MCPClientManager } from './client.js';
 import { loadMCPConfiguration } from './config.js';
 import { processXmlWithThinkingAndRecovery } from '../xmlParsingUtils.js';
+import { unescapeXmlEntities } from '../../tools/common.js';
 
 /**
  * Convert MCP tool to XML definition format
@@ -111,7 +112,7 @@ export function parseXmlMcpToolCall(xmlString, mcpToolNames = []) {
       let match;
       while ((match = paramPattern.exec(content)) !== null) {
         const [, paramName, paramValue] = match;
-        params[paramName] = paramValue.trim();
+        params[paramName] = unescapeXmlEntities(paramValue.trim());
       }
     }
 
@@ -393,7 +394,7 @@ function parseNativeXmlTool(xmlString, toolName) {
     const [, paramName, paramValue] = match;
     // Skip if this is the params tag itself (MCP format)
     if (paramName !== 'params') {
-      params[paramName] = paramValue.trim();
+      params[paramName] = unescapeXmlEntities(paramValue.trim());
     }
   }
 


### PR DESCRIPTION
## Summary
- LLMs emit XML-escaped characters (`&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`) in tool call parameters, but the XML parsers were passing them through as literal strings
- This caused bash commands like `cd tyk && git status` to be received as `cd tyk &amp;&amp; git status` and fail with permission denied errors
- Adds `unescapeXmlEntities()` helper and applies it in all three XML parsing codepaths: `parseXmlToolCall`, `parseNativeXmlTool`, and `parseXmlMcpToolCall`
- The decode order is carefully chosen (`&amp;` last) to prevent double-decoding (e.g., `&amp;lt;` → `&lt;`, not `<`)

## Test plan
- [x] 10 new unit tests for `unescapeXmlEntities()` (all 5 entities, multiple entities, double-decode prevention, non-string passthrough)
- [x] 6 new integration tests for `parseXmlToolCall` with XML entities (bash `&&`, redirects, search queries, `attempt_completion`, edit tool, complex commands)
- [x] All 124 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)