### PR TITLE
fix: pass validTools to removeThinkingTags so edit/create aren't dropped (#459)

### DIFF
--- a/npm/src/agent/xmlParsingUtils.js
+++ b/npm/src/agent/xmlParsingUtils.js
@@ -11,7 +11,7 @@ import { DEFAULT_VALID_TOOLS, buildToolTagPattern } from '../tools/common.js';
  * @param {string} xmlString - The XML string to clean
  * @returns {string} - Cleaned XML string without thinking tags
  */
-export function removeThinkingTags(xmlString) {
+export function removeThinkingTags(xmlString, validTools = DEFAULT_VALID_TOOLS) {
   let result = xmlString;
 
   // Remove all properly closed thinking tags first
@@ -26,8 +26,8 @@ export function removeThinkingTags(xmlString) {
     const afterThinking = result.substring(thinkingIndex + '<thinking>'.length);
 
     // Look for any tool tags in the remaining content
-    // Use the shared tool list to build the pattern dynamically
-    const toolPattern = buildToolTagPattern(DEFAULT_VALID_TOOLS);
+    // Use the provided valid tools list to build the pattern dynamically
+    const toolPattern = buildToolTagPattern(validTools);
     const toolMatch = afterThinking.match(toolPattern);
 
     if (toolMatch) {
@@ -201,7 +201,9 @@ export function processXmlWithThinkingAndRecovery(xmlString, validTools = []) {
   const thinkingContent = extractThinkingContent(xmlString);
 
   // Remove thinking tags and their content from the XML string
-  const cleanedXmlString = removeThinkingTags(xmlString);
+  // Forward validTools so that tool tags (e.g. edit, create) inside unclosed
+  // thinking blocks are preserved when they are in the valid tools list
+  const cleanedXmlString = removeThinkingTags(xmlString, validTools.length > 0 ? validTools : undefined);
 
   // Check for attempt_complete recovery patterns
   const recoveryResult = checkAttemptCompleteRecovery(cleanedXmlString, validTools);


### PR DESCRIPTION
## Summary

- `removeThinkingTags()` hardcoded `DEFAULT_VALID_TOOLS` which doesn't include `edit` or `create`. When Gemini wraps tool calls in unclosed `<thinking>` tags, `<edit>` and `<create>` calls were silently stripped before `parseXmlToolCall` ever saw them.
- Added optional `validTools` parameter to `removeThinkingTags()` (defaults to `DEFAULT_VALID_TOOLS` for backward compatibility)
- `processXmlWithThinkingAndRecovery()` now forwards its `validTools` argument through to `removeThinkingTags()`
- No changes needed in `parseXmlToolCallWithThinking` or `ProbeAgent.js` — they already pass the correct dynamic tools list

Closes #459

## Test plan

- [x] Added 3 tests documenting the bug (edit/create dropped with default tools, bash preserved)
- [x] Added 2 tests verifying the fix (edit/create preserved when passed in validTools)
- [x] Added 3 end-to-end tests via `parseXmlToolCallWithThinking` (edit parsing, create parsing, closed thinking regression)
- [x] Full xmlParsing test suite passes (143/143 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)