### PR TITLE
Add always-on wait logging for concurrency paths

### DIFF
--- a/npm/src/agent/dsl/environment.js
+++ b/npm/src/agent/dsl/environment.js
@@ -284,6 +284,7 @@ export function generateSandboxGlobals(options) {
       results.push(p);
 
       if (executing.size >= mapConcurrency) {
+        console.error(`[map] Concurrency limit reached (${executing.size}/${mapConcurrency}), waiting for a slot...`);
         await Promise.race(executing);
       }
     }

--- a/npm/src/delegate.js
+++ b/npm/src/delegate.js
@@ -122,20 +122,20 @@ class DelegationManager {
 		}
 
 		// Need to wait in queue
-		if (debug) {
-			console.error(`[DelegationManager] Slot unavailable (${this.globalActive}/${this.maxConcurrent}), queuing... (queue size: ${this.waitQueue.length}, timeout: ${effectiveTimeout}ms)`);
-		}
+		console.error(`[DelegationManager] Slot unavailable (${this.globalActive}/${this.maxConcurrent}), queuing... (queue size: ${this.waitQueue.length + 1}, timeout: ${effectiveTimeout}ms)`);
 
 		// Create a promise that will be resolved when a slot becomes available
 		// or rejected if session limit is exceeded or queue timeout expires
 		return new Promise((resolve, reject) => {
+			const queuedAt = Date.now();
 			const entry = {
 				resolve: null,  // Will be wrapped below
 				reject: null,   // Will be wrapped below
 				parentSessionId,
 				debug,
-				queuedAt: Date.now(),
-				timeoutId: null
+				queuedAt,
+				timeoutId: null,
+				reminderId: null
 			};
 
 			// Wrap resolve/reject to clear timeout and prevent double-settling
@@ -144,12 +144,14 @@ class DelegationManager {
 				if (settled) return;
 				settled = true;
 				if (entry.timeoutId) clearTimeout(entry.timeoutId);
+				if (entry.reminderId) clearInterval(entry.reminderId);
 				resolve(value);
 			};
 			entry.reject = (error) => {
 				if (settled) return;
 				settled = true;
 				if (entry.timeoutId) clearTimeout(entry.timeoutId);
+				if (entry.reminderId) clearInterval(entry.reminderId);
 				reject(error);
 			};
 
@@ -163,6 +165,15 @@ class DelegationManager {
 					}
 					entry.reject(new Error(`Delegation queue timeout: waited ${effectiveTimeout}ms for an available slot`));
 				}, effectiveTimeout);
+			}
+
+			// Always emit periodic wait visibility while queued.
+			entry.reminderId = setInterval(() => {
+				const waitedSeconds = Math.round((Date.now() - queuedAt) / 1000);
+				console.error(`[DelegationManager] Still waiting for slot (${waitedSeconds}s). ${this.globalActive}/${this.maxConcurrent} active, ${this.waitQueue.length} queued.`);
+			}, 15000);
+			if (entry.reminderId.unref) {
+				entry.reminderId.unref();
 			}
 
 			this.waitQueue.push(entry);
@@ -221,9 +232,7 @@ class DelegationManager {
 				if (sessionCount >= this.maxPerSession) {
 					// Session limit reached - reject with error (consistent with tryAcquire behavior)
 					// This is a hard limit, not something that will resolve by waiting longer
-					if (debug) {
-						console.error(`[DelegationManager] Session limit (${this.maxPerSession}) reached for queued item, rejecting`);
-					}
+					console.error(`[DelegationManager] Session limit (${this.maxPerSession}) reached for queued item, rejecting`);
 					toReject.push({ reject, error: new Error(`Maximum delegations per session (${this.maxPerSession}) reached for session ${parentSessionId}`) });
 					// Continue to process next item in queue
 					continue;
@@ -233,10 +242,8 @@ class DelegationManager {
 			// Grant the slot
 			this._incrementCounters(parentSessionId);
 
-			if (debug) {
-				const waitTime = Date.now() - queuedAt;
-				console.error(`[DelegationManager] Granted slot from queue (waited ${waitTime}ms). Active: ${this.globalActive}/${this.maxConcurrent}`);
-			}
+			const waitTime = Date.now() - queuedAt;
+			console.error(`[DelegationManager] Granted slot from queue (waited ${waitTime}ms). Active: ${this.globalActive}/${this.maxConcurrent}`);
 
 			toResolve.push(resolve);
 		}
@@ -295,6 +302,9 @@ class DelegationManager {
 		for (const entry of this.waitQueue) {
 			if (entry.timeoutId) {
 				clearTimeout(entry.timeoutId);
+			}
+			if (entry.reminderId) {
+				clearInterval(entry.reminderId);
 			}
 			// Reject pending entries so they don't hang
 			if (entry.reject) {

--- a/npm/src/downloader.js
+++ b/npm/src/downloader.js
@@ -95,9 +95,7 @@ async function acquireFileLock(lockPath, version) {
 	try {
 		// Try to create lock file atomically (fails if already exists)
 		await fs.writeFile(lockPath, JSON.stringify(lockData), { flag: 'wx' });
-		if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-			console.log(`Acquired file lock: ${lockPath}`);
-		}
+		console.log(`Acquired file lock: ${lockPath}`);
 		return true;
     } catch (error) {
 		if (error.code === 'EEXIST') {
@@ -108,17 +106,13 @@ async function acquireFileLock(lockPath, version) {
 
 				if (lockAge > LOCK_TIMEOUT_MS) {
 					// Lock is stale, remove it
-					if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-						console.log(`Removing stale lock file (age: ${Math.round(lockAge / 1000)}s, pid: ${existingLock.pid})`);
-					}
+					console.log(`Removing stale lock file (age: ${Math.round(lockAge / 1000)}s, pid: ${existingLock.pid})`);
 					await fs.remove(lockPath);
 					return false; // Caller should retry
 				}
 
 				// Lock is fresh, another process is downloading
-				if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-					console.log(`Download in progress by process ${existingLock.pid}, waiting...`);
-				}
+				console.log(`Download in progress by process ${existingLock.pid}, waiting...`);
 				return false;
 			} catch (readError) {
 				// Can't read lock file, might be corrupted - remove it
@@ -180,23 +174,23 @@ async function releaseFileLock(lockPath) {
  */
 async function waitForFileLock(lockPath, binaryPath) {
 	const startTime = Date.now();
+	let lastStatusTime = startTime;
+
+	console.log(`Waiting for file lock to clear: ${lockPath}`);
 
 	// Poll in a loop until binary appears, lock expires, or we timeout
 	while (Date.now() - startTime < MAX_LOCK_WAIT_MS) {
 		// Check #1: Is the binary now available?
 		if (await fs.pathExists(binaryPath)) {
-			if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-				console.log(`Binary now available at ${binaryPath}, download completed by another process`);
-			}
+			const waitedSeconds = Math.round((Date.now() - startTime) / 1000);
+			console.log(`Binary now available at ${binaryPath}, download completed by another process (waited ${waitedSeconds}s)`);
 			return true;
 		}
 
 		// Check #2: Is the lock file gone? (download finished or failed)
 		const lockExists = await fs.pathExists(lockPath);
 		if (!lockExists) {
-			if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-				console.log(`Lock file removed but binary not found - download may have failed`);
-			}
+			console.log(`Lock file removed but binary not found - download may have failed`);
 			return false;
 		}
 
@@ -205,22 +199,24 @@ async function waitForFileLock(lockPath, binaryPath) {
 			const lockData = JSON.parse(await fs.readFile(lockPath, 'utf-8'));
 			const lockAge = Date.now() - lockData.timestamp;
 			if (lockAge > LOCK_TIMEOUT_MS) {
-				if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-					console.log(`Lock expired (age: ${Math.round(lockAge / 1000)}s), will retry download`);
-				}
+				console.log(`Lock expired (age: ${Math.round(lockAge / 1000)}s), will retry download`);
 				return false;
 			}
 		} catch {
 			// Ignore errors reading lock file - will retry on next poll
 		}
 
+		if (Date.now() - lastStatusTime >= 15000) {
+			const elapsedSeconds = Math.round((Date.now() - startTime) / 1000);
+			console.log(`Still waiting for file lock (${elapsedSeconds}s/${MAX_LOCK_WAIT_MS / 1000}s max)`);
+			lastStatusTime = Date.now();
+		}
+
 		// Wait 1 second before checking again
 		await new Promise(resolve => setTimeout(resolve, LOCK_POLL_INTERVAL_MS));
 	}
 
-	if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-		console.log(`Timeout waiting for file lock`);
-	}
+	console.log(`Timeout waiting for file lock after ${MAX_LOCK_WAIT_MS / 1000}s`);
 	return false;
 }
 
@@ -247,9 +243,7 @@ async function withDownloadLock(version, downloadFn) {
 			}
 			downloadLocks.delete(lockKey);
 		} else {
-			if (process.env.DEBUG === '1' || process.env.VERBOSE === '1') {
-				console.log(`Download already in progress in this process for version ${lockKey}, waiting...`);
-			}
+			console.log(`Download already in progress in this process for version ${lockKey}, waiting...`);
 			try {
 				return await lock.promise;
 			} catch (error) {
@@ -262,10 +256,16 @@ async function withDownloadLock(version, downloadFn) {
 	}
 
 	// Create new download promise with timeout protection
+	let timeoutId = null;
 	const downloadPromise = Promise.race([
 		downloadFn(),
 		new Promise((_, reject) =>
-			setTimeout(() => reject(new Error(`Download timeout after ${LOCK_TIMEOUT_MS / 1000}s`)), LOCK_TIMEOUT_MS)
+			{
+				timeoutId = setTimeout(() => reject(new Error(`Download timeout after ${LOCK_TIMEOUT_MS / 1000}s`)), LOCK_TIMEOUT_MS);
+				if (timeoutId.unref) {
+					timeoutId.unref();
+				}
+			}
 		)
 	]);
 
@@ -278,6 +278,9 @@ async function withDownloadLock(version, downloadFn) {
 		const result = await downloadPromise;
 		return result;
 	} finally {
+		if (timeoutId) {
+			clearTimeout(timeoutId);
+		}
 		// Clean up lock after download completes (success or failure)
 		downloadLocks.delete(lockKey);
 	}

--- a/npm/src/tools/analyzeAll.js
+++ b/npm/src/tools/analyzeAll.js
@@ -227,18 +227,14 @@ async function processChunksParallel(chunks, extractionPrompt, maxWorkers, optio
 
 			active.add(promise);
 
-			if (options.debug) {
-				console.error(`[analyze_all] Started processing chunk ${chunk.id}/${chunk.total}`);
-			}
+			console.error(`[analyze_all] Started processing chunk ${chunk.id}/${chunk.total}`);
 		}
 
 		if (active.size > 0) {
 			const result = await Promise.race(active);
 			results.push(result);
 
-			if (options.debug) {
-				console.error(`[analyze_all] Completed chunk ${result.chunk.id}/${result.chunk.total}`);
-			}
+			console.error(`[analyze_all] Completed chunk ${result.chunk.id}/${result.chunk.total}`);
 		}
 	}
 

--- a/npm/tests/unit/issue487-analyzeAll-logging.test.js
+++ b/npm/tests/unit/issue487-analyzeAll-logging.test.js
@@ -1,0 +1,68 @@
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const analyzeAllPath = resolve(__dirname, '../../src/tools/analyzeAll.js');
+const searchPath = resolve(__dirname, '../../src/search.js');
+const delegatePath = resolve(__dirname, '../../src/delegate.js');
+
+const mockSearch = jest.fn();
+const mockDelegate = jest.fn();
+
+jest.unstable_mockModule(searchPath, () => ({ search: mockSearch }));
+jest.unstable_mockModule(delegatePath, () => ({ delegate: mockDelegate }));
+
+const { analyzeAll } = await import(analyzeAllPath);
+
+describe('Issue #487 - analyzeAll chunk-processing visibility', () => {
+  beforeEach(() => {
+    mockSearch.mockResolvedValue(
+      '```txt\nchunk-one-content\n```\n```txt\nchunk-two-content\n```'
+    );
+
+    mockDelegate.mockImplementation(async ({ task }) => {
+      if (task.includes('Use attempt_completion with this EXACT format')) {
+        return [
+          'SEARCH_QUERY: chunk',
+          'AGGREGATION: summarize',
+          'EXTRACTION_PROMPT: extract chunk facts'
+        ].join('\n');
+      }
+
+      if (task.includes('You are analyzing search results (chunk')) {
+        return '<result>chunk data</result>';
+      }
+
+      if (task.includes('Synthesize these analyses into a comprehensive summary')) {
+        return '<result>aggregated data</result>';
+      }
+
+      if (task.includes('Now provide a COMPREHENSIVE, DETAILED answer')) {
+        return '<result>final synthesized answer</result>';
+      }
+
+      return '<result>fallback</result>';
+    });
+  });
+
+  test('logs chunk start/completion even when debug=false', async () => {
+    const result = await analyzeAll({
+      question: 'What is in the chunks?',
+      path: '.',
+      chunkSizeTokens: 1,
+      maxChunks: 10,
+      debug: false
+    });
+
+    expect(result).toBe('final synthesized answer');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[analyze_all] Started processing chunk')
+    );
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[analyze_all] Completed chunk')
+    );
+  });
+});

--- a/npm/tests/unit/issue487-delegation-logging.test.js
+++ b/npm/tests/unit/issue487-delegation-logging.test.js
@@ -1,0 +1,94 @@
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const probeAgentPath = resolve(__dirname, '../../src/agent/ProbeAgent.js');
+const delegatePath = resolve(__dirname, '../../src/delegate.js');
+
+jest.unstable_mockModule(probeAgentPath, () => ({
+  ProbeAgent: jest.fn()
+}));
+
+const { DelegationManager } = await import(delegatePath);
+
+describe('Issue #487 - DelegationManager operational wait logging', () => {
+  let manager;
+
+  afterEach(() => {
+    if (manager) {
+      manager.cleanup();
+      manager = null;
+    }
+  });
+
+  test('logs when acquire() has to queue even when debug=false', async () => {
+    manager = new DelegationManager({ maxConcurrent: 1, queueTimeout: 2000 });
+
+    await manager.acquire('session-a', false);
+    const queuedAcquire = manager.acquire('session-b', false, 2000);
+    try {
+      await new Promise(resolve => setTimeout(resolve, 5));
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Slot unavailable')
+      );
+    } finally {
+      manager.release('session-a', false);
+      await queuedAcquire;
+      manager.release('session-b', false);
+    }
+  });
+
+  test('logs when queued item is granted even when debug=false', async () => {
+    manager = new DelegationManager({ maxConcurrent: 1, queueTimeout: 2000 });
+
+    await manager.acquire('session-a', false);
+    const queuedAcquire = manager.acquire('session-b', false, 2000);
+    try {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      console.error.mockClear();
+
+      manager.release('session-a', false);
+      await queuedAcquire;
+
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Granted slot from queue')
+      );
+    } finally {
+      if (manager.getStats().globalActive > 0) {
+        manager.release('session-b', false);
+      }
+    }
+  });
+
+  test('logs queued rejection on session-limit check even when debug=false', async () => {
+    manager = new DelegationManager({
+      maxConcurrent: 2,
+      maxPerSession: 1,
+      queueTimeout: 2000
+    });
+
+    await manager.acquire('session-a', false);
+    await manager.acquire('session-b', false);
+
+    const queuedAcquire = manager.acquire('session-a', false, 2000);
+    await new Promise(resolve => setTimeout(resolve, 5));
+
+    try {
+      console.error.mockClear();
+      manager.release('session-b', false);
+
+      await expect(queuedAcquire).rejects.toThrow(/Maximum delegations per session/);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('Session limit')
+      );
+    } finally {
+      if (manager.getStats().globalActive > 0) {
+        manager.release('session-a', false);
+      }
+    }
+  });
+});

--- a/npm/tests/unit/issue487-downloader-logging.test.js
+++ b/npm/tests/unit/issue487-downloader-logging.test.js
@@ -1,0 +1,134 @@
+import { jest } from '@jest/globals';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const downloaderPath = resolve(__dirname, '../../src/downloader.js');
+const directoryResolverPath = resolve(__dirname, '../../src/directory-resolver.js');
+const symlinkUtilsPath = resolve(__dirname, '../../src/utils/symlink-utils.js');
+
+async function loadDownloaderWithMocks({ fsMock, axiosMock, tarMock, getEntryTypeMock }) {
+  jest.resetModules();
+
+  jest.unstable_mockModule('fs-extra', () => ({
+    default: fsMock
+  }));
+
+  jest.unstable_mockModule('axios', () => ({
+    default: axiosMock
+  }));
+
+  jest.unstable_mockModule('tar', () => ({
+    default: tarMock
+  }));
+
+  jest.unstable_mockModule(directoryResolverPath, () => ({
+    getPackageBinDir: jest.fn().mockResolvedValue('/tmp/probe-issue-487')
+  }));
+
+  jest.unstable_mockModule(symlinkUtilsPath, () => ({
+    getEntryType: getEntryTypeMock
+  }));
+
+  return import(downloaderPath);
+}
+
+describe('Issue #487 - downloader lock visibility', () => {
+  test('logs cross-process lock wait and completion even without DEBUG/VERBOSE', async () => {
+    const fsMock = {
+      writeFile: jest.fn(async (_path, _content, opts) => {
+        if (opts?.flag === 'wx') {
+          const err = new Error('lock exists');
+          err.code = 'EEXIST';
+          throw err;
+        }
+      }),
+      readFile: jest.fn(async () => JSON.stringify({ pid: 777, timestamp: Date.now() })),
+      pathExists: jest
+        .fn()
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true)
+    };
+
+    const { downloadProbeBinary } = await loadDownloaderWithMocks({
+      fsMock,
+      axiosMock: { get: jest.fn(), isAxiosError: () => false },
+      tarMock: { extract: jest.fn() },
+      getEntryTypeMock: jest.fn()
+    });
+
+    await downloadProbeBinary('1.2.3');
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Download in progress by process')
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Binary now available')
+    );
+  });
+
+  test('logs in-process wait when a same-version download is already running', async () => {
+    let firstAssetRequest = true;
+
+    const fsMock = {
+      pathExists: jest.fn().mockResolvedValue(false),
+      ensureDir: jest.fn().mockResolvedValue(undefined),
+      writeFile: jest.fn(async (_path, _content, opts) => {
+        if (opts?.flag === 'wx') {
+          const err = new Error('permissions');
+          err.code = 'EACCES';
+          throw err;
+        }
+      }),
+      readFile: jest.fn(),
+      remove: jest.fn().mockResolvedValue(undefined),
+      readdir: jest.fn().mockResolvedValue([
+        {
+          name: 'probe-binary',
+          isFile: () => true,
+          isDirectory: () => false
+        }
+      ]),
+      copyFile: jest.fn().mockResolvedValue(undefined),
+      chmod: jest.fn().mockResolvedValue(undefined)
+    };
+
+    const axiosMock = {
+      get: jest.fn(async (_url, opts) => {
+        if (opts?.responseType === 'arraybuffer') {
+          if (firstAssetRequest) {
+            firstAssetRequest = false;
+            await new Promise(resolve => setTimeout(resolve, 30));
+          }
+          return { data: Buffer.from('fake-binary') };
+        }
+
+        throw new Error('no checksum');
+      }),
+      isAxiosError: () => false
+    };
+
+    const { downloadProbeBinary } = await loadDownloaderWithMocks({
+      fsMock,
+      axiosMock,
+      tarMock: { extract: jest.fn().mockResolvedValue(undefined) },
+      getEntryTypeMock: jest.fn().mockResolvedValue({
+        isFile: true,
+        isDirectory: false,
+        size: 11
+      })
+    });
+
+    const first = downloadProbeBinary('9.9.9');
+    await Promise.resolve();
+    const second = downloadProbeBinary('9.9.9');
+
+    await Promise.all([first, second]);
+
+    expect(console.log).toHaveBeenCalledWith(
+      expect.stringContaining('Download already in progress in this process')
+    );
+  });
+});

--- a/npm/tests/unit/issue487-dsl-map-logging.test.js
+++ b/npm/tests/unit/issue487-dsl-map-logging.test.js
@@ -1,0 +1,21 @@
+import { generateSandboxGlobals } from '../../src/agent/dsl/environment.js';
+
+describe('Issue #487 - DSL map concurrency visibility', () => {
+  test('logs when map() hits concurrency limit even without debug mode', async () => {
+    const globals = generateSandboxGlobals({
+      toolImplementations: {},
+      llmCall: async (_instruction, data) => {
+        await new Promise(resolve => setTimeout(resolve, 25));
+        return `processed:${data}`;
+      },
+      mapConcurrency: 1
+    });
+
+    const result = await globals.map([1, 2, 3], (item) => globals.LLM('process', item));
+
+    expect(result).toEqual(['processed:1', 'processed:2', 'processed:3']);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('[map] Concurrency limit reached')
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- add always-on operational logging for delegation queue waits and grants\n- add always-on lock wait/acquire/timeout logging for downloader cross-process and in-process locks\n- add map() concurrency-limit wait logging in DSL runtime\n- add always-on chunk start/complete logging in analyzeAll parallel processor\n- add issue-focused failing-first tests for delegation, downloader, map, and analyzeAll logging behavior\n\n## Validation\n- npm test -- --runTestsByPath tests/unit/issue487-delegation-logging.test.js tests/unit/issue487-downloader-logging.test.js tests/unit/issue487-dsl-map-logging.test.js tests/unit/issue487-analyzeAll-logging.test.js\n- npm test -- --runTestsByPath tests/unit/delegate-limits.test.js tests/unit/concurrency-limiter.test.js tests/unit/dsl-runtime.test.js tests/unit/analyzeAll.test.js\n\nCloses #487