### PR TITLE
fix: remove outdated XML format from prompts and context compactor

### DIFF
--- a/npm/src/agent/contextCompactor.js
+++ b/npm/src/agent/contextCompactor.js
@@ -59,13 +59,35 @@ export function isContextLimitError(error) {
 }
 
 /**
+ * Check if an assistant message contains an attempt_completion tool call.
+ * Supports both native tool calling (toolInvocations/tool_calls) and text content.
+ */
+function messageContainsCompletion(msg) {
+  // Native tool calling: Vercel AI SDK uses toolInvocations
+  if (Array.isArray(msg.toolInvocations)) {
+    if (msg.toolInvocations.some(t => t.toolName === 'attempt_completion')) return true;
+  }
+  // Native tool calling: OpenAI format uses tool_calls
+  if (Array.isArray(msg.tool_calls)) {
+    if (msg.tool_calls.some(t => t.function?.name === 'attempt_completion')) return true;
+  }
+  // Multipart content (Vercel AI SDK v4+)
+  if (Array.isArray(msg.content)) {
+    if (msg.content.some(p => p.type === 'tool-call' && p.toolName === 'attempt_completion')) return true;
+  }
+  // Text content fallback
+  const text = typeof msg.content === 'string' ? msg.content : '';
+  return text.includes('attempt_completion');
+}
+
+/**
  * Identify message boundaries in conversation history
  * Structure: <user> -> <internal agentic monologue> -> <final-agent-answer>
  *
  * A "segment" is:
  * - user message (role: 'user')
  * - followed by 0+ assistant messages (internal monologue)
- * - ending with tool_result or attempt_completion (final answer)
+ * - ending with attempt_completion tool call (final answer)
  *
  * @param {Array} messages - Array of message objects with {role, content}
  * @returns {Array} - Array of segments, each containing {userIndex, monologueIndices, finalIndex}
@@ -82,38 +104,33 @@ export function identifyMessageSegments(messages) {
       continue;
     }
 
+    // Tool result message (native tool calling format)
+    if (msg.role === 'tool' && currentSegment) {
+      currentSegment.monologueIndices.push(i);
+      continue;
+    }
+
     // User message starts a new segment
     if (msg.role === 'user') {
-      // Check if this is a tool_result (final answer from previous segment)
-      const content = typeof msg.content === 'string' ? msg.content : '';
-      const isToolResult = content.includes('<tool_result>');
-
-      if (isToolResult && currentSegment) {
-        // This is the final answer for the current segment
-        currentSegment.finalIndex = i;
+      // Save previous segment if it exists
+      if (currentSegment) {
         segments.push(currentSegment);
-        currentSegment = null;
-      } else {
-        // Save previous segment if it exists
-        if (currentSegment) {
-          segments.push(currentSegment);
-        }
-
-        // Start new segment
-        currentSegment = {
-          userIndex: i,
-          monologueIndices: [],
-          finalIndex: null
-        };
       }
+
+      // Start new segment
+      currentSegment = {
+        userIndex: i,
+        monologueIndices: [],
+        finalIndex: null
+      };
     }
 
     // Assistant message is part of monologue
     if (msg.role === 'assistant' && currentSegment) {
-      const content = typeof msg.content === 'string' ? msg.content : '';
+      // Check if this contains an attempt_completion tool call (native or XML format)
+      const hasCompletion = messageContainsCompletion(msg);
 
-      // Check if this contains attempt_completion (marks end of segment)
-      if (content.includes('<attempt_completion>') || content.includes('attempt_completion')) {
+      if (hasCompletion) {
         currentSegment.monologueIndices.push(i);
         currentSegment.finalIndex = i;
         segments.push(currentSegment);
@@ -138,7 +155,7 @@ export function identifyMessageSegments(messages) {
  *
  * Strategy:
  * 1. Keep all user messages
- * 2. Keep all final answers (tool_results, attempt_completion)
+ * 2. Keep all final answers (attempt_completion)
  * 3. Remove intermediate monologue messages from completed segments
  * 4. Keep the most recent (active) segment intact
  *

--- a/npm/src/agent/shared/prompts.js
+++ b/npm/src/agent/shared/prompts.js
@@ -94,9 +94,10 @@ If the solution is clear, you can jump to implementation right away. If not, ask
 - After every significant change, verify the project still builds and passes linting. Do not wait until the end to discover breakage.
 
 # After Implementation
-- Always run the project's tests before considering the task complete. If tests fail, fix them.
-- Run lint and typecheck commands if known for the project.
-- If a build, lint, or test fails, fix the issue before finishing.
+- Verify the project builds successfully. If it doesn't, fix the build before moving on.
+- Run lint and typecheck commands if known for the project. Fix any new warnings or errors you introduced.
+- Add tests for any new or changed functionality. Tests must cover the main path and important edge cases.
+- Run the project's full test suite. If any tests fail (including pre-existing ones you may have broken), fix them before finishing.
 - When the task is done, respond to the user with a concise summary of what was implemented, what files were changed, and any relevant details. Include links (e.g. pull request URL) so the user has everything they need.
 
 # GitHub Integration

--- a/npm/src/agent/tasks/taskTool.js
+++ b/npm/src/agent/tasks/taskTool.js
@@ -1,5 +1,5 @@
 /**
- * Task Tool - XML tool definition and executor for task management
+ * Task Tool - definition and executor for task management
  * @module agent/tasks/taskTool
  */
 
@@ -35,241 +35,57 @@ export const taskSchema = z.object({
 });
 
 /**
- * Task tool XML definition for system prompt
+ * Task tool definition (legacy export, no longer used — tool is registered natively via taskSchema)
  */
-export const taskToolDefinition = `## task
-Manage tasks for tracking progress during code exploration and problem-solving. Create tasks to break down complex problems, track dependencies, and ensure all work is completed.
-
-Parameters:
-- action: (required) The action to perform: create, update, complete, delete, list
-- tasks: (optional) Array of task objects for batch operations. Place raw JSON array directly between tags.
-- id: (optional) Task ID for single operations (e.g., "task-1")
-- title: (optional) Task title for create/update
-- description: (optional) Task description for create/update
-- status: (optional) Task status for update: pending, in_progress, completed, cancelled
-- priority: (optional) Task priority: low, medium, high, critical
-- dependencies: (optional) JSON array of task IDs that must be completed first
-- after: (optional) Task ID to insert the new task after (for ordering). By default, new tasks are appended to the end
-
-IMPORTANT - JSON Format:
-Place raw JSON arrays directly between tags without quotes or escaping:
-  CORRECT:   <tasks>[{"title": "Do X"}]</tasks>
-  INCORRECT: <tasks>"[{\"title\": \"Do X\"}]"</tasks>
-
-Usage Examples:
-
-Creating a single task:
-<task>
-<action>create</action>
-<title>Analyze authentication module</title>
-<description>Search and understand how authentication works</description>
-<priority>high</priority>
-</task>
-
-Creating multiple tasks with dependencies:
-<task>
-<action>create</action>
-<tasks>[
-  {"title": "Search for user model", "priority": "high"},
-  {"title": "Analyze authentication flow", "dependencies": ["task-1"]},
-  {"title": "Review session management", "dependencies": ["task-2"]}
-]</tasks>
-</task>
-
-Inserting a task after a specific task (instead of appending to end):
-<task>
-<action>create</action>
-<title>Investigate error handling</title>
-<after>task-2</after>
-</task>
-
-Updating a task status:
-<task>
-<action>update</action>
-<id>task-1</id>
-<status>in_progress</status>
-</task>
-
-Batch updating multiple tasks:
-<task>
-<action>update</action>
-<tasks>[
-  {"id": "task-1", "status": "completed"},
-  {"id": "task-2", "status": "in_progress"}
-]</tasks>
-</task>
-
-Completing a task:
-<task>
-<action>complete</action>
-<id>task-1</id>
-</task>
-
-Cancelling a task:
-<task>
-<action>update</action>
-<id>task-1</id>
-<status>cancelled</status>
-</task>
-
-Deleting a task:
-<task>
-<action>delete</action>
-<id>task-1</id>
-</task>
-
-Listing all tasks:
-<task>
-<action>list</action>
-</task>
-`;
+export const taskToolDefinition = '';
 
 /**
- * Task system prompt addition - comprehensive guidance for AI
+ * Task system prompt addition - guidance for AI on when and how to use tasks
  */
-export const taskSystemPrompt = `[Task Management System]
+export const taskSystemPrompt = `[Task Management]
 
-You have access to a task tracking tool to organize your work on complex requests.
+Use the task tool to track progress on complex requests with multiple distinct goals.
 
-## When to Create Tasks
+## When to Use Tasks
 
-CREATE TASKS when the request has **multiple distinct deliverables or goals**:
-- "Fix bug A AND add feature B" → Two separate tasks
-- "Investigate auth, payments, AND notifications" → Three independent areas
-- "Implement X, then add tests, then update docs" → Sequential phases with different outputs
-- User explicitly asks for a plan or task breakdown
+CREATE tasks when the request has **multiple separate deliverables**:
+- "Fix bug A AND add feature B" → two tasks
+- "Investigate auth, payments, AND notifications" → three tasks
+- "Implement X, then add tests, then update docs" → three sequential tasks
 
-SKIP TASKS for single-goal requests, even if they require multiple searches:
-- "How does ranking work?" → Just investigate and answer (one goal)
-- "What does function X do?" → Just look it up (one goal)
-- "Explain the authentication flow" → Just trace and explain (one goal)
-- "Find where errors are logged" → Just search and report (one goal)
+SKIP tasks for single-goal requests, even complex ones:
+- "How does ranking work?" — just investigate and answer
+- "Explain the authentication flow" — just trace and explain
+Multiple internal steps (search, read, analyze) for one goal ≠ multiple tasks.
 
-**Key insight**: Multiple *internal steps* (search, read, analyze) are NOT the same as multiple *goals*.
-A single investigation with many steps is still ONE task, not many.
+## Granularity
 
-## Task Granularity
+Tasks = logical units of work, not files or steps.
+- "Fix 8 similar test files" → ONE task (same fix repeated)
+- "Update API + tests + docs" → THREE tasks (different work types)
+- Max 3–4 tasks. More means you're too granular.
 
-Tasks represent LOGICAL UNITS OF WORK, not individual files or steps:
-- "Fix 8 similar test files" → ONE task (same type of fix across files)
-- "Update API + tests + docs" → THREE tasks (different types of work)
-- "Implement feature in 5 files" → ONE task (single feature)
+## Workflow
 
-**Rule of thumb**: If you're creating more than 3-4 tasks, you're probably too granular.
+1. **Plan**: Call task tool with action="create" and a tasks array up front
+2. **Execute**: Update status to "in_progress" / "completed" as you work. Add, split, or cancel tasks as you learn more.
+3. **Finish**: All tasks must be "completed" or "cancelled" before calling attempt_completion.
 
-**Anti-patterns to avoid**:
-- One task per file ❌
-- One task per function ❌
-- One task per repository (when same type of work) ❌
+## Rules
 
-**Good patterns**:
-- One task per distinct deliverable ✓
-- One task per phase (implement, test, document) ✓
-- One task per different type of work ✓
-
-MODIFY TASKS when (during execution):
-- You discover the problem is more complex than expected → Add new tasks
-- A single task covers too much scope → Split into smaller tasks
-- You find related work that needs attention → Add dependent tasks
-- A task becomes irrelevant based on findings → Cancel it
-- Task priorities change based on discoveries → Update priority
-- You learn new context → Update task description
-
-## Task Workflow
-
-**STEP 1 - Plan (at start):**
-Analyze the request and create tasks for each logical step:
-
-<task>
-<action>create</action>
-<tasks>[
-  {"title": "Search for authentication module", "priority": "high"},
-  {"title": "Analyze login flow implementation", "dependencies": ["task-1"]},
-  {"title": "Find session management code", "dependencies": ["task-1"]},
-  {"title": "Summarize authentication architecture", "dependencies": ["task-2", "task-3"]}
-]</tasks>
-</task>
-
-**STEP 2 - Execute (during work):**
-Update task status as you work:
-
-<task>
-<action>update</action>
-<id>task-1</id>
-<status>in_progress</status>
-</task>
-
-... do the work (search, extract, etc.) ...
-
-<task>
-<action>complete</action>
-<id>task-1</id>
-</task>
-
-**STEP 2b - Adapt (when you discover new work):**
-As you work, you may discover that:
-- A task is more complex than expected → Split it into subtasks
-- New areas need investigation → Add new tasks
-- Some tasks are no longer needed → Cancel them
-- Task order should change → Update dependencies
-
-*Adding a new task when you discover more work:*
-<task>
-<action>create</action>
-<title>Investigate caching layer</title>
-<description>Found references to Redis caching in auth module</description>
-</task>
-
-*Inserting a task after a specific task (to maintain logical order):*
-<task>
-<action>create</action>
-<title>Check rate limiting</title>
-<after>task-2</after>
-</task>
-
-*Cancelling and splitting a complex task:*
-<task>
-<action>update</action>
-<id>task-3</id>
-<status>cancelled</status>
-</task>
-<task>
-<action>create</action>
-<tasks>[
-  {"title": "Review JWT token generation", "priority": "high"},
-  {"title": "Review token refresh logic"}
-]</tasks>
-</task>
-
-**STEP 3 - Finish (before completion):**
-Before calling attempt_completion, ensure ALL tasks are either:
-- \`completed\` - you finished the work
-- \`cancelled\` - no longer needed
-
-If you created tasks, you MUST resolve them all before completing.
-
-## Key Rules
-
-1. **Dependencies are enforced**: A task cannot start until its dependencies are completed
-2. **Circular dependencies are rejected**: task-1 → task-2 → task-1 is invalid
-3. **Completion is blocked**: attempt_completion will fail if tasks remain unresolved
-4. **List to review**: Use <task><action>list</action></task> to see current task status
-5. **Tasks are living documents**: Add, split, or cancel tasks as you learn more about the problem
+- Dependencies are enforced: a task cannot start until its dependencies are completed
+- Circular dependencies are rejected
+- attempt_completion is blocked while tasks remain unresolved
 `;
 
 /**
  * Task guidance to inject at start of request
  */
-export const taskGuidancePrompt = `<task_guidance>
-Does this request have MULTIPLE DISTINCT GOALS?
+export const taskGuidancePrompt = `Does this request have MULTIPLE DISTINCT GOALS?
 - "Do A AND B AND C" (multiple goals) → Create tasks for each goal
 - "Investigate/explain/find X" (single goal) → Skip tasks, just answer directly
-
-Multiple internal steps (search, read, analyze) for ONE goal = NO tasks needed.
-Only create tasks when there are separate deliverables the user is asking for.
-
-If creating tasks, use the task tool with action="create" first.
-</task_guidance>`;
+Multiple internal steps for ONE goal = NO tasks needed.
+If creating tasks, use the task tool with action="create" first.`;
 
 /**
  * Create task completion blocked message
@@ -277,20 +93,15 @@ If creating tasks, use the task tool with action="create" first.
  * @returns {string} Formatted message
  */
 export function createTaskCompletionBlockedMessage(taskSummary) {
-  return `<task_completion_blocked>
-You cannot complete yet. The following tasks are still unresolved:
+  return `You cannot complete yet. The following tasks are still unresolved:
 
 ${taskSummary}
 
-Required action:
-1. For each "pending" or "in_progress" task, either:
-   - Complete the work and mark it: <task><action>complete</action><id>task-X</id></task>
-   - Or cancel if no longer needed: <task><action>update</action><id>task-X</id><status>cancelled</status></task>
+For each pending/in_progress task, either:
+- Complete it: call task tool with action="complete", id="task-X"
+- Cancel it: call task tool with action="update", id="task-X", status="cancelled"
 
-2. After ALL tasks are resolved (completed or cancelled), call attempt_completion again.
-
-Use <task><action>list</action></task> to review current status.
-</task_completion_blocked>`;
+After all tasks are resolved, call attempt_completion again.`;
 }
 
 /**

--- a/npm/src/tools/analyzeAll.js
+++ b/npm/src/tools/analyzeAll.js
@@ -176,8 +176,7 @@ Instructions:
 - Format as a structured list if multiple items found
 - If nothing relevant is found in this chunk, respond with "No relevant items found in this chunk."
 - Do NOT summarize the code - extract the specific information requested
-- IMPORTANT: When completing, always use the FULL format: <attempt_completion><result>YOUR ANSWER HERE</result></attempt_completion>
-- Do NOT use the shorthand <attempt_complete></attempt_complete> format`;
+- When done, use the attempt_completion tool with your answer as the result.`;
 
 	try {
 		const result = await delegate({
@@ -273,7 +272,7 @@ async function aggregateResults(chunkResults, aggregation, extractionPrompt, opt
 		.map(r => `--- Chunk ${r.chunk.id} ---\n${stripResultTags(r.result)}`)
 		.join('\n\n');
 
-	const completionNote = `\n\nIMPORTANT: When completing, always use the FULL format: <attempt_completion><result>YOUR ANSWER HERE</result></attempt_completion>`;
+	const completionNote = `\n\nWhen done, use the attempt_completion tool with your answer as the result.`;
 
 	const aggregationPrompts = {
 		summarize: `Synthesize these analyses into a comprehensive summary. Combine related findings, remove redundancy, and present a coherent overview.
@@ -460,7 +459,7 @@ Your answer should:
 
 Format your response as a well-structured document that fully answers: "${question}"
 
-IMPORTANT: When completing, use the FULL format: <attempt_completion><result>YOUR ANSWER HERE</result></attempt_completion>`;
+When done, use the attempt_completion tool with your answer as the result.`;
 
 	try {
 		const result = await delegate({

--- a/npm/src/tools/edit.js
+++ b/npm/src/tools/edit.js
@@ -88,7 +88,7 @@ async function handleSymbolEdit({ resolvedPath, file_path, symbol, new_string, p
   if (fileTracker) {
     const check = fileTracker.checkSymbolContent(resolvedPath, symbol, symbolInfo.code);
     if (!check.ok && check.reason === 'stale') {
-      return `Error editing ${file_path}: Symbol "${symbol}" has changed since you last read it. Use extract to re-read the current content, then retry.\n\nExample: <extract><targets>${file_path}#${symbol}</targets></extract>`;
+      return `Error editing ${file_path}: Symbol "${symbol}" has changed since you last read it. Use the extract tool with targets="${file_path}#${symbol}" to re-read the current content, then retry.`;
     }
   }
 
@@ -395,7 +395,7 @@ Parameters:
         // Check if file has been seen in this session (read-before-write guard)
         if (options.fileTracker && !options.fileTracker.isFileSeen(resolvedPath)) {
           const displayPath = toRelativePath(resolvedPath, workspaceRoot);
-          return `Error editing ${displayPath}: This file has not been read yet in this session. Use 'extract' to read the file first, then retry your edit. This ensures you are working with the current file content.\n\nExample: <extract><targets>${displayPath}</targets></extract>`;
+          return `Error editing ${displayPath}: This file has not been read yet in this session. Use the extract tool with targets="${displayPath}" to read the file first, then retry your edit.`;
         }
 
         // Route to appropriate mode (priority: symbol > start_line > old_string)
@@ -425,7 +425,7 @@ Parameters:
           const staleCheck = options.fileTracker.checkTextEditStaleness(resolvedPath);
           if (!staleCheck.ok) {
             const displayPath = toRelativePath(resolvedPath, workspaceRoot);
-            return `Error editing ${displayPath}: ${staleCheck.message}\n\nExample: <extract><targets>${displayPath}</targets></extract>`;
+            return `Error editing ${displayPath}: ${staleCheck.message}\n\nUse the extract tool with targets="${displayPath}" to re-read the file, then retry.`;
           }
         }
 

--- a/npm/tests/agent-compact-history.test.js
+++ b/npm/tests/agent-compact-history.test.js
@@ -25,43 +25,43 @@ describe('ProbeAgent.compactHistory()', () => {
   });
 
   it('should compact history and return statistics', async () => {
-    // Populate history with multiple segments
+    // Populate history with multiple segments (native tool calling format)
     agent.history = [
       { role: 'system', content: 'You are a helpful assistant' },
       // Segment 1
       { role: 'user', content: 'Search for functions' },
-      { role: 'assistant', content: '<thinking>I need to search</thinking>' },
-      { role: 'assistant', content: '<search>function</search>' },
-      { role: 'user', content: '<tool_result>Found 10 functions</tool_result>' },
+      { role: 'assistant', content: 'I need to search' },
+      { role: 'assistant', content: 'Searching...' },
+      { role: 'tool', content: 'Found 10 functions', toolName: 'search' },
+      { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Found functions' } }] },
       // Segment 2
       { role: 'user', content: 'Extract the first one' },
-      { role: 'assistant', content: '<thinking>Let me extract</thinking>' },
-      { role: 'assistant', content: '<extract>file.js:10</extract>' },
-      { role: 'user', content: '<tool_result>function code here</tool_result>' },
+      { role: 'assistant', content: 'Let me extract' },
+      { role: 'assistant', content: 'Extracting...' },
+      { role: 'tool', content: 'function code here', toolName: 'extract' },
+      { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Here is the code' } }] },
       // Segment 3 (active)
       { role: 'user', content: 'Modify it' },
-      { role: 'assistant', content: '<thinking>I will modify</thinking>' }
+      { role: 'assistant', content: 'I will modify' }
     ];
 
     const stats = await agent.compactHistory();
 
     // Check stats
-    expect(stats.originalCount).toBe(11);
-    expect(stats.compactedCount).toBeLessThan(11);
+    expect(stats.originalCount).toBe(13);
+    expect(stats.compactedCount).toBeLessThan(13);
     expect(stats.removed).toBeGreaterThan(0);
     expect(stats.reductionPercent).toBeGreaterThan(0);
     expect(stats.tokensSaved).toBeGreaterThan(0);
 
     // Check history was actually compacted
-    expect(agent.history.length).toBeLessThan(11);
+    expect(agent.history.length).toBeLessThan(13);
 
     // System message should be preserved
     expect(agent.history[0].role).toBe('system');
 
     // All user messages should be preserved
-    const userMessages = agent.history.filter(
-      m => m.role === 'user' && !m.content.includes('tool_result')
-    );
+    const userMessages = agent.history.filter(m => m.role === 'user');
     expect(userMessages.length).toBe(3);
 
     // Old segment thinking should be removed
@@ -92,13 +92,15 @@ describe('ProbeAgent.compactHistory()', () => {
   it('should respect custom options', async () => {
     agent.history = [
       { role: 'user', content: 'Query 1' },
-      { role: 'assistant', content: '<thinking>Thought 1</thinking>' },
-      { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+      { role: 'assistant', content: 'Thought 1' },
+      { role: 'tool', content: 'Result 1', toolName: 'search' },
+      { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 1' } }] },
       { role: 'user', content: 'Query 2' },
-      { role: 'assistant', content: '<thinking>Thought 2</thinking>' },
-      { role: 'user', content: '<tool_result>Result 2</tool_result>' },
+      { role: 'assistant', content: 'Thought 2' },
+      { role: 'tool', content: 'Result 2', toolName: 'search' },
+      { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 2' } }] },
       { role: 'user', content: 'Query 3' },
-      { role: 'assistant', content: '<thinking>Thought 3</thinking>' }
+      { role: 'assistant', content: 'Thought 3' }
     ];
 
     // Keep last 2 segments fully
@@ -141,7 +143,7 @@ describe('ProbeAgent.compactHistory()', () => {
   it('should handle history with incomplete segments', async () => {
     agent.history = [
       { role: 'user', content: 'Query' },
-      { role: 'assistant', content: '<thinking>Processing...</thinking>' }
+      { role: 'assistant', content: 'Processing...' }
     ];
 
     const stats = await agent.compactHistory();
@@ -155,10 +157,11 @@ describe('ProbeAgent.compactHistory()', () => {
     agent.history = [
       { role: 'system', content: 'System' },
       { role: 'user', content: 'Query 1' },
-      { role: 'assistant', content: '<search>test</search>' },
-      { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+      { role: 'assistant', content: 'Searching...' },
+      { role: 'tool', content: 'Result 1', toolName: 'search' },
+      { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] },
       { role: 'user', content: 'Query 2' },
-      { role: 'assistant', content: '<thinking>Active</thinking>' }
+      { role: 'assistant', content: 'Active thought' }
     ];
 
     await agent.compactHistory();
@@ -169,6 +172,6 @@ describe('ProbeAgent.compactHistory()', () => {
     // User messages should maintain their relative order
     const userMessages = agent.history.filter(m => m.role === 'user');
     expect(userMessages[0].content).toBe('Query 1');
-    expect(userMessages[2].content).toBe('Query 2');
+    expect(userMessages[1].content).toBe('Query 2');
   });
 });

--- a/npm/tests/contextCompactor.test.js
+++ b/npm/tests/contextCompactor.test.js
@@ -64,16 +64,17 @@ describe('Context Compactor', () => {
       const messages = [
         { role: 'system', content: 'You are an AI assistant' },
         { role: 'user', content: 'Search for function definitions' },
-        { role: 'assistant', content: '<thinking>Let me search</thinking>\n<search>function</search>' },
-        { role: 'user', content: '<tool_result>Found 10 results</tool_result>' }
+        { role: 'assistant', content: 'Let me search', toolInvocations: [{ toolName: 'search', args: { query: 'function' } }] },
+        { role: 'tool', content: 'Found 10 results', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] }
       ];
 
       const segments = identifyMessageSegments(messages);
       expect(segments).toHaveLength(1);
       expect(segments[0]).toEqual({
         userIndex: 1,
-        monologueIndices: [2],
-        finalIndex: 3
+        monologueIndices: [2, 3, 4],
+        finalIndex: 4
       });
     });
 
@@ -81,51 +82,53 @@ describe('Context Compactor', () => {
       const messages = [
         { role: 'system', content: 'System' },
         { role: 'user', content: 'First query' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result 1', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 1' } }] },
         { role: 'user', content: 'Second query' },
-        { role: 'assistant', content: '<extract>file.js</extract>' },
-        { role: 'user', content: '<tool_result>Result 2</tool_result>' }
+        { role: 'assistant', content: 'Extracting...' },
+        { role: 'tool', content: 'Result 2', toolName: 'extract' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 2' } }] }
       ];
 
       const segments = identifyMessageSegments(messages);
       expect(segments).toHaveLength(2);
 
       expect(segments[0].userIndex).toBe(1);
-      expect(segments[0].finalIndex).toBe(3);
+      expect(segments[0].finalIndex).toBe(4);
 
-      expect(segments[1].userIndex).toBe(4);
-      expect(segments[1].finalIndex).toBe(6);
+      expect(segments[1].userIndex).toBe(5);
+      expect(segments[1].finalIndex).toBe(8);
     });
 
     it('should handle segment with multiple monologue messages', () => {
       const messages = [
         { role: 'user', content: 'Query' },
-        { role: 'assistant', content: '<thinking>First thought</thinking>' },
-        { role: 'assistant', content: '<thinking>Second thought</thinking>' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result</tool_result>' }
+        { role: 'assistant', content: 'First thought' },
+        { role: 'assistant', content: 'Second thought' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] }
       ];
 
       const segments = identifyMessageSegments(messages);
       expect(segments).toHaveLength(1);
-      expect(segments[0].monologueIndices).toEqual([1, 2, 3]);
+      expect(segments[0].monologueIndices).toEqual([1, 2, 3, 4, 5]);
     });
 
     it('should handle attempt_completion as segment end', () => {
       const messages = [
         { role: 'user', content: 'Query' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Found results</tool_result>' },
-        { role: 'assistant', content: '<attempt_completion>Here is the answer</attempt_completion>' }
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Found results', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Here is the answer' } }] }
       ];
 
       const segments = identifyMessageSegments(messages);
       expect(segments).toHaveLength(1);
 
-      // Segment includes all messages with final being attempt_completion
       expect(segments[0].userIndex).toBe(0);
-      expect(segments[0].finalIndex).toBe(2); // tool_result is the final
+      expect(segments[0].finalIndex).toBe(3);
     });
 
     it('should handle incomplete segment (no final answer)', () => {
@@ -159,17 +162,19 @@ describe('Context Compactor', () => {
         { role: 'system', content: 'System' },
         // Segment 1 (old - should be compacted)
         { role: 'user', content: 'First query' },
-        { role: 'assistant', content: '<thinking>Thought 1</thinking>' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+        { role: 'assistant', content: 'Thought 1' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result 1', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 1' } }] },
         // Segment 2 (old - should be compacted)
         { role: 'user', content: 'Second query' },
-        { role: 'assistant', content: '<thinking>Thought 2</thinking>' },
-        { role: 'assistant', content: '<extract>file.js</extract>' },
-        { role: 'user', content: '<tool_result>Result 2</tool_result>' },
+        { role: 'assistant', content: 'Thought 2' },
+        { role: 'assistant', content: 'Extracting...' },
+        { role: 'tool', content: 'Result 2', toolName: 'extract' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 2' } }] },
         // Segment 3 (active - should be preserved)
         { role: 'user', content: 'Third query' },
-        { role: 'assistant', content: '<thinking>Active thought</thinking>' }
+        { role: 'assistant', content: 'Active thought' }
       ];
 
       const compacted = compactMessages(messages, {
@@ -183,21 +188,17 @@ describe('Context Compactor', () => {
       // Check system message preserved
       expect(compacted[0].role).toBe('system');
 
-      // Check segment 1 and 2 compacted (only user and final)
+      // Check segment 1 and 2 compacted (intermediate monologues removed)
       const hasFirstQuery = compacted.some(m => m.content === 'First query');
-      const hasResult1 = compacted.some(m => m.content === '<tool_result>Result 1</tool_result>');
       const hasThought1 = compacted.some(m => m.content && m.content.includes('Thought 1'));
 
       const hasSecondQuery = compacted.some(m => m.content === 'Second query');
-      const hasResult2 = compacted.some(m => m.content === '<tool_result>Result 2</tool_result>');
       const hasThought2 = compacted.some(m => m.content && m.content.includes('Thought 2'));
 
       expect(hasFirstQuery).toBe(true);
-      expect(hasResult1).toBe(true);
       expect(hasThought1).toBe(false); // Thought 1 should be removed
 
       expect(hasSecondQuery).toBe(true);
-      expect(hasResult2).toBe(true);
       expect(hasThought2).toBe(false); // Thought 2 should be removed
 
       // Check segment 3 is fully preserved (active)
@@ -210,8 +211,9 @@ describe('Context Compactor', () => {
         { role: 'system', content: 'System 1' },
         { role: 'user', content: 'Query' },
         { role: 'system', content: 'System 2' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result</tool_result>' }
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] }
       ];
 
       const compacted = compactMessages(messages);
@@ -228,10 +230,11 @@ describe('Context Compactor', () => {
     it('should preserve segments when minSegmentsToKeep is high', () => {
       const messages = [
         { role: 'user', content: 'Query 1' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result 1', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] },
         { role: 'user', content: 'Query 2' },
-        { role: 'assistant', content: '<extract>file</extract>' }
+        { role: 'assistant', content: 'Extracting...' }
       ];
 
       const compacted = compactMessages(messages, {
@@ -245,11 +248,12 @@ describe('Context Compactor', () => {
     it('should respect keepLastSegment option', () => {
       const messages = [
         { role: 'user', content: 'Query 1' },
-        { role: 'assistant', content: '<thinking>Old thought</thinking>' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result</tool_result>' },
+        { role: 'assistant', content: 'Old thought' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer' } }] },
         { role: 'user', content: 'Query 2' },
-        { role: 'assistant', content: '<thinking>New thought</thinking>' }
+        { role: 'assistant', content: 'New thought' }
       ];
 
       // With keepLastSegment=false and minSegmentsToKeep=1
@@ -260,8 +264,8 @@ describe('Context Compactor', () => {
 
       // Should only preserve the second-to-last segment fully
       // Segment 1 should be compacted
-      const hasOldThought = compacted.some(m => m.content.includes('Old thought'));
-      const hasNewThought = compacted.some(m => m.content.includes('New thought'));
+      const hasOldThought = compacted.some(m => m.content && m.content.includes('Old thought'));
+      const hasNewThought = compacted.some(m => m.content && m.content.includes('New thought'));
 
       expect(hasOldThought).toBe(false);
       expect(hasNewThought).toBe(true);
@@ -270,10 +274,11 @@ describe('Context Compactor', () => {
     it('should handle segments without final answers', () => {
       const messages = [
         { role: 'user', content: 'Query 1' },
-        { role: 'assistant', content: '<thinking>Thought 1</thinking>' },
-        { role: 'user', content: '<tool_result>Result</tool_result>' },
+        { role: 'assistant', content: 'Thought 1' },
+        { role: 'tool', content: 'Result', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer' } }] },
         { role: 'user', content: 'Query 2' },
-        { role: 'assistant', content: '<thinking>Thought 2</thinking>' }
+        { role: 'assistant', content: 'Thought 2' }
         // No final answer for segment 2
       ];
 
@@ -282,7 +287,7 @@ describe('Context Compactor', () => {
       });
 
       // Should preserve the last incomplete segment
-      expect(compacted).toContain(messages[4]);
+      expect(compacted).toContain(messages[5]);
     });
   });
 
@@ -352,12 +357,13 @@ describe('Context Compactor', () => {
       const error = new Error('context length exceeded');
       const messages = [
         { role: 'user', content: 'Query 1' },
-        { role: 'assistant', content: '<thinking>Thought 1</thinking>' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result 1</tool_result>' },
+        { role: 'assistant', content: 'Thought 1' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result 1', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Answer 1' } }] },
         { role: 'user', content: 'Query 2' },
-        { role: 'assistant', content: '<thinking>Thought 2</thinking>' },
-        { role: 'assistant', content: '<extract>file</extract>' }
+        { role: 'assistant', content: 'Thought 2' },
+        { role: 'assistant', content: 'Extracting...' }
       ];
 
       const result = handleContextLimitError(error, messages);
@@ -383,10 +389,11 @@ describe('Context Compactor', () => {
       const error = new Error('tokens exceed maximum');
       const messages = [
         { role: 'user', content: 'Query 1' },
-        { role: 'assistant', content: '<search>test</search>' },
-        { role: 'user', content: '<tool_result>Result</tool_result>' },
+        { role: 'assistant', content: 'Searching...' },
+        { role: 'tool', content: 'Result', toolName: 'search' },
+        { role: 'assistant', content: '', toolInvocations: [{ toolName: 'attempt_completion', args: { result: 'Done' } }] },
         { role: 'user', content: 'Query 2' },
-        { role: 'assistant', content: '<extract>file</extract>' }
+        { role: 'assistant', content: 'Extracting...' }
       ];
 
       const result = handleContextLimitError(error, messages, {


### PR DESCRIPTION
## Problem / Task

Multiple agent prompts, error messages, and the context compactor still used the old XML tool calling format (`<tool_result>`, `<attempt_completion><result>...</result></attempt_completion>`, `<extract><targets>...</targets></extract>`) even though the agent now uses native tool calling via Vercel AI SDK. The task system prompt was also bloated (210+ lines) with XML examples that no longer apply.

## Changes

- **`taskTool.js`**: Trimmed `taskSystemPrompt` from 128 → 34 lines — kept all decision logic (when to create tasks, granularity rules, workflow, enforcement rules), removed all XML examples. Emptied dead `taskToolDefinition` export (never imported anywhere). Cleaned up `taskGuidancePrompt` and `createTaskCompletionBlockedMessage` to remove XML wrappers.
- **`edit.js`** (3 places): Replaced `<extract><targets>file#Symbol</targets></extract>` XML in error messages with plain `Use the extract tool with targets="..."`.
- **`analyzeAll.js`** (3 places): Replaced `<attempt_completion><result>...</result></attempt_completion>` XML instructions with `use the attempt_completion tool with your answer as the result`.
- **`contextCompactor.js`**: Rewrote `identifyMessageSegments` to handle native tool calling format — `role: 'tool'` messages, `toolInvocations` (Vercel AI SDK), `tool_calls` (OpenAI format), and multipart content arrays. Added `messageContainsCompletion()` helper for format-agnostic detection.
- **`prompts.js`**: Strengthened engineer persona "After Implementation" checklist — build must succeed, lint/typecheck must pass, tests must be added for new/changed code, full test suite must pass.
- **Tests**: Updated `contextCompactor.test.js` and `agent-compact-history.test.js` to use native tool calling message format instead of XML.

## Testing

- All 2637 existing tests pass (`npm test --prefix npm`)
- Updated test files: `contextCompactor.test.js` (22 tests), `agent-compact-history.test.js` (6 tests) — all converted from XML to native tool calling format

🤖 Generated with [Claude Code](https://claude.com/claude-code)