### PR TITLE
fix: use Proxy to wrap read-only textStream on DefaultStreamTextResult

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1444,11 +1444,13 @@ export class ProbeAgent {
         result = await this._executeWithVercelProvider(options, controller);
       }
 
-      // Wrap textStream so limiter slot is held until stream completes
+      // Wrap textStream so limiter slot is held until stream completes.
+      // result.textStream is a read-only getter on DefaultStreamTextResult,
+      // so we wrap the result in a Proxy that intercepts the textStream property.
       if (limiter && result.textStream) {
         const originalStream = result.textStream;
         const debug = this.debug;
-        result.textStream = (async function* () {
+        const wrappedStream = (async function* () {
           try {
             for await (const chunk of originalStream) {
               yield chunk;
@@ -1461,6 +1463,13 @@ export class ProbeAgent {
             }
           }
         })();
+        return new Proxy(result, {
+          get(target, prop) {
+            if (prop === 'textStream') return wrappedStream;
+            const value = target[prop];
+            return typeof value === 'function' ? value.bind(target) : value;
+          }
+        });
       } else if (limiter) {
         // No textStream (shouldn't happen, but release just in case)
         limiter.release(null);


### PR DESCRIPTION
## Problem / Task

`streamTextWithRetryAndFallback` wraps `result.textStream` with a generator that holds the concurrency limiter slot until the stream completes. However, the Vercel AI SDK's `DefaultStreamTextResult` defines `textStream` as a getter-only property (no setter), causing:

```
TypeError: Cannot set property textStream of #<DefaultStreamTextResult> which has only a getter
```

This crashes the entire agent request.

## Changes

- **`npm/src/agent/ProbeAgent.js`**: Replace direct property assignment (`result.textStream = ...`) with a `Proxy` that intercepts the `textStream` getter and returns the wrapped stream. All other properties are transparently forwarded to the original result object.

## Testing

- All 2733 existing tests pass (1 pre-existing flaky LLM-as-judge test excluded)
- The fix is a minimal change — same wrapping logic, just using Proxy instead of direct assignment

```
npm test --prefix npm
```