### PR TITLE
chore: update default AI models to latest production versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ const { searchTool, queryTool, extractTool } = tools;
 
 // Use with Vercel AI SDK
 const result = await generateText({
-  model: anthropic('claude-sonnet-4-5-20250929'),
+  model: anthropic('claude-sonnet-4-6'),
   tools: {
     search: searchTool({ defaultPath: './src' }),
     query: queryTool({ defaultPath: './src' }),
@@ -470,7 +470,7 @@ GOOGLE_API_KEY=...
 
 # Provider Selection
 FORCE_PROVIDER=anthropic
-MODEL_NAME=claude-sonnet-4-5-20250929
+MODEL_NAME=claude-sonnet-4-6
 
 # Custom Endpoints
 ANTHROPIC_API_URL=https://your-proxy.com

--- a/docs/guides/agent-workflows.md
+++ b/docs/guides/agent-workflows.md
@@ -311,7 +311,7 @@ async function routedAgent(task, complexity) {
     config.model = 'claude-3-haiku-20240307';  // Fast, cost-effective
   } else if (complexity === 'complex') {
     config.provider = 'anthropic';
-    config.model = 'claude-sonnet-4-5-20250929';
+    config.model = 'claude-sonnet-4-6';
   }
 
   const agent = new ProbeAgent(config);

--- a/docs/probe-agent/ai-integration.md
+++ b/docs/probe-agent/ai-integration.md
@@ -1088,7 +1088,7 @@ const extractTool = tools.createExtractTool();
 
 // Create a ChatOpenAI instance with tools
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 
@@ -1245,7 +1245,7 @@ import { StringOutputParser } from '@langchain/core/output_parsers';
 async function createCodeAssistant() {
   // Create a chat model
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.7
   });
   

--- a/docs/probe-agent/chat/cli-usage.md
+++ b/docs/probe-agent/chat/cli-usage.md
@@ -77,7 +77,7 @@ echo "Find error handling code" | probe-chat ./src
 | `-m, --model-name <model>` | Specify model name |
 
 ```bash
-probe-chat --force-provider anthropic --model-name claude-sonnet-4-5-20250929 ./src
+probe-chat --force-provider anthropic --model-name claude-sonnet-4-6 ./src
 ```
 
 ### Interface Mode
@@ -195,7 +195,7 @@ export GOOGLE_API_KEY=...
 export FORCE_PROVIDER=anthropic
 
 # Model
-export MODEL_NAME=claude-sonnet-4-5-20250929
+export MODEL_NAME=claude-sonnet-4-6
 
 # Paths
 export ALLOWED_FOLDERS=/path/to/project

--- a/docs/probe-agent/chat/configuration.md
+++ b/docs/probe-agent/chat/configuration.md
@@ -26,7 +26,7 @@ GOOGLE_API_KEY=...
 FORCE_PROVIDER=anthropic  # anthropic, openai, google
 
 # Model override
-MODEL_NAME=claude-sonnet-4-5-20250929
+MODEL_NAME=claude-sonnet-4-6
 
 # Custom API endpoints
 LLM_BASE_URL=https://your-proxy.com
@@ -107,7 +107,7 @@ AIDER_ADDITIONAL_ARGS=--no-auto-commits
 ### Claude Code Backend
 
 ```bash
-CLAUDE_CODE_MODEL=claude-3-5-sonnet-20241022
+CLAUDE_CODE_MODEL=claude-sonnet-4-6
 CLAUDE_CODE_MAX_TOKENS=8000
 CLAUDE_CODE_TEMPERATURE=0.3
 CLAUDE_CODE_MAX_TURNS=100
@@ -185,7 +185,7 @@ OTEL_ENABLE_CONSOLE=true
       "timeout": 300000,
       "maxTokens": 8000,
       "temperature": 0.3,
-      "model": "claude-3-5-sonnet-20241022",
+      "model": "claude-sonnet-4-6",
       "systemPrompt": null,
       "tools": ["edit", "search", "bash"],
       "maxTurns": 100
@@ -344,7 +344,7 @@ probe-chat ./my-project
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 export FORCE_PROVIDER=anthropic
-export MODEL_NAME=claude-sonnet-4-5-20250929
+export MODEL_NAME=claude-sonnet-4-6
 export ENABLE_MCP=1
 export DEBUG=true
 

--- a/docs/probe-agent/sdk/api-reference.md
+++ b/docs/probe-agent/sdk/api-reference.md
@@ -473,8 +473,8 @@ const agent = new ProbeAgent({
   fallback: {
     strategy: 'custom',
     providers: [
-      { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-      { provider: 'openai', model: 'gpt-4o' }
+      { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      { provider: 'openai', model: 'gpt-5.2' }
     ]
   }
 });
@@ -657,7 +657,7 @@ GOOGLE_API_KEY=...
 
 ```bash
 FORCE_PROVIDER=anthropic
-MODEL_NAME=claude-sonnet-4-5-20250929
+MODEL_NAME=claude-sonnet-4-6
 REQUEST_TIMEOUT=120000
 MAX_OPERATION_TIMEOUT=600000
 DEBUG_CHAT=1

--- a/docs/probe-agent/sdk/engines.md
+++ b/docs/probe-agent/sdk/engines.md
@@ -14,7 +14,7 @@ const agent = new ProbeAgent({ path: './src' });
 const agent = new ProbeAgent({
   path: './src',
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6'
 });
 ```
 
@@ -26,10 +26,10 @@ const agent = new ProbeAgent({
 
 | Provider | Environment Variable | Default Model |
 |----------|---------------------|---------------|
-| Anthropic | `ANTHROPIC_API_KEY` | `claude-sonnet-4-5-20250929` |
-| OpenAI | `OPENAI_API_KEY` | `gpt-4o` |
-| Google | `GOOGLE_GENERATIVE_AI_API_KEY` | `gemini-2.0-flash-exp` |
-| AWS Bedrock | AWS credentials | `anthropic.claude-sonnet-4-20250514-v1:0` |
+| Anthropic | `ANTHROPIC_API_KEY` | `claude-sonnet-4-6` |
+| OpenAI | `OPENAI_API_KEY` | `gpt-5.2` |
+| Google | `GOOGLE_GENERATIVE_AI_API_KEY` | `gemini-2.5-flash` |
+| AWS Bedrock | AWS credentials | `anthropic.claude-sonnet-4-6` |
 
 ### CLI-Based Providers
 
@@ -52,12 +52,12 @@ export ANTHROPIC_API_KEY=sk-ant-...
 const agent = new ProbeAgent({
   path: './src',
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929'  // Optional
+  model: 'claude-sonnet-4-6'  // Optional
 });
 ```
 
 **Available Models:**
-- `claude-sonnet-4-5-20250929` (default)
+- `claude-sonnet-4-6` (default)
 - `claude-opus-4-20250514`
 - `claude-3-haiku-20240307`
 
@@ -71,13 +71,13 @@ export OPENAI_API_KEY=sk-...
 const agent = new ProbeAgent({
   path: './src',
   provider: 'openai',
-  model: 'gpt-4o'  // Optional
+  model: 'gpt-5.2'  // Optional
 });
 ```
 
 **Available Models:**
-- `gpt-4o` (default)
-- `gpt-4o-mini`
+- `gpt-5.2` (default)
+- `gpt-5.2-mini`
 - `gpt-4-turbo`
 
 ### Google Gemini
@@ -90,12 +90,12 @@ export GOOGLE_GENERATIVE_AI_API_KEY=...
 const agent = new ProbeAgent({
   path: './src',
   provider: 'google',
-  model: 'gemini-2.0-flash-exp'  // Optional
+  model: 'gemini-2.5-flash'  // Optional
 });
 ```
 
 **Available Models:**
-- `gemini-2.0-flash-exp` (default)
+- `gemini-2.5-flash` (default)
 - `gemini-1.5-pro`
 - `gemini-1.5-flash`
 
@@ -112,7 +112,7 @@ export AWS_REGION=us-east-1
 const agent = new ProbeAgent({
   path: './src',
   provider: 'bedrock',
-  model: 'anthropic.claude-sonnet-4-20250514-v1:0'  // Optional
+  model: 'anthropic.claude-sonnet-4-6'  // Optional
 });
 ```
 
@@ -243,7 +243,7 @@ const agent = new ProbeAgent({
   provider: 'anthropic',
   fallback: {
     strategy: 'same-model',
-    models: ['claude-sonnet-4-5-20250929']
+    models: ['claude-sonnet-4-6']
   }
 });
 ```
@@ -258,7 +258,7 @@ const agent = new ProbeAgent({
   provider: 'anthropic',
   fallback: {
     strategy: 'same-provider',
-    models: ['claude-sonnet-4-5-20250929', 'claude-3-haiku-20240307']
+    models: ['claude-sonnet-4-6', 'claude-3-haiku-20240307']
   }
 });
 ```
@@ -273,9 +273,9 @@ const agent = new ProbeAgent({
   fallback: {
     strategy: 'custom',
     providers: [
-      { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-      { provider: 'openai', model: 'gpt-4o' },
-      { provider: 'google', model: 'gemini-2.0-flash-exp' }
+      { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      { provider: 'openai', model: 'gpt-5.2' },
+      { provider: 'google', model: 'gemini-2.5-flash' }
     ],
     stopOnSuccess: true,
     maxTotalAttempts: 10
@@ -387,7 +387,7 @@ const agent = new ProbeAgent({
 // Complex analysis: use capable model
 const analyzerAgent = new ProbeAgent({
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929'
+  model: 'claude-sonnet-4-6'
 });
 
 // Simple queries: use fast model

--- a/docs/probe-agent/sdk/getting-started.md
+++ b/docs/probe-agent/sdk/getting-started.md
@@ -127,7 +127,7 @@ const agent = new ProbeAgent({
 
   // Provider Configuration
   provider: 'anthropic',            // 'anthropic', 'openai', 'google', 'bedrock'
-  model: 'claude-sonnet-4-5-20250929',  // Override default model
+  model: 'claude-sonnet-4-6',  // Override default model
 
   // Behavior
   debug: false,                     // Enable debug output
@@ -180,8 +180,8 @@ const agent = new ProbeAgent({
     strategy: 'any',  // Try any available provider
     // Or custom provider list:
     // providers: [
-    //   { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-    //   { provider: 'openai', model: 'gpt-4o' }
+    //   { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+    //   { provider: 'openai', model: 'gpt-5.2' }
     // ]
   }
 });

--- a/docs/probe-agent/sdk/nodejs-sdk.md
+++ b/docs/probe-agent/sdk/nodejs-sdk.md
@@ -323,7 +323,7 @@ const extractTool = tools.createExtractTool({ debug: true });
 
 // Create a ChatOpenAI instance with tools
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 
@@ -440,7 +440,7 @@ import { StringOutputParser } from '@langchain/core/output_parsers';
 async function createCodeAssistant() {
   // Create a chat model
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.7
   });
   

--- a/docs/probe-agent/sdk/retry-fallback.md
+++ b/docs/probe-agent/sdk/retry-fallback.md
@@ -113,8 +113,8 @@ const agent = new ProbeAgent({
   fallback: {
     strategy: 'custom',
     providers: [
-      { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-      { provider: 'openai', model: 'gpt-4o' },
+      { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      { provider: 'openai', model: 'gpt-5.2' },
       { provider: 'google', model: 'gemini-2.0-flash' }
     ],
     stopOnSuccess: true,
@@ -140,7 +140,7 @@ GOOGLE_API_KEY=...     # → google (3rd)
 ```javascript
 {
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929',
+  model: 'claude-sonnet-4-6',
   apiKey: 'sk-ant-...',           // Override env var
   baseURL: 'https://proxy.com',   // Custom endpoint
   maxRetries: 5                   // Provider-specific retries
@@ -152,7 +152,7 @@ GOOGLE_API_KEY=...     # → google (3rd)
 ```javascript
 {
   provider: 'bedrock',
-  model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+  model: 'anthropic.claude-sonnet-4-6',
   region: 'us-east-1',
   accessKeyId: 'AKIA...',
   secretAccessKey: '...',
@@ -267,8 +267,8 @@ const agent = new ProbeAgent({
   fallback: {
     strategy: 'custom',
     providers: [
-      { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
-      { provider: 'openai', model: 'gpt-4o' },
+      { provider: 'anthropic', model: 'claude-sonnet-4-6' },
+      { provider: 'openai', model: 'gpt-5.2' },
       { provider: 'google', model: 'gemini-2.0-flash' }
     ]
   }
@@ -282,9 +282,9 @@ const agent = new ProbeAgent({
   fallback: {
     strategy: 'same-provider',
     models: [
-      'claude-sonnet-4-5-20250929',
-      'claude-3-5-sonnet-20241022',
-      'claude-3-haiku-20240307'
+      'claude-sonnet-4-6',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5-20251001'
     ]
   }
 });

--- a/docs/probe-cli/cli-reference.md
+++ b/docs/probe-cli/cli-reference.md
@@ -283,7 +283,7 @@ probe-chat [PATH] [OPTIONS]
 |--------|----------|
 | `[PATH]` | Path to the codebase to search (overrides `ALLOWED_FOLDERS` env var) |
 | `-d, --debug` | Enable debug mode for verbose logging |
-| `--model-name <model>` | Specify the AI model to use (e.g., `claude-3-opus-20240229`, `gpt-4o`) |
+| `--model-name <model>` | Specify the AI model to use (e.g., `claude-3-opus-20240229`, `gpt-5.2`) |
 | `-f, --force-provider <provider>` | Force a specific provider (`anthropic`, `openai`, `google`) |
 | `-w, --web` | Run in web interface mode instead of CLI |
 | `-p, --port <port>` | Port for web server (default: 8080) |

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -252,7 +252,7 @@ import { streamText } from 'ai';
 import { createAnthropic } from '@ai-sdk/anthropic';
 
 const result = await streamText({
-  model: createAnthropic()('claude-sonnet-4-5-20250929'),
+  model: createAnthropic()('claude-sonnet-4-6'),
   system: systemPrompt,
   messages: history,
   tools: toolDefinitions

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -220,14 +220,14 @@ const agent = new ProbeAgent({
 // Correct model names
 const agent = new ProbeAgent({
   provider: 'anthropic',
-  model: 'claude-sonnet-4-5-20250929'  // Not 'claude-3-sonnet'
+  model: 'claude-sonnet-4-6'  // Not 'claude-3-sonnet'
 });
 ```
 
 **Current default models:**
-- Anthropic: `claude-sonnet-4-5-20250929`
-- OpenAI: `gpt-4o`
-- Google: `gemini-2.0-flash-exp`
+- Anthropic: `claude-sonnet-4-6`
+- OpenAI: `gpt-5.2`
+- Google: `gemini-2.5-flash`
 
 ### Token limit exceeded
 

--- a/docs/use-cases/building-ai-tools.md
+++ b/docs/use-cases/building-ai-tools.md
@@ -101,7 +101,7 @@ const extractTool = tools.createExtractTool();
 
 // Create a ChatOpenAI instance with tools
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 
@@ -138,7 +138,7 @@ import { StringOutputParser } from '@langchain/core/output_parsers';
 async function createCodeExplainer() {
   // Create a chat model
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.5
   });
   

--- a/docs/use-cases/deploying-probe-web-interface.md
+++ b/docs/use-cases/deploying-probe-web-interface.md
@@ -96,7 +96,7 @@ You can specify which AI model to use:
 export MODEL_NAME=claude-3-opus-20240229
 
 # For OpenAI
-export MODEL_NAME=gpt-4o
+export MODEL_NAME=gpt-5.2
 ```
 
 ## Authentication & Environment Variables
@@ -120,7 +120,7 @@ export AUTH_PASSWORD=your_secure_password
 | `OPENAI_API_KEY` | Your OpenAI API key | (Required if not using Anthropic) |
 | `ALLOWED_FOLDERS` | Comma-separated list of folders to search | (Required) |
 | `PORT` | The port to run the server on | 8080 |
-| `MODEL_NAME` | Override the default model | claude-3-7-sonnet-latest or gpt-4o |
+| `MODEL_NAME` | Override the default model | claude-3-7-sonnet-latest or gpt-5.2 |
 | `AUTH_ENABLED` | Enable basic authentication | false |
 | `AUTH_USERNAME` | Username for authentication | admin |
 | `AUTH_PASSWORD` | Password for authentication | password |

--- a/docs/use-cases/nodejs-sdk.md
+++ b/docs/use-cases/nodejs-sdk.md
@@ -29,7 +29,7 @@ import { StringOutputParser } from '@langchain/core/output_parsers';
 async function createCodeAssistant() {
   // Create a chat model
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.7
   });
   
@@ -269,7 +269,7 @@ async function generateDocumentation(codebasePath, outputDir) {
   
   // Create AI model for documentation generation
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.2
   });
   
@@ -324,7 +324,7 @@ import fs from 'fs/promises';
 
 async function reviewPullRequest(repoPath, changedFiles) {
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.3
   });
   
@@ -442,7 +442,7 @@ const extractTool = tools.createExtractTool();
 
 // Create a ChatOpenAI instance with tools
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -48,8 +48,8 @@ DEBUG=false
 
 # Default model (optional)
 # For Anthropic: MODEL_NAME=claude-3-7-sonnet-latest
-# For OpenAI: MODEL_NAME=gpt-4o-2024-05-13
-# For Google: MODEL_NAME=gemini-2.0-flash
+# For OpenAI: MODEL_NAME=gpt-5.2
+# For Google: MODEL_NAME=gemini-2.5-flash
 
 # API URL configuration (optional)
 # Generic base URL for all providers (if provider-specific URL not set)
@@ -123,7 +123,7 @@ This will override any ALLOWED_FOLDERS setting in your .env file.
 ### Command-line Options
 
 - `-d, --debug`: Enable debug mode for verbose logging
-- `-m, --model <model>`: Specify the model to use (e.g., `claude-3-7-sonnet-latest`, `gpt-4o-2024-05-13`, `gemini-2.0-flash`)
+- `-m, --model <model>`: Specify the model to use (e.g., `claude-3-7-sonnet-latest`, `gpt-5.2`, `gemini-2.5-flash`)
 - `-f, --force-provider <provider>`: Force a specific provider (options: `anthropic`, `openai`, `google`)
 - `-w, --web`: Run in web interface mode
 - `-p, --port <port>`: Port to run web server on (default: 8080)
@@ -166,12 +166,12 @@ Probe Chat supports multiple AI providers, giving you flexibility in choosing wh
    - Best for: Complex code analysis, detailed explanations, and understanding nuanced patterns
 
 2. **OpenAI GPT**
-   - Default model: `gpt-4o-2024-05-13`
+   - Default model: `gpt-5.2`
    - Environment variable: `OPENAI_API_KEY`
    - Best for: General code search, pattern recognition, and concise explanations
 
 3. **Google Gemini**
-   - Default model: `gemini-2.0-flash`
+   - Default model: `gemini-2.5-flash`
    - Environment variable: `GOOGLE_API_KEY`
    - Best for: Fast responses, code generation, and efficient search
 
@@ -201,8 +201,8 @@ You can specify which model to use for each provider:
 1. **Using the command line option**:
    ```bash
    node index.js --model claude-3-7-sonnet-latest
-   node index.js --model gpt-4o-2024-05-13
-   node index.js --model gemini-2.0-flash
+   node index.js --model gpt-5.2
+   node index.js --model gemini-2.5-flash
    ```
 
 2. **Using the environment variable**:

--- a/examples/chat/implement/README.md
+++ b/examples/chat/implement/README.md
@@ -54,7 +54,7 @@ export AIDER_AUTO_COMMIT=false                    # Auto-commit changes
 export AIDER_TIMEOUT=300000                       # Aider-specific timeout (deprecated - use IMPLEMENT_TOOL_TIMEOUT)
 
 # Claude Code Configuration  
-export CLAUDE_CODE_MODEL=claude-3-5-sonnet-20241022  # Claude model
+export CLAUDE_CODE_MODEL=claude-sonnet-4-6  # Claude model
 export CLAUDE_CODE_MAX_TOKENS=8000                # Max tokens
 export CLAUDE_CODE_TEMPERATURE=0.3                # Temperature (0-2)
 export CLAUDE_CODE_MAX_TURNS=10                   # Max conversation turns
@@ -79,7 +79,7 @@ Create `implement-config.json` in your project root:
       "additionalArgs": ["--no-auto-commits"]
     },
     "claude-code": {
-      "model": "claude-3-5-sonnet-20241022",
+      "model": "claude-sonnet-4-6",
       "maxTokens": 8000,
       "temperature": 0.3,
       "tools": ["edit", "search", "bash"]
@@ -136,7 +136,7 @@ const implementTool = createImplementTool({
     backends: {
       'claude-code': {
         apiKey: process.env.MY_CLAUDE_KEY,
-        model: 'claude-3-5-sonnet-20241022',
+        model: 'claude-sonnet-4-6',
         systemPrompt: 'You are an expert TypeScript developer...'
       }
     }

--- a/examples/chat/implement/backends/AiderBackend.js
+++ b/examples/chat/implement/backends/AiderBackend.js
@@ -315,7 +315,7 @@ class AiderBackend extends BaseBackend {
       if (geminiApiKey) {
         return 'gemini/gemini-2.5-pro';
       } else if (anthropicApiKey) {
-        return 'claude-3-5-sonnet-20241022';
+        return 'claude-sonnet-4-6';
       } else if (openaiApiKey) {
         return 'gpt-4';
       }

--- a/examples/chat/implement/backends/ClaudeCodeBackend.js
+++ b/examples/chat/implement/backends/ClaudeCodeBackend.js
@@ -29,7 +29,7 @@ class ClaudeCodeBackend extends BaseBackend {
   async initialize(config) {
     this.config = {
       apiKey: config.apiKey || process.env.ANTHROPIC_API_KEY,
-      model: config.model || 'claude-3-5-sonnet-20241022',
+      model: config.model || 'claude-sonnet-4-6',
       baseUrl: config.baseUrl,
       timeout: config.timeout || getDefaultTimeoutMs(), // Use centralized default (20 minutes)
       maxTokens: config.maxTokens || 8000,

--- a/examples/chat/implement/core/config.js
+++ b/examples/chat/implement/core/config.js
@@ -137,7 +137,7 @@ class ConfigManager {
           timeout: getDefaultTimeoutMs(), // Use centralized default (20 minutes)
           maxTokens: 8000,
           temperature: 0.3,
-          model: 'claude-3-5-sonnet-20241022',
+          model: 'claude-sonnet-4-6',
           systemPrompt: null,
           tools: ['edit', 'search', 'bash'],
           maxTurns: 100

--- a/examples/chat/npm/README.md
+++ b/examples/chat/npm/README.md
@@ -50,7 +50,7 @@ You can configure the chat using environment variables:
 
 - `ANTHROPIC_API_KEY`: Your Anthropic API key
 - `OPENAI_API_KEY`: Your OpenAI API key
-- `MODEL_NAME`: The model to use (e.g., 'claude-3-7-sonnet-latest', 'gpt-4o-2024-05-13')
+- `MODEL_NAME`: The model to use (e.g., 'claude-3-7-sonnet-latest', 'gpt-5.2')
 - `ALLOWED_FOLDERS`: Comma-separated list of folders to search in
 - `DEBUG`: Set to 'true' to enable debug mode
 - `ANTHROPIC_API_URL`: Custom Anthropic API URL (optional)
@@ -140,15 +140,15 @@ const systemMessage = tools.DEFAULT_SYSTEM_MESSAGE;
 ### Anthropic Models
 - `claude-3-7-sonnet-latest` (default)
 - `claude-3-7-opus-latest`
-- `claude-3-5-sonnet-20241022`
-- `claude-3-5-sonnet-20240620`
+- `claude-sonnet-4-6`
+- `claude-sonnet-4-6`
 - `claude-3-opus-20240229`
 - `claude-3-sonnet-20240229`
 - `claude-3-haiku-20240307`
 
 ### OpenAI Models
-- `gpt-4o-2024-05-13` (default)
-- `gpt-4o`
+- `gpt-5.2` (default)
+- `gpt-5.2`
 - `gpt-4-turbo`
 - `gpt-4`
 

--- a/examples/chat/npm/index.js
+++ b/examples/chat/npm/index.js
@@ -95,7 +95,7 @@ export class ProbeChat {
         return openai(modelName);
       };
 
-      this.model = this.options.model || 'gpt-4o-2024-05-13';
+      this.model = this.options.model || 'gpt-5.2';
       this.apiType = 'openai';
 
       if (this.options.debug) {

--- a/examples/chat/test-mcp-with-ai.js
+++ b/examples/chat/test-mcp-with-ai.js
@@ -101,7 +101,7 @@ async function testMCPWithAI() {
     const google = createGoogleGenerativeAI({
       apiKey: process.env.GOOGLE_API_KEY || process.env.GOOGLE_AI_API_KEY
     });
-    model = google('gemini-2.0-flash-exp');
+    model = google('gemini-2.5-flash');
     console.log('🤖 Using Google Gemini 2.0 Flash');
   } else if (hasAnthropic) {
     const anthropic = createAnthropic();
@@ -109,7 +109,7 @@ async function testMCPWithAI() {
     console.log('🤖 Using Claude 3.5 Haiku');
   } else {
     const openai = createOpenAI();
-    model = openai('gpt-4o-mini');
+    model = openai('gpt-5.2-mini');
     console.log('🤖 Using GPT-4o Mini');
   }
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -91,7 +91,7 @@ const agent = new ProbeAgent({
   sessionId: 'my-session',  // Optional: for conversation continuity
   path: '/path/to/your/project',
   provider: 'anthropic',   // or 'openai', 'google'
-  model: 'claude-3-5-sonnet-20241022',  // Optional: override model
+  model: 'claude-sonnet-4-6',  // Optional: override model
   allowEdit: true,         // Optional: enable edit + create tools for code modification
   debug: true,            // Optional: enable debug logging
   allowedTools: ['*'],    // Optional: filter available tools (see Tool Filtering below)
@@ -128,7 +128,7 @@ export GOOGLE_API_KEY=your_google_key
 export FORCE_PROVIDER=anthropic
 
 # Optional: Override model name
-export MODEL_NAME=claude-3-5-sonnet-20241022
+export MODEL_NAME=claude-sonnet-4-6
 ```
 
 **ProbeAgent Features:**
@@ -204,12 +204,12 @@ const agent = new ProbeAgent({
         region: 'us-west-2',
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        model: 'anthropic.claude-sonnet-4-20250514-v1:0'
+        model: 'anthropic.claude-sonnet-4-6'
       },
       {
         provider: 'openai',
         apiKey: process.env.OPENAI_API_KEY,
-        model: 'gpt-4o'
+        model: 'gpt-5.2'
       }
     ],
     maxTotalAttempts: 15  // Maximum attempts across all providers
@@ -919,7 +919,7 @@ const extractTool = tools.createExtractTool();
 
 // Create a ChatOpenAI instance with tools
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 

--- a/npm/docs/CODEX_INTEGRATION.md
+++ b/npm/docs/CODEX_INTEGRATION.md
@@ -202,12 +202,12 @@ agent.events.on('toolBatch', (batch) => {
 
 ### Model Selection
 
-Default model is `gpt-4o`. Override with:
+Default model is `gpt-5.2`. Override with:
 
 ```javascript
 const agent = new ProbeAgent({
   provider: 'codex',
-  model: 'gpt-4o-mini',  // Use faster model
+  model: 'gpt-5.2-mini',  // Use faster model
   allowedFolders: [process.cwd()]
 });
 ```
@@ -215,7 +215,7 @@ const agent = new ProbeAgent({
 Or via environment:
 
 ```bash
-MODEL_NAME=gpt-4o-mini USE_CODEX=true node script.js
+MODEL_NAME=gpt-5.2-mini USE_CODEX=true node script.js
 ```
 
 ### Tool Filtering
@@ -469,7 +469,7 @@ agent.events.on('toolBatch', (batch) => {
 **Issue:** Codex CLI is slow
 
 **Solutions:**
-1. Use faster model: `model: 'gpt-4o-mini'`
+1. Use faster model: `model: 'gpt-5.2-mini'`
 2. Limit tool access: `allowedTools: ['search']`
 3. Reduce workspace size: `allowedFolders: ['/specific/path']`
 

--- a/npm/docs/RETRY_AND_FALLBACK.md
+++ b/npm/docs/RETRY_AND_FALLBACK.md
@@ -49,7 +49,7 @@ const agent = new ProbeAgent({
         provider: 'anthropic',
         apiKey: process.env.ANTHROPIC_API_KEY,
         baseURL: 'https://api.anthropic.com/v1',
-        model: 'claude-3-7-sonnet-20250219',
+        model: 'claude-sonnet-4-6',
         maxRetries: 5  // Retry 5 times on this provider
       },
       {
@@ -57,13 +57,13 @@ const agent = new ProbeAgent({
         region: 'us-west-2',
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        model: 'anthropic.claude-sonnet-4-20250514-v1:0',
+        model: 'anthropic.claude-sonnet-4-6',
         maxRetries: 3
       },
       {
         provider: 'openai',
         apiKey: process.env.OPENAI_API_KEY,
-        model: 'gpt-4o',
+        model: 'gpt-5.2',
         maxRetries: 3
       }
     ],
@@ -158,19 +158,19 @@ FALLBACK_PROVIDERS='[
   {
     "provider": "anthropic",
     "apiKey": "sk-ant-xxx",
-    "model": "claude-3-7-sonnet-20250219"
+    "model": "claude-sonnet-4-6"
   },
   {
     "provider": "bedrock",
     "region": "us-west-2",
     "accessKeyId": "xxx",
     "secretAccessKey": "xxx",
-    "model": "anthropic.claude-sonnet-4-20250514-v1:0"
+    "model": "anthropic.claude-sonnet-4-6"
   }
 ]'
 
 # Fallback models (JSON array, for same-provider fallback)
-FALLBACK_MODELS='["claude-3-7-sonnet-20250219", "claude-3-5-sonnet-20241022"]'
+FALLBACK_MODELS='["claude-sonnet-4-6", "claude-sonnet-4-6"]'
 
 # Max total attempts across all providers
 FALLBACK_MAX_TOTAL_ATTEMPTS=15
@@ -192,14 +192,14 @@ const agent = new ProbeAgent({
         provider: 'anthropic',
         apiKey: process.env.AZURE_CLAUDE_API_KEY,
         baseURL: 'https://your-azure-endpoint.com/v1',
-        model: 'claude-3-7-sonnet-20250219'
+        model: 'claude-sonnet-4-6'
       },
       {
         provider: 'bedrock',
         region: 'us-west-2',
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-        model: 'anthropic.claude-sonnet-4-20250514-v1:0'
+        model: 'anthropic.claude-sonnet-4-6'
       }
     ]
   }
@@ -219,17 +219,17 @@ const agent = new ProbeAgent({
       {
         provider: 'anthropic',
         apiKey: process.env.ANTHROPIC_API_KEY,
-        model: 'claude-3-7-sonnet-20250219'
+        model: 'claude-sonnet-4-6'
       },
       {
         provider: 'anthropic',
         apiKey: process.env.ANTHROPIC_API_KEY,
-        model: 'claude-3-5-sonnet-20241022'
+        model: 'claude-sonnet-4-6'
       },
       {
         provider: 'openai',
         apiKey: process.env.OPENAI_API_KEY,
-        model: 'gpt-4o'
+        model: 'gpt-5.2'
       }
     ]
   }
@@ -389,11 +389,11 @@ if (agent.fallbackManager) {
   // {
   //   totalAttempts: 3,
   //   providerAttempts: {
-  //     'anthropic/claude-3-7-sonnet-20250219': 1,
-  //     'bedrock/anthropic.claude-sonnet-4-20250514-v1:0': 1,
-  //     'openai/gpt-4o': 1
+  //     'anthropic/claude-sonnet-4-6': 1,
+  //     'bedrock/anthropic.claude-sonnet-4-6': 1,
+  //     'openai/gpt-5.2': 1
   //   },
-  //   successfulProvider: 'openai/gpt-4o',
+  //   successfulProvider: 'openai/gpt-5.2',
   //   failedProviders: [
   //     { provider: 'anthropic/...', error: {...} },
   //     { provider: 'bedrock/...', error: {...} }
@@ -419,7 +419,7 @@ const agent = new ProbeAgent({
 // [FallbackManager] Attempting provider: anthropic/claude-3-7-... (attempt 1/10)
 // [FallbackManager] ❌ Failed with provider: anthropic/claude-3-7-...
 // [FallbackManager] Trying next provider (2 remaining)...
-// [FallbackManager] ✅ Success with provider: openai/gpt-4o
+// [FallbackManager] ✅ Success with provider: openai/gpt-5.2
 ```
 
 ## Best Practices

--- a/npm/example-usage.js
+++ b/npm/example-usage.js
@@ -262,7 +262,7 @@ async function langchainToolsExample() {
 		console.log(`
 async function chatWithAI(userMessage) {
   const model = new ChatOpenAI({
-    modelName: "gpt-4o",
+    modelName: "gpt-5.2",
     temperature: 0.7
   }).withTools([searchTool, queryTool, extractTool]);
   
@@ -305,7 +305,7 @@ const result = await generateText({
 
 // Example with LangChain
 const model = new ChatOpenAI({
-  modelName: "gpt-4o",
+  modelName: "gpt-5.2",
   temperature: 0.7
 }).withTools([searchTool, queryTool, extractTool]);
 

--- a/npm/src/agent/FallbackManager.js
+++ b/npm/src/agent/FallbackManager.js
@@ -41,10 +41,10 @@ export const FALLBACK_STRATEGIES = {
  * Default model mappings for each provider
  */
 const DEFAULT_MODELS = {
-  anthropic: 'claude-sonnet-4-5-20250929',
-  openai: 'gpt-4o',
-  google: 'gemini-2.0-flash-exp',
-  bedrock: 'anthropic.claude-sonnet-4-20250514-v1:0'
+  anthropic: 'claude-sonnet-4-6',
+  openai: 'gpt-5.2',
+  google: 'gemini-2.5-flash',
+  bedrock: 'anthropic.claude-sonnet-4-6'
 };
 
 /**

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -718,7 +718,7 @@ export class ProbeAgent {
           // Set provider to claude-code
           this.clientApiProvider = 'claude-code';
           this.provider = null;
-          this.model = this.clientApiModel || 'claude-3-5-sonnet-20241022';
+          this.model = this.clientApiModel || 'claude-sonnet-4-6';
           this.apiType = 'claude-code';
         } else if (codexAvailable) {
           if (this.debug) {
@@ -728,7 +728,7 @@ export class ProbeAgent {
           // Set provider to codex
           this.clientApiProvider = 'codex';
           this.provider = null;
-          this.model = this.clientApiModel || 'gpt-4o';
+          this.model = this.clientApiModel || 'gpt-5.2';
           this.apiType = 'codex';
         } else {
           // Neither API keys nor CLI commands available
@@ -1040,7 +1040,7 @@ export class ProbeAgent {
       // Claude Code engine will be initialized lazily in getEngine()
       // Set minimal defaults for compatibility
       this.provider = null;
-      this.model = modelName || 'claude-3-5-sonnet-20241022';
+      this.model = modelName || 'claude-sonnet-4-6';
       this.apiType = 'claude-code';
       if (this.debug) {
         console.log('[DEBUG] Claude Code engine selected - will use built-in access if available');
@@ -1498,7 +1498,7 @@ export class ProbeAgent {
       apiKey: apiKey,
       ...(apiUrl && { baseURL: apiUrl }),
     });
-    this.model = modelName || 'claude-sonnet-4-5-20250929';
+    this.model = modelName || 'claude-sonnet-4-6';
     this.apiType = 'anthropic';
     
     if (this.debug) {
@@ -1515,7 +1515,7 @@ export class ProbeAgent {
       apiKey: apiKey,
       ...(apiUrl && { baseURL: apiUrl }),
     });
-    this.model = modelName || 'gpt-5-thinking';
+    this.model = modelName || 'gpt-5.2';
     this.apiType = 'openai';
     
     if (this.debug) {
@@ -1645,7 +1645,7 @@ export class ProbeAgent {
     }
     
     this.provider = createAmazonBedrock(config);
-    this.model = modelName || 'anthropic.claude-sonnet-4-20250514-v1:0';
+    this.model = modelName || 'anthropic.claude-sonnet-4-6';
     this.apiType = 'bedrock';
 
     if (this.debug) {
@@ -1714,7 +1714,7 @@ export class ProbeAgent {
           sessionId: this.options?.sessionId,
           debug: this.debug,
           allowedTools: this.allowedTools,  // Pass tool filtering configuration
-          model: this.model  // Pass model name (e.g., gpt-4o, o3, etc.)
+          model: this.model  // Pass model name (e.g., gpt-5.2, o3, etc.)
         });
         if (this.debug) {
           console.log('[DEBUG] Using Codex CLI engine with Probe tools');
@@ -3247,9 +3247,7 @@ Follow these instructions carefully:
         if (!maxResponseTokens) {
           // Use model-based defaults if not explicitly configured
           maxResponseTokens = 4000;
-          if (this.model && this.model.includes('opus') || this.model && this.model.includes('sonnet') || this.model && this.model.startsWith('gpt-4-')) {
-            maxResponseTokens = 8192;
-          } else if (this.model && this.model.startsWith('gpt-4o')) {
+          if (this.model && this.model.includes('opus') || this.model && this.model.includes('sonnet') || this.model && this.model.startsWith('gpt-4') || this.model && this.model.startsWith('gpt-5')) {
             maxResponseTokens = 8192;
           } else if (this.model && this.model.startsWith('gemini')) {
             maxResponseTokens = 32000;

--- a/npm/test-codex-e2e.js
+++ b/npm/test-codex-e2e.js
@@ -14,7 +14,7 @@ async function main() {
   let agent;
 
   try {
-    // Create agent with Codex provider (use default model, not gpt-4o)
+    // Create agent with Codex provider (use default model, not gpt-5.2)
     console.log('1️⃣  Creating ProbeAgent with provider: codex (using default model)');
     agent = new ProbeAgent({
       provider: 'codex',

--- a/npm/tests/integration/retryFallback.test.js
+++ b/npm/tests/integration/retryFallback.test.js
@@ -129,7 +129,7 @@ describe('Retry and Fallback Integration', () => {
             provider: 'bedrock',
             region: 'us-west-2',
             apiKey: 'bedrock-key',
-            model: 'anthropic.claude-sonnet-4-20250514-v1:0'
+            model: 'anthropic.claude-sonnet-4-6'
           }
         ],
         debug: false

--- a/npm/tests/unit/fallbackManager.test.js
+++ b/npm/tests/unit/fallbackManager.test.js
@@ -268,7 +268,7 @@ describe('FallbackManager', () => {
 
       await fallback.executeWithFallback(mockFn);
 
-      expect(receivedModel).toBe('claude-sonnet-4-5-20250929');
+      expect(receivedModel).toBe('claude-sonnet-4-6');
     });
 
     test('should throw error when no providers configured', async () => {


### PR DESCRIPTION
Updated default models across all providers to the latest production releases:
- Anthropic: claude-sonnet-4-6 (from claude-sonnet-4-5-20250929)
- OpenAI: gpt-5.2 (from gpt-4o)
- Google: gemini-2.5-flash (from gemini-2.0-flash-exp)
- Bedrock: anthropic.claude-sonnet-4-6 (from anthropic.claude-sonnet-4-20250514-v1:0)
- Claude Code: claude-sonnet-4-6 (from claude-3-5-sonnet-20241022)

All tests pass. Changes include source code, tests, documentation, and examples.