### PR TITLE
fix: clarify search delegate prompt example

### DIFF
--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -145,7 +145,7 @@ function buildSearchDelegateTask({ searchQuery, searchPath, exact, language, all
 		'',
 		'Strategy for complex queries:',
 		'1. Analyze the query - identify key concepts, entities, and relationships',
-		'2. Run focused searches for each concept (e.g., "error handling" + "authentication" separately)',
+		'2. Run focused searches for each independent concept (e.g., for "how do payments work and how are emails sent", search "payments" and "emails" separately since they are unrelated)',
 		'3. Use extract to verify relevance of promising results',
 		'4. Combine all relevant targets in your final response',
 		'',


### PR DESCRIPTION
## Problem / Task

The search delegate prompt in `buildSearchDelegateTask()` used a misleading example: it suggested splitting "error handling" + "authentication" into separate searches. But if someone asks about "error handling in authentication," those concepts are tightly coupled and should be searched together. The example contradicted the intent of the instruction.

## Changes

- Updated the example in `npm/src/tools/vercel.js:148` to use genuinely independent concepts: "how do payments work and how are emails sent" → search "payments" and "emails" separately. This correctly illustrates when query decomposition is appropriate (truly unrelated topics).

## Testing

- Single-line prompt string change, no logic affected.
- Verified no other prompts in the codebase contain the same misleading pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)