### PR TITLE
fix: accept noDefaultAllow/noDefaultDeny aliases in bashConfig

### DIFF
--- a/npm/src/tools/bash.js
+++ b/npm/src/tools/bash.js
@@ -45,8 +45,8 @@ export const bashTool = (options = {}) => {
   const permissionChecker = new BashPermissionChecker({
     allow: bashConfig.allow,
     deny: bashConfig.deny,
-    disableDefaultAllow: bashConfig.disableDefaultAllow,
-    disableDefaultDeny: bashConfig.disableDefaultDeny,
+    disableDefaultAllow: bashConfig.disableDefaultAllow || bashConfig.noDefaultAllow,
+    disableDefaultDeny: bashConfig.disableDefaultDeny || bashConfig.noDefaultDeny,
     debug,
     tracer
   });


### PR DESCRIPTION
## Summary

- Accept visor's `noDefaultAllow`/`noDefaultDeny` field names as aliases for probe's `disableDefaultAllow`/`disableDefaultDeny` in `bashTool()`
- Visor passes `bashConfig` from workflow YAML directly to probe without field-name mapping, so probe needs to accept both conventions

## Test plan

- [ ] Verify `bashConfig: { noDefaultAllow: true }` disables the default allow list (same as `disableDefaultAllow: true`)
- [ ] Verify existing `disableDefaultAllow`/`disableDefaultDeny` usage continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)