### PR TITLE
feat: add structured PR description template to engineer prompt

### DIFF
--- a/npm/src/agent/shared/prompts.js
+++ b/npm/src/agent/shared/prompts.js
@@ -98,11 +98,33 @@ If the solution is clear, you can jump to implementation right away. If not, ask
 
 # GitHub Integration
 - Use the \`gh\` CLI for all GitHub operations: issues, pull requests, checks, releases.
-- To create a pull request: commit your changes, push the branch, then use \`gh pr create --title "..." --body "..."\`.
 - To view issues or PRs: \`gh issue view <number>\`, \`gh pr view <number>\`.
 - If given a GitHub URL, use \`gh\` to fetch the relevant information rather than guessing.
 - Always return the pull request URL to the user after creating one.
-- When checking GitHub Actions, only read logs of failed jobs — do not waste time on successful ones. Use \`gh run view <run-id> --log-failed\` to fetch only the relevant output.`,
+- When checking GitHub Actions, only read logs of failed jobs — do not waste time on successful ones. Use \`gh run view <run-id> --log-failed\` to fetch only the relevant output.
+
+# Pull Request Creation
+- Commit your changes, push the branch, then use \`gh pr create --title "..." --body "..."\`.
+- **PR title**: Keep it short (under 72 characters). Use imperative mood describing the change (e.g. "Add retry logic for API calls", "Fix race condition in cache invalidation"). Prefix with the type of change when useful: \`fix:\`, \`feat:\`, \`refactor:\`, \`docs:\`, \`test:\`, \`chore:\`.
+- **PR body**: MUST follow this structure:
+
+\`\`\`
+## Problem / Task
+<What problem is being solved or what task was requested. If there is a linked issue, reference it with #number. Be specific about the root cause or motivation.>
+
+## Changes
+<Concise list of what was actually changed. Describe each meaningful change — files modified, logic added/removed, and why. Do NOT just list filenames; explain what each change does.>
+
+## Testing
+<What tests were added, modified, or run. Include:
+- New test names and what they verify
+- Whether existing tests still pass
+- Manual verification steps if applicable
+- Commands used to validate (e.g. \`make test\`, \`npm test\`)>
+\`\`\`
+
+- If the task originated from a GitHub issue, always reference it in the PR body (e.g. "Fixes #123" or "Closes #123") so the issue is automatically closed on merge. If it originated from an external ticket system (Jira, Linear, etc.), include the ticket ID and link in the Problem / Task section (e.g. "Resolves PROJ-456").
+- Do not leave the PR body empty or vague. Every PR must clearly communicate what was done and why so reviewers can understand the change without reading every line of diff.`,
 
   'support': `You are ProbeChat Support, a specialized AI assistant focused on helping developers troubleshoot issues and solve problems. Your primary function is to help users diagnose errors, understand unexpected behaviors, and find solutions using the provided code analysis tools.
 


### PR DESCRIPTION
## Problem / Task

The engineer prompt's GitHub Integration section had only a generic one-liner about `gh pr create` with no guidance on what the PR title or body should contain. This led to PRs with inconsistent, vague, or empty descriptions that made it hard for reviewers to understand what was changed and why.

## Changes

- **`npm/src/agent/shared/prompts.js`**: Added a dedicated "Pull Request Creation" section to the engineer prompt with:
  - **PR title guidelines**: under 72 characters, imperative mood, optional conventional commit prefixes (`fix:`, `feat:`, `refactor:`, etc.)
  - **PR body template**: mandatory 3-section structure — "Problem / Task" (what and why), "Changes" (what was done), "Testing" (what was verified)
  - **Ticket references**: guidance to link GitHub issues (`Fixes #123`) and external ticket systems like Jira/Linear (`Resolves PROJ-456`)
  - **Quality guardrail**: explicit instruction that PR bodies must never be empty or vague

## Testing

- No executable logic was changed — this is a prompt text update
- Verified the JS file is syntactically valid (no broken template literals)
- Existing tests unaffected since this modifies prompt content only