### PR TITLE
fix: agent error resilience — consecutive error breaker and path error guidance

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -3508,6 +3508,7 @@ Follow these instructions carefully:
                     return true;
                   }
                 }
+
               }
 
               return false;
@@ -3535,6 +3536,24 @@ Follow these instructions carefully:
                     }
                     return { toolChoice: 'none' };
                   }
+                }
+              }
+
+              // Force text-only response after 3 consecutive tool errors
+              // (e.g. workspace deleted mid-run — let the model produce its answer)
+              if (steps.length >= 3) {
+                const last3 = steps.slice(-3);
+                const allErrors = last3.every(s =>
+                  s.toolResults?.length > 0 && s.toolResults.every(tr => {
+                    const r = typeof tr.result === 'string' ? tr.result : '';
+                    return r.includes('<error ') || r.includes('does not exist');
+                  })
+                );
+                if (allErrors) {
+                  if (this.debug) {
+                    console.log(`[DEBUG] prepareStep: 3 consecutive tool errors, forcing toolChoice=none`);
+                  }
+                  return { toolChoice: 'none' };
                 }
               }
 
@@ -3574,7 +3593,8 @@ Here is the result to review:
 ${resultToReview}
 </result>
 
-Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If something needs to be fixed or is missing, do it now, then respond with the COMPLETE updated answer (everything you did in total, not just the fix).`;
+IMPORTANT: First review ALL completed work in the conversation above before taking any action.
+Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If your text has inaccuracies, fix the text. Only call a tool if you find a genuinely MISSING action — NEVER redo work that was already completed successfully. Respond with the COMPLETE corrected answer.`;
 
                   return {
                     userMessage: completionPromptMessage,
@@ -3783,7 +3803,8 @@ Here is the result to review:
 ${finalResult}
 </result>
 
-Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If something needs to be fixed or is missing, do it now, then respond with the COMPLETE updated answer (everything you did in total, not just the fix).`;
+IMPORTANT: First review ALL completed work in the conversation above before taking any action.
+Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If your text has inaccuracies, fix the text. Only call a tool if you find a genuinely MISSING action — NEVER redo work that was already completed successfully. Respond with the COMPLETE corrected answer.`;
 
             currentMessages.push({ role: 'user', content: completionPromptMessage });
 

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -478,7 +478,11 @@ export const searchTool = (options = {}) => {
 					return result;
 				} catch (error) {
 					console.error('Error executing search command:', error);
-					return formatErrorForAI(error);
+					const formatted = formatErrorForAI(error);
+					if (error.category === 'path_error' || error.message?.includes('does not exist')) {
+						return formatted + '\n\nThe path does not exist. Use the listFiles tool to verify the correct directory structure before retrying. If the workspace itself is gone, output your final answer with whatever information you have.';
+					}
+					return formatted;
 				}
 			}
 

--- a/npm/src/utils/error-types.js
+++ b/npm/src/utils/error-types.js
@@ -181,14 +181,14 @@ export function categorizeError(error) {
       errorCode === 'enoent') {
     return new PathError(message, {
       originalError: error,
-      suggestion: 'The specified path does not exist. Please verify the path or use a different directory.'
+      suggestion: 'The specified path does not exist. Use the listFiles tool to check the correct directory structure, then retry with a valid path.'
     });
   }
 
   if (lowerMessage.includes('not a directory') || errorCode === 'enotdir') {
     return new PathError(message, {
       originalError: error,
-      suggestion: 'The path is not a directory. Please provide a valid directory path.'
+      suggestion: 'The path is not a directory. Use the listFiles tool to find the correct directory, then retry.'
     });
   }
 

--- a/npm/src/utils/path-validation.js
+++ b/npm/src/utils/path-validation.js
@@ -110,7 +110,7 @@ export async function validateCwdPath(inputPath, defaultPath = process.cwd()) {
 		}
 		if (error.code === 'ENOENT') {
 			throw new PathError(`Path does not exist: ${normalizedPath}`, {
-				suggestion: 'The specified path does not exist. Please verify the path is correct or use a different directory.',
+				suggestion: 'The specified path does not exist. Use the listFiles tool to check the correct directory structure, then retry with a valid path.',
 				details: { path: normalizedPath }
 			});
 		}

--- a/npm/tests/unit/circuit-breaker.test.js
+++ b/npm/tests/unit/circuit-breaker.test.js
@@ -109,6 +109,42 @@ describe('ProbeAgent circuit breaker for repeated tool calls', () => {
     jest.restoreAllMocks();
   });
 
+  test('prepareStep forces toolChoice=none after 3 consecutive tool errors', async () => {
+    const agent = createMockedAgent();
+
+    let capturedOptions = null;
+    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (opts) => {
+      capturedOptions = opts;
+      return createMockStreamResult('Answer');
+    });
+
+    agent.answer('test question').catch(() => {});
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    const { prepareStep } = capturedOptions;
+
+    // 3 consecutive steps where all tool results are errors → force text output
+    const errorResult = '<error type="path_error" recoverable="true"><message>Path does not exist: /tmp/workspace</message></error>';
+    const errorSteps = [
+      { toolCalls: [{ toolName: 'search', args: { query: 'from' } }], toolResults: [{ result: errorResult }], finishReason: 'tool-calls' },
+      { toolCalls: [{ toolName: 'search', args: { query: 'require' } }], toolResults: [{ result: errorResult }], finishReason: 'tool-calls' },
+      { toolCalls: [{ toolName: 'search', args: { query: 'use' } }], toolResults: [{ result: errorResult }], finishReason: 'tool-calls' },
+    ];
+    const result = prepareStep({ steps: errorSteps, stepNumber: 4 });
+    expect(result).toEqual({ toolChoice: 'none' });
+
+    // Mixed results (some errors, some success) should NOT force text-only
+    const mixedSteps = [
+      { toolCalls: [{ toolName: 'search', args: { query: 'one' } }], toolResults: [{ result: errorResult }], finishReason: 'tool-calls' },
+      { toolCalls: [{ toolName: 'search', args: { query: 'two' } }], toolResults: [{ result: 'some results' }], finishReason: 'tool-calls' },
+      { toolCalls: [{ toolName: 'search', args: { query: 'three' } }], toolResults: [{ result: errorResult }], finishReason: 'tool-calls' },
+    ];
+    const mixedResult = prepareStep({ steps: mixedSteps, stepNumber: 4 });
+    expect(mixedResult?.toolChoice).toBeUndefined();
+
+    jest.restoreAllMocks();
+  });
+
   test('prepareStep forces toolChoice=none after 2 consecutive identical tool calls', async () => {
     const agent = createMockedAgent();
 

--- a/npm/tests/unit/completion-prompt.test.js
+++ b/npm/tests/unit/completion-prompt.test.js
@@ -154,13 +154,14 @@ Here is the result to review:
 ${finalResult}
 </result>
 
-Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If something needs to be fixed or is missing, do it now, then respond with the COMPLETE updated answer (everything you did in total, not just the fix).`;
+IMPORTANT: First review ALL completed work in the conversation above before taking any action.
+Double-check your response based on the criteria above. If everything looks good, respond with your previous answer exactly as-is. If your text has inaccuracies, fix the text. Only call a tool if you find a genuinely MISSING action — NEVER redo work that was already completed successfully. Respond with the COMPLETE corrected answer.`;
 
     expect(formattedMessage).toContain(completionPrompt);
     expect(formattedMessage).toContain(finalResult);
     expect(formattedMessage).toContain('<result>');
     expect(formattedMessage).toContain('</result>');
-    expect(formattedMessage).toContain('Double-check your response');
+    expect(formattedMessage).toContain('NEVER redo work');
     expect(formattedMessage).toContain('respond with your previous answer exactly as-is');
   });
 });


### PR DESCRIPTION
## Problem / Task

When the workspace is deleted mid-run (e.g. temp workspace cleanup), the agent spirals through all 34 iterations searching for stopwords ("from", "require", "use", "let") because every search fails with PathError but the existing circuit breaker only catches *identical* tool calls. Path error messages were also unhelpful — they said "verify the path" without telling the AI *how*.

Additionally, the completion prompt review pass sometimes re-executed already-completed tools instead of just reviewing the text.

## Changes

### Consecutive error circuit breaker (`npm/src/agent/ProbeAgent.js`)
- After 3 consecutive tool calls that all return errors, `prepareStep` forces `toolChoice: 'none'` so the model must produce text
- Soft approach: doesn't kill the agent — model can recover on next step if it has useful info

### Path error guidance (`npm/src/utils/path-validation.js`, `npm/src/utils/error-types.js`, `npm/src/tools/vercel.js`)
- All PathError suggestions now recommend using `listFiles` tool to verify correct directory structure
- Search tool appends extra hint about listFiles or outputting final answer if workspace is gone

### Completion prompt fix (`npm/src/agent/ProbeAgent.js`)
- Updated wording: review ALL completed work before acting, only call tools for genuinely MISSING actions, NEVER redo completed work

## Testing

- `npm/tests/unit/circuit-breaker.test.js` — new test for consecutive-error detection (positive + negative)
- `npm/tests/unit/completion-prompt.test.js` — updated to match new prompt wording
- All 2734 tests pass

```
npm test --prefix npm
```