### PR TITLE
fix: require task id in batch create and improve dependency error messages

### DIFF
--- a/npm/src/agent/tasks/TaskManager.js
+++ b/npm/src/agent/tasks/TaskManager.js
@@ -138,6 +138,16 @@ export class TaskManager {
    * @returns {Task[]} Created tasks
    */
   createTasks(tasksData) {
+    // Validate that all batch items have an id when dependencies are used
+    const hasDependencies = tasksData.some(t => t.dependencies && t.dependencies.length > 0);
+    if (hasDependencies) {
+      for (let i = 0; i < tasksData.length; i++) {
+        if (!tasksData[i].id) {
+          throw new Error(`Task at index ${i} is missing required "id" field. When using dependencies, every task in the batch must have an "id" so other tasks can reference it.`);
+        }
+      }
+    }
+
     // Build a mapping of user-provided IDs to future auto-generated IDs
     const idMap = new Map();
     const batchAutoIds = new Set();
@@ -161,7 +171,8 @@ export class TaskManager {
           if (idMap.has(depId)) return idMap.get(depId);
           // Check if it's already an existing task ID or a batch auto-generated ID
           if (this.tasks.has(depId) || batchAutoIds.has(depId)) return depId;
-          throw new Error(`Dependency "${depId}" does not exist. Available tasks: ${this._getAvailableTaskIds()}${idMap.size > 0 ? `, batch IDs: ${Array.from(idMap.keys()).join(', ')}` : ''}`);
+          const batchIds = idMap.size > 0 ? Array.from(idMap.keys()).join(', ') : '(none provided)';
+          throw new Error(`Dependency "${depId}" does not exist. Each task in the batch must have an "id" field, and dependencies must reference those IDs. Current batch IDs: ${batchIds}. Existing tasks: ${this._getAvailableTaskIds()}`);
         });
       }
 

--- a/npm/src/agent/tasks/taskTool.js
+++ b/npm/src/agent/tasks/taskTool.js
@@ -9,12 +9,12 @@ import { z } from 'zod';
  * Schema for a single task item in batch operations
  */
 export const taskItemSchema = z.object({
-  id: z.string().optional(),
+  id: z.string().describe('Unique task identifier. Use short descriptive slugs (e.g. "auth", "setup-db"). Dependencies reference these IDs.'),
   title: z.string().optional(),
   description: z.string().optional(),
   status: z.enum(['pending', 'in_progress', 'completed', 'cancelled']).optional(),
   priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
-  dependencies: z.array(z.string()).optional(),
+  dependencies: z.array(z.string()).optional().describe('Array of task IDs (from this batch or previously created) that must complete before this task can start.'),
   after: z.string().optional()
 });
 

--- a/npm/tests/unit/task-manager.test.js
+++ b/npm/tests/unit/task-manager.test.js
@@ -83,9 +83,9 @@ describe('TaskManager', () => {
 
     test('should create tasks with dependencies to earlier tasks in batch', () => {
       const tasks = manager.createTasks([
-        { title: 'Task 1' },
-        { title: 'Task 2', dependencies: ['task-1'] },
-        { title: 'Task 3', dependencies: ['task-1', 'task-2'] }
+        { id: 'first', title: 'Task 1' },
+        { id: 'second', title: 'Task 2', dependencies: ['first'] },
+        { id: 'third', title: 'Task 3', dependencies: ['first', 'second'] }
       ]);
 
       expect(tasks[1].dependencies).toEqual(['task-1']);
@@ -145,15 +145,26 @@ describe('TaskManager', () => {
       expect(manager.listTasks()).toHaveLength(0);
     });
 
-    test('should handle mix of user-provided and missing IDs in batch', () => {
+    test('should require id on all items when batch has dependencies', () => {
+      expect(() => {
+        manager.createTasks([
+          { id: 'setup', title: 'Setup' },
+          { title: 'Build (no custom id)' },
+          { id: 'deploy', title: 'Deploy', dependencies: ['setup'] }
+        ]);
+      }).toThrow(/missing required "id" field/);
+
+      expect(manager.listTasks()).toHaveLength(0);
+    });
+
+    test('should allow missing IDs in batch without dependencies', () => {
       const tasks = manager.createTasks([
-        { id: 'setup', title: 'Setup' },
-        { title: 'Build (no custom id)' },
-        { id: 'deploy', title: 'Deploy', dependencies: ['setup'] }
+        { title: 'Task A' },
+        { title: 'Task B' },
+        { title: 'Task C' }
       ]);
 
       expect(tasks).toHaveLength(3);
-      expect(tasks[2].dependencies).toEqual(['task-1']);
     });
 
     test('should error when batch dependency references unknown user ID', () => {
@@ -163,6 +174,30 @@ describe('TaskManager', () => {
           { id: 'b', title: 'Task B', dependencies: ['unknown'] }
         ]);
       }).toThrow(/does not exist/);
+    });
+
+    test('should error with clear message when dependencies use auto-generated IDs without providing batch IDs', () => {
+      expect(() => {
+        manager.createTasks([
+          { id: 'first', title: 'First task' },
+          { id: 'second', title: 'Second task', dependencies: ['task-0'] }
+        ]);
+      }).toThrow(/does not exist/);
+
+      expect(manager.listTasks()).toHaveLength(0);
+    });
+
+    test('should include batch IDs in error message for failed dependency resolution', () => {
+      try {
+        manager.createTasks([
+          { id: 'auth', title: 'Auth' },
+          { id: 'fetch', title: 'Fetch', dependencies: ['wrong-id'] }
+        ]);
+        expect(true).toBe(false); // should not reach here
+      } catch (e) {
+        expect(e.message).toContain('batch IDs: auth, fetch');
+        expect(e.message).toContain('wrong-id');
+      }
     });
   });
 


### PR DESCRIPTION
## Problem / Task

AI models frequently fail when creating tasks in batch because they either:
1. Omit `id` fields entirely and reference non-existent auto-generated IDs like `"task-0"` in dependencies
2. Don't know what IDs to use in dependencies because the schema didn't communicate the requirement

Example failing call from production:
```json
[
  {"title": "Reset branch", "description": "..."},
  {"title": "Force push", "dependencies": ["task-0"]}
]
```

This fails because `task-0` doesn't exist (auto-generated IDs start at `task-1`), and without user-provided IDs there's nothing to resolve.

## Changes

- **`npm/src/agent/tasks/taskTool.js`**: Made `id` required (not optional) in `taskItemSchema` with a `.describe()` hint so AI models understand they must provide IDs and how to use them in dependencies
- **`npm/src/agent/tasks/TaskManager.js`**: 
  - Added early validation: when any task in the batch has dependencies, all items must have an `id` field
  - Improved error message to list available batch IDs, helping the AI self-correct
- **`npm/tests/unit/task-manager.test.js`**: Added 4 new tests, updated 1 existing test:
  - Validates missing `id` error when dependencies are used
  - Allows missing IDs when no dependencies exist
  - Tests error for non-existent auto-generated ID references (`task-0`)
  - Verifies batch IDs appear in error messages

## Testing

All 2646 tests pass (`npm test` from `npm/` directory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)