### PR TITLE
fix: prevent _buildNativeTools crash when MCP tools are in toolImplementations

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1836,9 +1836,13 @@ export class ProbeAgent {
     }
 
     // Add all enabled tools from toolImplementations
+    // Note: MCP tools are also in toolImplementations but have no schema in _getToolSchemaAndDescription.
+    // They are handled separately via mcpBridge.getVercelTools() below, so we skip them here.
     for (const [toolName, toolImpl] of Object.entries(this.toolImplementations)) {
       // Get schema and description for this tool
-      const { schema, description } = this._getToolSchemaAndDescription(toolName);
+      const toolInfo = this._getToolSchemaAndDescription(toolName);
+      if (!toolInfo) continue;
+      const { schema, description } = toolInfo;
       if (schema && description) {
         nativeTools[toolName] = wrapTool(toolName, schema, description, toolImpl.execute);
       }

--- a/npm/tests/unit/mcp-message-history.test.js
+++ b/npm/tests/unit/mcp-message-history.test.js
@@ -116,6 +116,59 @@ describe('MCP Tool Native Integration', () => {
       expect(tools).toHaveProperty('attempt_completion');
       expect(tools).not.toHaveProperty('test_mcp_tool');
     });
+
+    test('should not crash when MCP tools are in toolImplementations (issue #469)', () => {
+      // Reproduce the exact scenario from the bug:
+      // After initializeMCP(), MCP tools are merged into toolImplementations.
+      // _buildNativeTools iterates ALL toolImplementations, including MCP tools.
+      // _getToolSchemaAndDescription returns null for MCP tools, causing a
+      // TypeError when destructuring: Cannot destructure property 'schema' of null.
+      const mcpToolName = '__tools___slack-send-dm';
+      agent.toolImplementations[mcpToolName] = {
+        execute: jest.fn(async () => 'MCP result')
+      };
+
+      // This should NOT throw "Cannot destructure property 'schema' of null"
+      const onComplete = () => {};
+      expect(() => {
+        agent._buildNativeTools({}, onComplete);
+      }).not.toThrow();
+
+      const tools = agent._buildNativeTools({}, onComplete);
+
+      // MCP tools in toolImplementations should be skipped (no schema known)
+      // They get included via mcpBridge.getVercelTools() instead
+      expect(tools).not.toHaveProperty(mcpToolName);
+      // MCP tool from the bridge should still be present
+      expect(tools).toHaveProperty('test_mcp_tool');
+      expect(tools).toHaveProperty('attempt_completion');
+    });
+
+    test('should handle multiple MCP tools in toolImplementations without crash', () => {
+      // Simulate what initializeMCP does: merge all MCP tools into toolImplementations
+      const mcpTools = {
+        '__tools___slack-send-dm': { execute: jest.fn() },
+        '__tools___slack-search': { execute: jest.fn() },
+        '__tools___slack-read-thread': { execute: jest.fn() },
+        '__tools___slack-download-file': { execute: jest.fn() },
+      };
+      for (const [name, impl] of Object.entries(mcpTools)) {
+        agent.toolImplementations[name] = impl;
+      }
+
+      const onComplete = () => {};
+      expect(() => {
+        agent._buildNativeTools({}, onComplete);
+      }).not.toThrow();
+
+      const tools = agent._buildNativeTools({}, onComplete);
+      // None of the MCP tools from toolImplementations should be in native tools
+      for (const name of Object.keys(mcpTools)) {
+        expect(tools).not.toHaveProperty(name);
+      }
+      // But the bridge-provided MCP tool should be there
+      expect(tools).toHaveProperty('test_mcp_tool');
+    });
   });
 
   describe('MCP bridge API surface', () => {


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot destructure property 'schema' of null` when MCP tools are present in `toolImplementations`
- Add null check before destructuring `_getToolSchemaAndDescription()` return value
- Add 2 regression tests covering single and multiple MCP tools in `toolImplementations`

Closes #469

### Root cause

After `initializeMCP()`, MCP tools get merged into `this.toolImplementations`. When `_buildNativeTools()` iterates all entries, it calls `_getToolSchemaAndDescription(toolName)` which returns `null` for MCP tool names (e.g. `__tools___slack-send-dm`). The destructuring `const { schema, description } = null` throws a TypeError before the `if (schema && description)` guard can execute.

### Fix

```javascript
// Before (crashes):
const { schema, description } = this._getToolSchemaAndDescription(toolName);

// After (safe):
const toolInfo = this._getToolSchemaAndDescription(toolName);
if (!toolInfo) continue;
const { schema, description } = toolInfo;
```

MCP tools are already handled separately via `mcpBridge.getVercelTools()` further down in the same method, so skipping them in the `toolImplementations` loop is correct.

## Test plan

- [x] 2 new tests in `mcp-message-history.test.js` reproducing the exact crash scenario
- [x] All 106 test suites pass (2621 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)