### PR TITLE
feat: add multi_edit tool for batch file editing

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -59,6 +59,7 @@ import {
   attemptCompletionToolDefinition,
   editToolDefinition,
   createToolDefinition,
+  multiEditToolDefinition,
   googleSearchToolDefinition,
   urlContextToolDefinition,
   attemptCompletionSchema,
@@ -963,6 +964,9 @@ export class ProbeAgent {
       }
       if (wrappedTools.createToolInstance && isToolAllowed('create')) {
         this.toolImplementations.create = wrappedTools.createToolInstance;
+      }
+      if (wrappedTools.multiEditToolInstance && isToolAllowed('multi_edit')) {
+        this.toolImplementations.multi_edit = wrappedTools.multiEditToolInstance;
       }
     }
 
@@ -2565,6 +2569,9 @@ ${extractGuidance}
     if (this.allowEdit && isToolAllowed('create')) {
       toolDefinitions += `${createToolDefinition}\n`;
     }
+    if (this.allowEdit && isToolAllowed('multi_edit')) {
+      toolDefinitions += `${multiEditToolDefinition}\n`;
+    }
     // Bash tool (require both enableBash flag AND allowedTools permission)
     if (this.enableBash && isToolAllowed('bash')) {
       toolDefinitions += `${bashToolDefinition}\n`;
@@ -2669,6 +2676,9 @@ The configuration is loaded from src/config.js lines 15-25 which contains the da
     }
     if (this.allowEdit && isToolAllowed('create')) {
       availableToolsList += '- create: Create new files with specified content.\n';
+    }
+    if (this.allowEdit && isToolAllowed('multi_edit')) {
+      availableToolsList += '- multi_edit: Apply multiple file edits in one call using a JSON array of operations.\n';
     }
     if (this.enableDelegate && isToolAllowed('delegate')) {
       availableToolsList += '- delegate: Delegate big distinct tasks to specialized probe subagents.\n';
@@ -3429,6 +3439,9 @@ Follow these instructions carefully:
           }
           if (this.allowEdit && this.allowedTools.isEnabled('create')) {
             validTools.push('create');
+          }
+          if (this.allowEdit && this.allowedTools.isEnabled('multi_edit')) {
+            validTools.push('multi_edit');
           }
           // Bash tool (require both enableBash flag AND allowedTools permission)
           if (this.enableBash && this.allowedTools.isEnabled('bash')) {

--- a/npm/src/agent/probeTool.js
+++ b/npm/src/agent/probeTool.js
@@ -256,6 +256,15 @@ export function createWrappedTools(baseTools) {
     );
   }
 
+  // Wrap multi_edit tool
+  if (baseTools.multiEditTool) {
+    wrappedTools.multiEditToolInstance = wrapToolWithEmitter(
+      baseTools.multiEditTool,
+      'multi_edit',
+      baseTools.multiEditTool.execute
+    );
+  }
+
   return wrappedTools;
 }
 

--- a/npm/src/agent/tools.js
+++ b/npm/src/agent/tools.js
@@ -10,6 +10,7 @@ import {
   bashTool,
   editTool,
   createTool,
+  multiEditTool,
   DEFAULT_SYSTEM_MESSAGE,
   attemptCompletionSchema,
   attemptCompletionToolDefinition,
@@ -23,6 +24,7 @@ import {
   bashSchema,
   editSchema,
   createSchema,
+  multiEditSchema,
   searchToolDefinition,
   queryToolDefinition,
   extractToolDefinition,
@@ -33,6 +35,7 @@ import {
   bashToolDefinition,
   editToolDefinition,
   createToolDefinition,
+  multiEditToolDefinition,
   googleSearchToolDefinition,
   urlContextToolDefinition,
   parseXmlToolCall
@@ -87,6 +90,9 @@ export function createTools(configOptions) {
   if (configOptions.allowEdit && isToolAllowed('create')) {
     tools.createTool = createTool(configOptions);
   }
+  if (configOptions.allowEdit && isToolAllowed('multi_edit')) {
+    tools.multiEditTool = multiEditTool(configOptions);
+  }
   return tools;
 }
 
@@ -114,6 +120,7 @@ export {
   bashSchema,
   editSchema,
   createSchema,
+  multiEditSchema,
   attemptCompletionSchema,
   searchToolDefinition,
   queryToolDefinition,
@@ -125,6 +132,7 @@ export {
   bashToolDefinition,
   editToolDefinition,
   createToolDefinition,
+  multiEditToolDefinition,
   attemptCompletionToolDefinition,
   googleSearchToolDefinition,
   urlContextToolDefinition,

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -44,13 +44,15 @@ import {
 import {
 	editSchema,
 	createSchema,
+	multiEditSchema,
 	editToolDefinition,
-	createToolDefinition
+	createToolDefinition,
+	multiEditToolDefinition
 } from './tools/edit.js';
 import { searchTool, queryTool, extractTool, delegateTool, analyzeAllTool } from './tools/vercel.js';
 import { createExecutePlanTool, getExecutePlanToolDefinition, createCleanupExecutePlanTool, getCleanupExecutePlanToolDefinition } from './tools/executePlan.js';
 import { bashTool } from './tools/bash.js';
-import { editTool, createTool } from './tools/edit.js';
+import { editTool, createTool, multiEditTool } from './tools/edit.js';
 import { FileTracker } from './tools/fileTracker.js';
 import { ProbeAgent } from './agent/ProbeAgent.js';
 import { SimpleTelemetry, SimpleAppTracer, initializeSimpleTelemetryFromOptions } from './agent/simpleTelemetry.js';
@@ -99,6 +101,7 @@ export {
 	bashTool,
 	editTool,
 	createTool,
+	multiEditTool,
 	FileTracker,
 	// Export tool instances
 	listFilesToolInstance,
@@ -115,6 +118,7 @@ export {
 	bashSchema,
 	editSchema,
 	createSchema,
+	multiEditSchema,
 	// Export tool definitions
 	searchToolDefinition,
 	queryToolDefinition,
@@ -127,6 +131,7 @@ export {
 	bashToolDefinition,
 	editToolDefinition,
 	createToolDefinition,
+	multiEditToolDefinition,
 	googleSearchToolDefinition,
 	urlContextToolDefinition,
 	// Export parser function

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -5,7 +5,7 @@
 
 import { z } from 'zod';
 import { resolve, isAbsolute } from 'path';
-import { editSchema, createSchema } from './edit.js';
+import { editSchema, createSchema, multiEditSchema } from './edit.js';
 import { taskSchema } from '../agent/tasks/taskTool.js';
 
 // Common schemas for tool parameters (used for internal execution after XML parsing)
@@ -492,7 +492,8 @@ function getValidParamsForTool(toolName) {
 		task: taskSchema,
 		attempt_completion: attemptCompletionSchema,
 		edit: editSchema,
-		create: createSchema
+		create: createSchema,
+		multi_edit: multiEditSchema
 	};
 
 	const schema = schemaMap[toolName];
@@ -707,7 +708,7 @@ export function detectUnrecognizedToolCall(xmlString, validTools) {
 	const knownToolNames = [
 		'search', 'query', 'extract', 'listFiles', 'searchFiles',
 		'listSkills', 'useSkill', 'readImage', 'edit',
-		'create', 'delegate', 'bash', 'task', 'attempt_completion',
+		'create', 'multi_edit', 'delegate', 'bash', 'task', 'attempt_completion',
 		'attempt_complete', 'read_file', 'write_file', 'run_command',
 		'grep', 'find', 'cat', 'list_directory'
 	];

--- a/npm/src/tools/index.js
+++ b/npm/src/tools/index.js
@@ -6,7 +6,7 @@
 // Export Vercel AI SDK tool generators
 export { searchTool, queryTool, extractTool, delegateTool } from './vercel.js';
 export { bashTool } from './bash.js';
-export { editTool, createTool } from './edit.js';
+export { editTool, createTool, multiEditTool } from './edit.js';
 
 // Export LangChain tools
 export { createSearchTool, createQueryTool, createExtractTool } from './langchain.js';
@@ -39,10 +39,13 @@ export {
 export {
 	editSchema,
 	createSchema,
+	multiEditSchema,
 	editDescription,
 	createDescription,
+	multiEditDescription,
 	editToolDefinition,
-	createToolDefinition
+	createToolDefinition,
+	multiEditToolDefinition
 } from './edit.js';
 
 // Export system message

--- a/npm/tests/unit/multi-edit-tool.test.js
+++ b/npm/tests/unit/multi-edit-tool.test.js
@@ -1,0 +1,168 @@
+/**
+ * Tests for multi_edit tool
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
+import { multiEditTool } from '../../src/tools/edit.js';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { randomUUID } from 'crypto';
+
+describe('multi_edit tool', () => {
+  let testDir;
+
+  beforeEach(async () => {
+    testDir = join(tmpdir(), `probe-multi-edit-test-${randomUUID()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (existsSync(testDir)) {
+      await fs.rm(testDir, { recursive: true, force: true });
+    }
+  });
+
+  function createTool() {
+    return multiEditTool({
+      debug: false,
+      allowedFolders: [testDir]
+    });
+  }
+
+  async function createFile(name, content) {
+    const path = join(testDir, name);
+    await fs.writeFile(path, content);
+    return path;
+  }
+
+  test('should apply two text edits on different files', async () => {
+    const fileA = await createFile('a.txt', 'Hello world');
+    const fileB = await createFile('b.txt', 'Goodbye world');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      edits: JSON.stringify([
+        { file_path: fileA, old_string: 'Hello', new_string: 'Hi' },
+        { file_path: fileB, old_string: 'Goodbye', new_string: 'Bye' }
+      ])
+    });
+
+    expect(result).toContain('Multi-edit: 2/2 succeeded');
+    expect(result).toContain('[1] OK');
+    expect(result).toContain('[2] OK');
+
+    const contentA = await fs.readFile(fileA, 'utf-8');
+    expect(contentA).toBe('Hi world');
+
+    const contentB = await fs.readFile(fileB, 'utf-8');
+    expect(contentB).toBe('Bye world');
+  });
+
+  test('should handle partial failure — failed edit does not stop remaining edits', async () => {
+    const fileA = await createFile('a.txt', 'Hello world');
+    const fileB = await createFile('b.txt', 'Goodbye world');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      edits: JSON.stringify([
+        { file_path: fileA, old_string: 'Hello', new_string: 'Hi' },
+        { file_path: fileA, old_string: 'NONEXISTENT', new_string: 'replaced' },
+        { file_path: fileB, old_string: 'Goodbye', new_string: 'Bye' }
+      ])
+    });
+
+    expect(result).toContain('Multi-edit: 2/3 succeeded, 1 failed');
+    expect(result).toContain('[1] OK');
+    expect(result).toContain('[2] FAIL');
+    expect(result).toContain('[3] OK');
+
+    const contentB = await fs.readFile(fileB, 'utf-8');
+    expect(contentB).toBe('Bye world');
+  });
+
+  test('should return error for invalid JSON', async () => {
+    const tool = createTool();
+    const result = await tool.execute({ edits: 'not valid json' });
+
+    expect(result).toContain('Error: Invalid JSON');
+  });
+
+  test('should return error for empty array', async () => {
+    const tool = createTool();
+    const result = await tool.execute({ edits: '[]' });
+
+    expect(result).toContain('Error: edits must be a non-empty JSON array');
+  });
+
+  test('should return error when exceeding 50 edits limit', async () => {
+    const edits = Array.from({ length: 51 }, (_, i) => ({
+      file_path: `file${i}.txt`,
+      old_string: 'a',
+      new_string: 'b'
+    }));
+
+    const tool = createTool();
+    const result = await tool.execute({ edits: JSON.stringify(edits) });
+
+    expect(result).toContain('Error: Too many edits (51)');
+    expect(result).toContain('Maximum 50');
+  });
+
+  test('should handle sequential same-file edits — second sees first changes', async () => {
+    const file = await createFile('seq.txt', 'aaa bbb ccc');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      edits: JSON.stringify([
+        { file_path: file, old_string: 'aaa', new_string: 'xxx' },
+        { file_path: file, old_string: 'xxx bbb', new_string: 'yyy' }
+      ])
+    });
+
+    expect(result).toContain('Multi-edit: 2/2 succeeded');
+
+    const content = await fs.readFile(file, 'utf-8');
+    expect(content).toBe('yyy ccc');
+  });
+
+  test('should handle non-object entries in array gracefully', async () => {
+    const file = await createFile('a.txt', 'Hello world');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      edits: JSON.stringify([
+        'not an object',
+        { file_path: file, old_string: 'Hello', new_string: 'Hi' }
+      ])
+    });
+
+    expect(result).toContain('1/2 succeeded, 1 failed');
+    expect(result).toContain('[1] FAIL');
+    expect(result).toContain('[2] OK');
+
+    const content = await fs.readFile(file, 'utf-8');
+    expect(content).toBe('Hi world');
+  });
+
+  test('should accept edits as a pre-parsed array (not just JSON string)', async () => {
+    const file = await createFile('a.txt', 'Hello world');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      edits: [
+        { file_path: file, old_string: 'Hello', new_string: 'Hi' }
+      ]
+    });
+
+    expect(result).toContain('Multi-edit: 1/1 succeeded');
+  });
+
+  test('should return error for non-array, non-string edits', async () => {
+    const tool = createTool();
+    const result = await tool.execute({ edits: 42 });
+
+    expect(result).toContain('Error: edits must be a JSON array');
+  });
+});


### PR DESCRIPTION
## Summary

Add new `multi_edit` tool that applies multiple file edits in a single tool call. Each operation uses the same edit modes as the existing `edit` tool (text replacement, symbol-based, line-targeted), but accepts a JSON array for batch operations.

- Edits applied sequentially (order matters for same-file changes)
- Failures don't halt remaining edits
- Aggregated results summary showing success/failure counts
- Max 50 edits per batch, gated behind `allowEdit` flag

## Implementation

- Reuses existing `editTool` implementation (no duplication)
- Full tool registration across agent layer (5 ProbeAgent registration points)
- 9 test cases, all passing
- Build passes, no breaking changes to existing tests

## Test Plan

- All 9 new multi_edit tests passing
- Existing edit/create tests remain passing
- npm build completes successfully

🤖 Generated with Claude Code