### PR TITLE
fix: resolve user-provided task IDs in batch createTasks dependencies

### DIFF
--- a/npm/src/agent/tasks/TaskManager.js
+++ b/npm/src/agent/tasks/TaskManager.js
@@ -132,14 +132,53 @@ export class TaskManager {
   }
 
   /**
-   * Create multiple tasks in batch
+   * Create multiple tasks in batch, resolving user-provided IDs to auto-generated IDs.
+   * If any task fails validation, no tasks are created (atomic operation).
    * @param {Object[]} tasksData - Array of task data objects
    * @returns {Task[]} Created tasks
    */
   createTasks(tasksData) {
-    const createdTasks = [];
-
+    // Build a mapping of user-provided IDs to future auto-generated IDs
+    const idMap = new Map();
+    const batchAutoIds = new Set();
+    let nextCounter = this.taskCounter;
     for (const taskData of tasksData) {
+      nextCounter++;
+      const autoId = `task-${nextCounter}`;
+      batchAutoIds.add(autoId);
+      if (taskData.id) {
+        idMap.set(taskData.id, autoId);
+      }
+    }
+
+    // Resolve dependencies and "after" references, then validate before creating anything
+    const resolvedTasksData = tasksData.map(taskData => {
+      const resolved = { ...taskData };
+      delete resolved.id; // Don't pass user ID to createTask
+
+      if (resolved.dependencies) {
+        resolved.dependencies = resolved.dependencies.map(depId => {
+          if (idMap.has(depId)) return idMap.get(depId);
+          // Check if it's already an existing task ID or a batch auto-generated ID
+          if (this.tasks.has(depId) || batchAutoIds.has(depId)) return depId;
+          throw new Error(`Dependency "${depId}" does not exist. Available tasks: ${this._getAvailableTaskIds()}${idMap.size > 0 ? `, batch IDs: ${Array.from(idMap.keys()).join(', ')}` : ''}`);
+        });
+      }
+
+      if (resolved.after) {
+        if (idMap.has(resolved.after)) {
+          resolved.after = idMap.get(resolved.after);
+        } else if (!this.tasks.has(resolved.after) && !batchAutoIds.has(resolved.after)) {
+          throw new Error(`Task "${resolved.after}" does not exist. Cannot insert after non-existent task. Available tasks: ${this._getAvailableTaskIds()}${idMap.size > 0 ? `, batch IDs: ${Array.from(idMap.keys()).join(', ')}` : ''}`);
+        }
+      }
+
+      return resolved;
+    });
+
+    // All validation passed — create tasks
+    const createdTasks = [];
+    for (const taskData of resolvedTasksData) {
       const task = this.createTask(taskData);
       createdTasks.push(task);
     }

--- a/npm/tests/unit/task-manager.test.js
+++ b/npm/tests/unit/task-manager.test.js
@@ -91,6 +91,79 @@ describe('TaskManager', () => {
       expect(tasks[1].dependencies).toEqual(['task-1']);
       expect(tasks[2].dependencies).toEqual(['task-1', 'task-2']);
     });
+
+    test('should resolve user-provided IDs to auto-generated IDs in batch dependencies', () => {
+      const tasks = manager.createTasks([
+        { id: 'auth', title: 'Authenticate with API' },
+        { id: 'list-projects', title: 'List Projects', dependencies: ['auth'] },
+        { id: 'list-clusters', title: 'List Clusters', dependencies: ['list-projects'] }
+      ]);
+
+      expect(tasks).toHaveLength(3);
+      // Dependencies should be remapped to auto-generated IDs
+      expect(tasks[0].id).toBe('task-1');
+      expect(tasks[1].id).toBe('task-2');
+      expect(tasks[1].dependencies).toEqual(['task-1']);
+      expect(tasks[2].id).toBe('task-3');
+      expect(tasks[2].dependencies).toEqual(['task-2']);
+    });
+
+    test('should resolve user-provided IDs with multiple dependencies', () => {
+      const tasks = manager.createTasks([
+        { id: 'setup', title: 'Setup' },
+        { id: 'build', title: 'Build', dependencies: ['setup'] },
+        { id: 'test', title: 'Test', dependencies: ['setup'] },
+        { id: 'deploy', title: 'Deploy', dependencies: ['build', 'test'] }
+      ]);
+
+      expect(tasks).toHaveLength(4);
+      expect(tasks[3].dependencies).toEqual(['task-2', 'task-3']);
+    });
+
+    test('should resolve user-provided IDs in "after" parameter', () => {
+      const tasks = manager.createTasks([
+        { id: 'first', title: 'First task' },
+        { id: 'third', title: 'Third task' },
+        { id: 'second', title: 'Second task', after: 'first' }
+      ]);
+
+      expect(tasks).toHaveLength(3);
+      const allTasks = manager.listTasks();
+      const taskIds = allTasks.map(t => t.id);
+      expect(taskIds).toEqual(['task-1', 'task-3', 'task-2']);
+    });
+
+    test('should not create any tasks if batch validation fails', () => {
+      expect(() => {
+        manager.createTasks([
+          { id: 'a', title: 'Task A' },
+          { id: 'b', title: 'Task B', dependencies: ['nonexistent'] }
+        ]);
+      }).toThrow();
+
+      // No tasks should have been created (atomic batch)
+      expect(manager.listTasks()).toHaveLength(0);
+    });
+
+    test('should handle mix of user-provided and missing IDs in batch', () => {
+      const tasks = manager.createTasks([
+        { id: 'setup', title: 'Setup' },
+        { title: 'Build (no custom id)' },
+        { id: 'deploy', title: 'Deploy', dependencies: ['setup'] }
+      ]);
+
+      expect(tasks).toHaveLength(3);
+      expect(tasks[2].dependencies).toEqual(['task-1']);
+    });
+
+    test('should error when batch dependency references unknown user ID', () => {
+      expect(() => {
+        manager.createTasks([
+          { id: 'a', title: 'Task A' },
+          { id: 'b', title: 'Task B', dependencies: ['unknown'] }
+        ]);
+      }).toThrow(/does not exist/);
+    });
   });
 
   describe('getTask', () => {


### PR DESCRIPTION
## Problem / Task

When AI models call `createTasks` with user-provided IDs and reference them in dependencies, the batch creation crashes midway. For example:

```json
[
  {"id": "auth", "title": "Authenticate"},
  {"id": "list-projects", "title": "List Projects", "dependencies": ["auth"]},
  {"id": "list-clusters", "title": "List Clusters", "dependencies": ["list-projects"]}
]
```

The first task gets created as `task-1`, but when the second task references `dependencies: ["auth"]`, it fails because `"auth"` was never used as an actual task ID. This leaves the TaskManager in a partially-created state (task-1 exists, rest don't).

## Changes

- **`npm/src/agent/tasks/TaskManager.js`**: Rewrote `createTasks()` to:
  1. Pre-scan batch to build a mapping of user-provided IDs → auto-generated IDs
  2. Resolve all dependencies and `after` references before creating anything
  3. Make batch creation atomic — if any task fails validation, no tasks are created
  
- **`npm/tests/unit/task-manager.test.js`**: Added 6 new tests:
  - User-provided ID resolution in dependencies
  - Multiple dependency resolution (diamond pattern)
  - User-provided ID resolution in `after` parameter
  - Atomic batch failure (no partial creation)
  - Mixed user-provided and auto-generated IDs
  - Unknown dependency error in batch

## Testing

All 2643 tests pass, including 6 new tests and 68 existing task manager tests.

```
npm test --prefix npm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)