### PR TITLE
fix: improve debug logging with tool names, args, and tool list

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -126,6 +126,27 @@ const MAX_HISTORY_MESSAGES = 100;
 const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;
 
 /**
+ * Truncate a string for debug logging, showing first and last portion.
+ */
+export function debugTruncate(s, limit = 200) {
+  if (s.length <= limit) return s;
+  const half = Math.floor(limit / 2);
+  return s.substring(0, half) + ` ... [${s.length} chars] ... ` + s.substring(s.length - half);
+}
+
+/**
+ * Log tool results details for debug output.
+ */
+export function debugLogToolResults(toolResults) {
+  if (!toolResults || toolResults.length === 0) return;
+  for (const tr of toolResults) {
+    const argsStr = JSON.stringify(tr.args || {});
+    const resultStr = typeof tr.result === 'string' ? tr.result : JSON.stringify(tr.result || '');
+    console.log(`[DEBUG]   tool: ${tr.toolName} | args: ${debugTruncate(argsStr)} | result: ${debugTruncate(resultStr)}`);
+  }
+}
+
+/**
  * ProbeAgent class to handle AI interactions with code search capabilities
  */
 export class ProbeAgent {
@@ -3385,6 +3406,11 @@ Follow these instructions carefully:
         completionAttempted = true;
       }, toolContext);
 
+      if (this.debug) {
+        const toolNames = Object.keys(tools);
+        console.log(`[DEBUG] Agent tools registered (${toolNames.length}): ${toolNames.join(', ')}`);
+      }
+
       let maxResponseTokens = this.maxResponseTokens;
       if (!maxResponseTokens) {
         maxResponseTokens = 4000;
@@ -3434,6 +3460,7 @@ Follow these instructions carefully:
 
               if (this.debug) {
                 console.log(`[DEBUG] Step ${currentIteration}/${maxIterations} finished (reason: ${finishReason}, tools: ${toolResults?.length || 0})`);
+                debugLogToolResults(toolResults);
               }
             }
           };
@@ -3645,6 +3672,7 @@ Double-check your response based on the criteria above. If everything looks good
               }
               if (this.debug) {
                 console.log(`[DEBUG] Completion prompt step finished (reason: ${finishReason}, tools: ${toolResults?.length || 0})`);
+                debugLogToolResults(toolResults);
               }
             }
           };

--- a/npm/tests/unit/debug-logging.test.js
+++ b/npm/tests/unit/debug-logging.test.js
@@ -1,0 +1,100 @@
+import { describe, test, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { debugTruncate, debugLogToolResults } from '../../src/agent/ProbeAgent.js';
+
+describe('Debug logging helpers', () => {
+  describe('debugTruncate', () => {
+    test('should return short strings unchanged', () => {
+      expect(debugTruncate('hello')).toBe('hello');
+      expect(debugTruncate('')).toBe('');
+      expect(debugTruncate('a'.repeat(200))).toBe('a'.repeat(200));
+    });
+
+    test('should truncate long strings showing first and last portions', () => {
+      const long = 'A'.repeat(100) + 'B'.repeat(100) + 'C'.repeat(100);
+      const result = debugTruncate(long);
+      expect(result).toContain('A'.repeat(100));
+      expect(result).toContain('C'.repeat(100));
+      expect(result).toContain('300 chars');
+      expect(result.length).toBeLessThan(long.length);
+    });
+
+    test('should respect custom limit', () => {
+      const s = 'abcdefghij'; // 10 chars
+      const result = debugTruncate(s, 6);
+      // half = 3, so first 3 + last 3
+      expect(result).toContain('abc');
+      expect(result).toContain('hij');
+      expect(result).toContain('10 chars');
+    });
+
+    test('should not truncate at exactly the limit', () => {
+      const s = 'a'.repeat(200);
+      expect(debugTruncate(s, 200)).toBe(s);
+    });
+  });
+
+  describe('debugLogToolResults', () => {
+    let consoleSpy;
+
+    beforeEach(() => {
+      consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      consoleSpy.mockRestore();
+    });
+
+    test('should not log anything for empty or null results', () => {
+      debugLogToolResults(null);
+      debugLogToolResults([]);
+      debugLogToolResults(undefined);
+      expect(consoleSpy).not.toHaveBeenCalled();
+    });
+
+    test('should log tool name and args', () => {
+      debugLogToolResults([{
+        toolName: 'search',
+        args: { query: 'test query', path: '/src' },
+        result: 'found 3 results'
+      }]);
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
+      const output = consoleSpy.mock.calls[0][0];
+      expect(output).toContain('tool: search');
+      expect(output).toContain('test query');
+      expect(output).toContain('found 3 results');
+    });
+
+    test('should log multiple tool results', () => {
+      debugLogToolResults([
+        { toolName: 'search', args: { query: 'a' }, result: 'res1' },
+        { toolName: 'extract', args: { file: 'b.js' }, result: 'res2' }
+      ]);
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(consoleSpy.mock.calls[0][0]).toContain('tool: search');
+      expect(consoleSpy.mock.calls[1][0]).toContain('tool: extract');
+    });
+
+    test('should truncate long args and results', () => {
+      const longArg = 'x'.repeat(500);
+      debugLogToolResults([{
+        toolName: 'search',
+        args: { query: longArg },
+        result: 'y'.repeat(500)
+      }]);
+      const output = consoleSpy.mock.calls[0][0];
+      expect(output).toContain('500 chars');
+      expect(output.length).toBeLessThan(1000);
+    });
+
+    test('should handle non-string results (objects)', () => {
+      debugLogToolResults([{
+        toolName: 'search',
+        args: {},
+        result: { files: ['a.js', 'b.js'] }
+      }]);
+      const output = consoleSpy.mock.calls[0][0];
+      expect(output).toContain('a.js');
+      expect(output).toContain('b.js');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Tool list at start**: When `DEBUG=1`, log all registered tool names when the agentic flow begins (e.g. `[DEBUG] Agent tools registered (7): search, extract, delegate, ...`)
- **Tool call details per step**: Each `onStepFinish` now logs tool name, truncated args, and truncated result for every tool call (showing first/last 100 chars for long values)
- **Reusable helpers**: Extracted `debugTruncate()` and `debugLogToolResults()` as exported module-level functions

### Before
```
[DEBUG] Step 17/34 finished (reason: tool-calls, tools: 1)
```

### After
```
[DEBUG] Agent tools registered (7): search, query, extract, delegate, execute_plan, listFiles, searchFiles
[DEBUG] Step 17/34 finished (reason: tool-calls, tools: 1)
[DEBUG]   tool: search | args: {"query":"error handling","path":"/src"} | result: Found 5 matches in... [2340 chars] ...src/handler.rs:42
```

## Test plan

- [x] 9 new unit tests for `debugTruncate()` and `debugLogToolResults()` helpers
- [x] All 2671 tests pass (107 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)