### PR TITLE
fix: XML parsing and path resolution bugs in create/edit tools

### DIFF
--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -538,6 +538,15 @@ export function unescapeXmlEntities(str) {
 		.replace(/&amp;/g, '&');
 }
 
+// Parameters that contain arbitrary code/file content — use lastIndexOf for closing tag
+// to handle cases where the content itself contains the closing tag string.
+const RAW_CONTENT_PARAMS = new Set(['content', 'new_string', 'old_string']);
+
+// Tools whose content can include their own closing tag string (e.g., file content
+// containing </create> or </edit>). Use lastIndexOf for outer tag boundary, same
+// strategy already used for attempt_completion.
+const LAST_INDEX_TOOLS = new Set(['attempt_completion', 'create', 'edit']);
+
 // Simple XML parser helper - safer string-based approach
 export function parseXmlToolCall(xmlString, validTools = DEFAULT_VALID_TOOLS) {
 	// Find the tool that appears EARLIEST in the string
@@ -564,13 +573,13 @@ export function parseXmlToolCall(xmlString, validTools = DEFAULT_VALID_TOOLS) {
 	const closeTag = `</${toolName}>`;
 	const openIndex = earliestOpenIndex;
 
-	// For attempt_completion, use lastIndexOf to find the LAST occurrence of closing tag
-	// This prevents issues where the content contains the closing tag string (e.g., in regex patterns)
-	// For other tools, use indexOf from the opening tag position
+	// For tools that contain arbitrary content (file content, code), use lastIndexOf
+	// to find the LAST occurrence of the closing tag. This prevents issues where the
+	// content itself contains the closing tag string (e.g., file content with </create>).
+	// For other tools, use indexOf from the opening tag position.
 	let closeIndex;
-	if (toolName === 'attempt_completion') {
+	if (LAST_INDEX_TOOLS.has(toolName)) {
 		// Find the last occurrence of the closing tag in the entire string
-		// This assumes attempt_completion doesn't have nested tags of the same name
 		closeIndex = xmlString.lastIndexOf(closeTag);
 		// Make sure the closing tag is after the opening tag
 		if (closeIndex !== -1 && closeIndex <= openIndex + openTag.length) {
@@ -610,7 +619,19 @@ export function parseXmlToolCall(xmlString, validTools = DEFAULT_VALID_TOOLS) {
 			continue; // Parameter not found
 		}
 
-		let paramCloseIndex = innerContent.indexOf(paramCloseTag, paramOpenIndex + paramOpenTag.length);
+		// For raw content params (file content, code), use lastIndexOf to find the
+		// LAST closing tag — the content itself may contain the closing tag string.
+		// For other params (file_path, overwrite, etc.), use indexOf (first match).
+		let paramCloseIndex;
+		if (RAW_CONTENT_PARAMS.has(paramName)) {
+			paramCloseIndex = innerContent.lastIndexOf(paramCloseTag);
+			// Ensure it's after the opening tag
+			if (paramCloseIndex !== -1 && paramCloseIndex <= paramOpenIndex + paramOpenTag.length) {
+				paramCloseIndex = -1;
+			}
+		} else {
+			paramCloseIndex = innerContent.indexOf(paramCloseTag, paramOpenIndex + paramOpenTag.length);
+		}
 
 		// Handle unclosed parameter tags - use content until next tag or end of content
 		if (paramCloseIndex === -1) {
@@ -626,23 +647,34 @@ export function parseXmlToolCall(xmlString, validTools = DEFAULT_VALID_TOOLS) {
 			paramCloseIndex = nextTagIndex;
 		}
 
-		let paramValue = unescapeXmlEntities(innerContent.substring(
+		const rawValue = innerContent.substring(
 			paramOpenIndex + paramOpenTag.length,
 			paramCloseIndex
-		).trim());
+		);
 
-		// Basic type inference (can be improved)
-		if (paramValue.toLowerCase() === 'true') {
-			paramValue = true;
-		} else if (paramValue.toLowerCase() === 'false') {
-			paramValue = false;
-		} else if (!isNaN(paramValue) && paramValue.trim() !== '') {
-			// Check if it's potentially a number (handle integers and floats)
-			const num = Number(paramValue);
-			if (Number.isFinite(num)) { // Use Number.isFinite to avoid Infinity/NaN
-				paramValue = num;
+		// For raw content params, preserve whitespace (only strip XML formatting newlines).
+		// For other params, trim all whitespace.
+		let paramValue;
+		if (RAW_CONTENT_PARAMS.has(paramName)) {
+			paramValue = unescapeXmlEntities(rawValue.replace(/^\n/, '').replace(/\n$/, ''));
+		} else {
+			paramValue = unescapeXmlEntities(rawValue.trim());
+		}
+
+		// Type coercion for non-content params only (content/new_string/old_string must stay strings)
+		if (!RAW_CONTENT_PARAMS.has(paramName)) {
+			if (paramValue.toLowerCase() === 'true') {
+				paramValue = true;
+			} else if (paramValue.toLowerCase() === 'false') {
+				paramValue = false;
+			} else if (!isNaN(paramValue) && paramValue.trim() !== '') {
+				// Check if it's potentially a number (handle integers and floats)
+				const num = Number(paramValue);
+				if (Number.isFinite(num)) { // Use Number.isFinite to avoid Infinity/NaN
+					paramValue = num;
+				}
+				// Keep as string if not a valid finite number
 			}
-			// Keep as string if not a valid finite number
 		}
 
 		params[paramName] = paramValue;

--- a/npm/src/tools/edit.js
+++ b/npm/src/tools/edit.js
@@ -363,7 +363,7 @@ Parameters:
       required: ['file_path', 'new_string']
     },
 
-    execute: async ({ file_path, old_string, new_string, replace_all = false, symbol, position, start_line, end_line }) => {
+    execute: async ({ file_path, old_string, new_string, replace_all = false, symbol, position, start_line, end_line, workingDirectory }) => {
       try {
         // Validate input parameters
         if (!file_path || typeof file_path !== 'string' || file_path.trim() === '') {
@@ -373,8 +373,9 @@ Parameters:
           return `Error editing file: Invalid new_string - must be a string. Provide the replacement content as a string value (empty string "" is valid for deletions).`;
         }
 
-        // Resolve the file path
-        const resolvedPath = isAbsolute(file_path) ? file_path : resolve(cwd || process.cwd(), file_path);
+        // Resolve the file path (workingDirectory from runtime takes priority over cwd from tool creation)
+        const effectiveCwd = workingDirectory || cwd || process.cwd();
+        const resolvedPath = isAbsolute(file_path) ? file_path : resolve(effectiveCwd, file_path);
 
         if (debug) {
           console.error(`[Edit] Attempting to edit file: ${resolvedPath}`);
@@ -530,7 +531,7 @@ Important:
       required: ['file_path', 'content']
     },
 
-    execute: async ({ file_path, content, overwrite = false }) => {
+    execute: async ({ file_path, content, overwrite = false, workingDirectory }) => {
       try {
         // Validate input parameters
         if (!file_path || typeof file_path !== 'string' || file_path.trim() === '') {
@@ -540,8 +541,9 @@ Important:
           return `Error creating file: Invalid content - must be a string. Provide the file content as a string value (empty string "" is valid for an empty file).`;
         }
 
-        // Resolve the file path
-        const resolvedPath = isAbsolute(file_path) ? file_path : resolve(cwd || process.cwd(), file_path);
+        // Resolve the file path (workingDirectory from runtime takes priority over cwd from tool creation)
+        const effectiveCwd = workingDirectory || cwd || process.cwd();
+        const resolvedPath = isAbsolute(file_path) ? file_path : resolve(effectiveCwd, file_path);
 
         if (debug) {
           console.error(`[Create] Attempting to create file: ${resolvedPath}`);


### PR DESCRIPTION
## Summary

- **XML parsing: content truncation** — `parseXmlToolCall()` used `indexOf` to find closing tags for `<create>`, `<edit>`, `<content>`, `<new_string>`, `<old_string>`. If file content contained these strings (e.g., documenting XML tags), the parser would truncate at the first match. Now uses `lastIndexOf` for these tools/params, matching the existing `attempt_completion` strategy.
- **Type coercion corrupting content** — The XML parser coerced `"true"`/`"false"` to booleans and numeric strings to numbers for ALL params. For `content`/`new_string`/`old_string`, this caused the create tool to reject valid file content. Now skips coercion for raw content params.
- **Whitespace stripping** — `.trim()` was applied to all param values, stripping leading/trailing whitespace from file content. Now only strips XML formatting newlines for content params.
- **`workingDirectory` ignored** — Create/edit tools used `cwd` from tool creation time, ignoring the runtime `workingDirectory` from ProbeAgent. In multi-repo workspaces, relative paths resolved against the workspace root instead of the correct repo directory. Now accepts and uses `workingDirectory` with fallback to `cwd`.

## Test plan

- [x] 11 new XML parsing tests (content tag preservation, type coercion, whitespace)
- [x] 4 new workingDirectory integration tests (relative/absolute paths, fallback)
- [x] All existing edit/create XML parsing tests pass (no regressions)
- [x] Full test suite: 2720 passed, 2 pre-existing failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)