### PR TITLE
fix: prevent over-scoped text edits from silently deleting content

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2771,6 +2771,7 @@ Follow these instructions carefully:
       * For rewriting entire functions/classes/methods, use the symbol parameter instead (no exact text matching needed).
       * For editing specific lines from search/extract output, use start_line (and optionally end_line) with the line numbers shown in the output.${this.hashLines ? ' Line references include content hashes (e.g. "42:ab") for integrity verification.' : ''}
       * For editing inside large functions: first use extract with the symbol target (e.g. "file.js#myFunction") to see the function with line numbers${this.hashLines ? ' and hashes' : ''}, then use start_line/end_line to surgically edit specific lines within it.
+      * IMPORTANT: Keep old_string as small as possible — include only the lines you need to change plus minimal context for uniqueness. For replacing large blocks (10+ lines), prefer line-targeted editing with start_line/end_line to constrain scope.
     - Use 'create' for new files or complete file rewrites.
     - If an edit fails, read the error message — it tells you exactly how to fix the call and retry.
     - The system tracks which files you've seen via search/extract. If you try to edit a file you haven't read, or one that changed since you last read it, the edit will fail with instructions to re-read first. Always use extract before editing to ensure you have current file content.` : ''}

--- a/npm/src/agent/shared/prompts.js
+++ b/npm/src/agent/shared/prompts.js
@@ -87,6 +87,7 @@ If the solution is clear, you can jump to implementation right away. If not, ask
 - Avoid implementing special cases when a general approach works
 - Never expose secrets, API keys, or credentials in generated code. Never log sensitive information.
 - Do not surprise the user with unrequested changes. Do what was asked, including reasonable follow-up actions, but do not refactor surrounding code or add features that were not requested.
+- When editing files, keep edits focused and minimal. For changes spanning more than a few lines, prefer line-targeted editing (start_line/end_line) over text replacement (old_string) — it constrains scope and prevents accidental removal of adjacent content. Never include unrelated sections in an edit operation.
 - After every significant change, verify the project still builds and passes linting. Do not wait until the end to discover breakage.
 
 # After Implementation

--- a/npm/src/tools/edit.js
+++ b/npm/src/tools/edit.js
@@ -448,6 +448,13 @@ Parameters:
           return `Error editing file: Multiple occurrences found - the old_string appears ${occurrences} times in ${file_path}. To fix: (1) Set replace_all=true to replace all occurrences, or (2) Include more surrounding lines in old_string to make the match unique (add the full line or adjacent lines for context).`;
         }
 
+        // Guard against over-scoped text edits (replacing large blocks with tiny replacements)
+        const oldLines = matchTarget.split('\n').length;
+        const newLines = new_string.split('\n').length;
+        if (oldLines >= 20 && newLines < oldLines * 0.5) {
+          return `Error editing file: Edit scope too large — replacing ${oldLines} lines with ${newLines} lines risks accidental content deletion. To fix: (1) Use line-targeted editing (start_line/end_line) instead to constrain scope, or (2) Split into smaller, focused edits that each target only the lines you intend to change.`;
+        }
+
         // Perform the replacement
         let newContent;
         if (replace_all) {

--- a/npm/tests/unit/edit-create-tools.test.js
+++ b/npm/tests/unit/edit-create-tools.test.js
@@ -184,6 +184,59 @@ describe('Edit and Create Tools', () => {
       expect(newContent).toContain('const message = "Goodbye"');
       expect(newContent).not.toContain('const message = "Hello"');
     });
+    test('should reject text edit when old_string is much larger than new_string', async () => {
+      // Create a file with 30+ lines
+      const lines = Array.from({ length: 35 }, (_, i) => `line ${i + 1}: some content here`);
+      const originalContent = lines.join('\n');
+      await fs.writeFile(testFile, originalContent);
+
+      const edit = editTool({ allowedFolders: [testDir] });
+
+      // Try to replace 25 lines with just 2 lines (over-scoped edit)
+      const oldString = lines.slice(5, 30).join('\n'); // 25 lines
+      const newString = 'replacement line 1\nreplacement line 2'; // 2 lines
+
+      const result = await edit.execute({
+        file_path: testFile,
+        old_string: oldString,
+        new_string: newString
+      });
+
+      expect(result).toContain('Error editing file: Edit scope too large');
+      expect(result).toContain('25 lines with 2 lines');
+      expect(result).toContain('line-targeted editing');
+
+      // Verify file was not modified
+      const content = await fs.readFile(testFile, 'utf-8');
+      expect(content).toBe(originalContent);
+    });
+
+    test('should allow text edit when replacement is proportional', async () => {
+      // Create a file with 30+ lines
+      const lines = Array.from({ length: 35 }, (_, i) => `line ${i + 1}: some content here`);
+      const originalContent = lines.join('\n');
+      await fs.writeFile(testFile, originalContent);
+
+      const edit = editTool({ allowedFolders: [testDir] });
+
+      // Replace 25 lines with 20 lines (proportional, no false positive)
+      const oldString = lines.slice(5, 30).join('\n'); // 25 lines
+      const newLines = Array.from({ length: 20 }, (_, i) => `new line ${i + 1}: updated content`);
+      const newString = newLines.join('\n'); // 20 lines
+
+      const result = await edit.execute({
+        file_path: testFile,
+        old_string: oldString,
+        new_string: newString
+      });
+
+      expect(result).toContain('Successfully edited');
+
+      // Verify the edit was applied
+      const content = await fs.readFile(testFile, 'utf-8');
+      expect(content).toContain('new line 1: updated content');
+      expect(content).not.toContain('line 10: some content here');
+    });
   });
 
   describe('createTool', () => {


### PR DESCRIPTION
## Summary

- Adds a mechanical guard in the edit tool (`edit.js`) that rejects text-mode edits where `old_string` spans 20+ lines and `new_string` is less than 50% of that line count — catches the "accidental deletion" pattern where an AI replaces a large block with a tiny replacement
- Adds prompt reinforcement in the engineer prompt (`prompts.js`) and system message guidance (`ProbeAgent.js`) to steer toward line-targeted editing (`start_line`/`end_line`) for large blocks
- Adds 2 unit tests verifying the guard triggers correctly and doesn't false-positive on proportional edits

## Context

In trace `3afc73dad05339c0a4c6e49cc55f5d63`, the AI used text-mode editing with a ~47-line `old_string` covering both the target section AND an unrelated section. The 5-line `new_string` silently deleted content the user didn't ask to remove. The edit tool worked correctly — the AI just over-scoped.

## Test plan

- [x] New test: rejects 25→2 line replacement with correct error message
- [x] New test: allows 25→20 line proportional replacement (no false positive)
- [x] All existing edit-create-tools tests pass (1 pre-existing failure in symbol disambiguation unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)