### PR TITLE
fix: resolve search delegate paths against workspace root to prevent doubled segments

### DIFF
--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -10,6 +10,7 @@ import { extract } from '../extract.js';
 import { delegate } from '../delegate.js';
 import { analyzeAll } from './analyzeAll.js';
 import { searchSchema, querySchema, extractSchema, delegateSchema, analyzeAllSchema, searchDescription, queryDescription, extractDescription, delegateDescription, analyzeAllDescription, parseTargets, parseAndResolvePaths, resolveTargetPath } from './common.js';
+import { existsSync } from 'fs';
 import { formatErrorForAI } from '../utils/error-types.js';
 import { annotateOutputWithHashes } from './hashline.js';
 
@@ -116,6 +117,18 @@ function parseDelegatedTargets(rawResponse) {
 	}
 
 	return normalizeTargets(fallbackTargetsFromText(trimmed));
+}
+
+function splitTargetSuffix(target) {
+	const searchStart = (target.length > 2 && target[1] === ':' && /[a-zA-Z]/.test(target[0])) ? 2 : 0;
+	const colonIdx = target.indexOf(':', searchStart);
+	const hashIdx = target.indexOf('#');
+	if (colonIdx !== -1 && (hashIdx === -1 || colonIdx < hashIdx)) {
+		return { filePart: target.substring(0, colonIdx), suffix: target.substring(colonIdx) };
+	} else if (hashIdx !== -1) {
+		return { filePart: target.substring(0, hashIdx), suffix: target.substring(hashIdx) };
+	}
+	return { filePart: target, suffix: '' };
 }
 
 function buildSearchDelegateTask({ searchQuery, searchPath, exact, language, allowTests }) {
@@ -286,13 +299,61 @@ export const searchTool = (options = {}) => {
 					return fallbackResult;
 				}
 
-				// Resolve relative paths against the actual search directory, not the general cwd.
-				// The delegate returns paths relative to where the search was performed (searchPaths[0]),
-				// which may differ from options.cwd when the user specifies a path parameter.
+				// The delegate runs from workspace root (allowedFolders[0] or cwd), NOT from searchPaths[0].
+				// It returns paths relative to that workspace root. Resolve against the same base.
+				const delegateBase = options.allowedFolders?.[0] || options.cwd || '.';
 				const resolutionBase = searchPaths[0] || options.cwd || '.';
-				const resolvedTargets = targets.map(target => resolveTargetPath(target, resolutionBase));
+				const resolvedTargets = targets.map(target => resolveTargetPath(target, delegateBase));
+
+				// Auto-fix: detect and repair invalid paths (doubled segments, AI hallucinations)
+				const validatedTargets = [];
+				for (const target of resolvedTargets) {
+					const { filePart, suffix } = splitTargetSuffix(target);
+
+					// 1. Path exists as-is
+					if (existsSync(filePart)) {
+						validatedTargets.push(target);
+						continue;
+					}
+
+					// 2. Detect doubled directory segments: /ws/proj/proj/src → /ws/proj/src
+					let fixed = false;
+					const parts = filePart.split('/').filter(Boolean);
+					for (let i = 0; i < parts.length - 1; i++) {
+						if (parts[i] === parts[i + 1]) {
+							const candidate = '/' + [...parts.slice(0, i), ...parts.slice(i + 1)].join('/');
+							if (existsSync(candidate)) {
+								validatedTargets.push(candidate + suffix);
+								if (debug) console.error(`[search-delegate] Fixed doubled path segment: ${filePart} → ${candidate}`);
+								fixed = true;
+								break;
+							}
+						}
+					}
+					if (fixed) continue;
+
+					// 3. Try resolving against alternative bases (searchPaths[0], cwd)
+					for (const altBase of [resolutionBase, options.cwd].filter(Boolean)) {
+						if (altBase === delegateBase) continue;
+						const altResolved = resolveTargetPath(target, altBase);
+						const { filePart: altFile } = splitTargetSuffix(altResolved);
+						if (existsSync(altFile)) {
+							validatedTargets.push(altResolved);
+							if (debug) console.error(`[search-delegate] Resolved with alt base: ${filePart} → ${altFile}`);
+							fixed = true;
+							break;
+						}
+					}
+					if (fixed) continue;
+
+					// 4. Keep target anyway (probe binary will report the error)
+					//    but log a warning
+					if (debug) console.error(`[search-delegate] Warning: target may not exist: ${filePart}`);
+					validatedTargets.push(target);
+				}
+
 				const extractOptions = {
-					files: resolvedTargets,
+					files: validatedTargets,
 					cwd: resolutionBase,
 					allowTests: allow_tests ?? true
 				};

--- a/npm/tests/unit/search-delegate.test.js
+++ b/npm/tests/unit/search-delegate.test.js
@@ -92,22 +92,23 @@ describe('searchDelegate behavior', () => {
     );
     const extractArgs = mockExtract.mock.calls[0][0];
     expect(extractArgs).toEqual(expect.objectContaining({ files: expect.any(Array) }));
-    // Paths should be resolved against the search path (/workspace/src), not cwd (/workspace)
+    // Paths should be resolved against delegateBase (allowedFolders[0] = /workspace),
+    // not searchPaths[0] (/workspace/src)
     const normalizedFiles = extractArgs.files.map((file) =>
       file.replace(/^[A-Za-z]:/, '').replace(/\\/g, '/')
     );
     expect(normalizedFiles).toEqual(expect.arrayContaining([
-      '/workspace/src/a.js#foo',
-      '/workspace/src/b.js:10-12'
+      '/workspace/a.js#foo',
+      '/workspace/b.js:10-12'
     ]));
     expect(mockSearch).not.toHaveBeenCalled();
   });
 
-  test('resolves delegate paths against search path, not cwd, when they differ', async () => {
-    // Simulate the bug case: cwd differs from search path
-    // Delegate returns paths relative to the search directory
+  test('resolves delegate paths against workspace root when subagent returns workspace-relative paths', async () => {
+    // Real scenario: subagent runs from /tmp/workspace (workspace root)
+    // and returns paths relative to that root, including the project dir name
     mockDelegate.mockResolvedValue(JSON.stringify({
-      targets: ['dashboard/api.go#Handler', 'dashboard/model.go:10-20']
+      targets: ['tyk-analytics/dashboard/api.go#Handler', 'tyk-analytics/dashboard/model.go:10-20']
     }));
     mockExtract.mockResolvedValue('EXTRACTED');
 
@@ -127,13 +128,15 @@ describe('searchDelegate behavior', () => {
     const normalizedFiles = extractArgs.files.map((file) =>
       file.replace(/^[A-Za-z]:/, '').replace(/\\/g, '/')
     );
-    // Paths must resolve against the search path (/tmp/workspace/tyk-analytics),
-    // NOT against cwd (/tmp/workspace)
+    // Paths should resolve against delegateBase (/tmp/workspace), NOT searchPaths[0] (/tmp/workspace/tyk-analytics)
+    // This prevents doubled path: /tmp/workspace/tyk-analytics/tyk-analytics/dashboard/api.go
     expect(normalizedFiles).toEqual(expect.arrayContaining([
       '/tmp/workspace/tyk-analytics/dashboard/api.go#Handler',
       '/tmp/workspace/tyk-analytics/dashboard/model.go:10-20'
     ]));
-    // Extract cwd should also be the search path
+    // Should NOT have doubled paths
+    expect(normalizedFiles.some(f => f.includes('tyk-analytics/tyk-analytics'))).toBe(false);
+    // Extract cwd should be the search path (resolutionBase)
     expect(extractArgs.cwd).toBe('/tmp/workspace/tyk-analytics');
   });
 


### PR DESCRIPTION
## Summary

- **Fix doubled paths in search delegate**: The subagent runs from workspace root (`allowedFolders[0]`) but returned paths were being resolved against `searchPaths[0]` (the project subdirectory). This caused paths like `/workspace/project/project/src/file.go` when the subagent returned workspace-relative paths (e.g. `project/src/file.go`).
- **Add path validation safety net**: After resolution, validate paths with `existsSync` and auto-repair doubled directory segments or try alternative resolution bases — catches edge cases and AI path hallucinations.
- **Update tests**: Fix existing assertions to match new resolution base and add a test covering the real-world scenario (workspace-relative paths with project dir prefix).

**Trace**: `cb1bb8d74c4d93fbff8ccaf1e63028ab` — `explore-code` probe delegation returns targets with project prefix, which got doubled when joined with `searchPaths[0]`.

### Root Cause

1. Parent calls `searchTool(searchDelegate: true)` with `path` → `searchPaths[0]` = `/tmp/.../slack-xxx/tyk-analytics-ui`
2. Subagent spawned with `path: allowedFolders[0]` → workspace root `/tmp/.../slack-xxx`
3. Subagent returns: `tyk-analytics-ui/app/pages/...` (relative to workspace root)
4. **Bug**: `resolveTargetPath("tyk-analytics-ui/app/...", "/tmp/.../tyk-analytics-ui")` → **DOUBLED**
5. **Fix**: Resolve against `delegateBase` (workspace root) instead of `searchPaths[0]`

## Test plan

- [x] Updated existing search-delegate test assertions to match new resolution base
- [x] Added test: workspace-relative paths with project dir prefix resolve correctly (no doubling)
- [x] All 6 search-delegate tests pass
- [x] Full test suite: 106 suites, 2637 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)