### PR TITLE
fix: string-aware bracket matching in cleanSchemaResponse prevents truncation

### DIFF
--- a/npm/tests/unit/schemaUtils.test.js
+++ b/npm/tests/unit/schemaUtils.test.js
@@ -175,6 +175,24 @@ describe('Schema Utilities', () => {
       expect(cleanSchemaResponse(input)).toBe(expected);
     });
 
+    test('should not truncate when JSON string values contain brackets', () => {
+      // Regression: bracket counter must skip brackets inside quoted strings
+      const input = '```json\n{"text": "Configure with: \\\"http_server_options\\\": { \\\"use_ssl\\\": true } and restart."}\n```';
+      const result = cleanSchemaResponse(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.text).toContain('use_ssl');
+      expect(parsed.text).toContain('and restart.');
+    });
+
+    test('should not truncate when JSON string values contain unescaped closing braces', () => {
+      // The text field contains } characters that look like JSON closing braces
+      const jsonObj = {"text": "Step 1: add { \"key\": \"val\" } to config. Step 2: restart. Step 3: verify."};
+      const input = '```json\n' + JSON.stringify(jsonObj) + '\n```';
+      const result = cleanSchemaResponse(input);
+      const parsed = JSON.parse(result);
+      expect(parsed.text).toBe(jsonObj.text);
+    });
+
     test('should not extract JSON when embedded in surrounding text', () => {
       const input = 'Here is some JSON: {"test": "value"} that should be extracted';
       // Should return original since JSON has text before and after it


### PR DESCRIPTION
## Summary

- Fix naive bracket-matching in `cleanSchemaResponse()` that truncated LLM responses containing `}` or `]` inside JSON string values
- Add `inString`/`escapeNext` tracking to the code-block JSON extraction loop, matching the correct implementation already in `tryExtractValidJsonPrefix()` in the same file
- Add 2 regression tests for bracket-in-string scenarios

## Problem

When an LLM returned a JSON response inside a ` ```json ` code block where the `text` field contained curly braces or square brackets (e.g., code examples, JSON config snippets), the bracket counter would hit zero prematurely and `substring()` would return truncated JSON.

**Production impact:** A 24,971-char response was truncated to ~600 chars, with content lost from both the beginning and end. Discovered via Jaeger trace `3a6ad65c7ca29c7ea2d7c7c8d1dbd21f`.

## Test plan

- [x] All 163 schemaUtils tests pass (161 existing + 2 new regression tests)
- [x] New tests verify string values containing brackets are not truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)