### PR TITLE
fix: sanitize hyphenated MCP tool names in execute_plan DSL

### DIFF
--- a/npm/src/agent/dsl/environment.js
+++ b/npm/src/agent/dsl/environment.js
@@ -234,7 +234,14 @@ export function generateSandboxGlobals(options) {
         }
         return tryParseJSONValue(text);
       };
-      globals[name] = traceToolCall(name, rawMcpFn, tracer, logFn);
+      const tracedFn = traceToolCall(name, rawMcpFn, tracer, logFn);
+      globals[name] = tracedFn;
+      // Register sanitized alias for names with hyphens/dots/etc that aren't valid JS identifiers
+      // e.g. "workable-api" → also available as "workable_api"
+      const sanitized = name.replace(/[^a-zA-Z0-9_$]/g, '_');
+      if (sanitized !== name) {
+        globals[sanitized] = tracedFn;
+      }
     }
   }
 

--- a/npm/src/agent/dsl/runtime.js
+++ b/npm/src/agent/dsl/runtime.js
@@ -181,9 +181,17 @@ export function createDSLRuntime(options) {
         'dsl.error': e.message?.substring(0, 500),
       });
 
+      // Enrich "X is not defined" errors with available tool names
+      let errorMsg = `Execution failed: ${e.message}`;
+      if (e.message && e.message.includes('is not defined')) {
+        const globalNames = Object.keys(toolGlobals).sort();
+        errorMsg += `\nAvailable functions: ${globalNames.join(', ')}`;
+        errorMsg += `\nNote: Tools with hyphens (e.g. "my-tool") are available with underscores: my_tool()`;
+      }
+
       return {
         status: 'error',
-        error: `Execution failed: ${e.message}`,
+        error: errorMsg,
         logs,
       };
     }

--- a/npm/src/tools/executePlan.js
+++ b/npm/src/tools/executePlan.js
@@ -778,6 +778,7 @@ return table;
 - Do NOT define helper functions that call tools. Write all logic inline or use for..of loops.
 - Do NOT use regex literals (/pattern/) — use String methods like indexOf, includes, startsWith instead.
 - ONLY use functions listed below. Do NOT call functions that are not listed.
+- MCP tools with hyphens in their names (e.g. \`workable-api\`) are available using underscores: \`workable_api()\`. Hyphens are not valid in JS identifiers.
 
 ### Available functions
 


### PR DESCRIPTION
## Summary

MCP tools with hyphens in their names (e.g. `workable-api`) are **uncallable** inside `execute_plan` DSL code because JavaScript parses `workable-api()` as `workable - api()` (subtraction operator), not a function call.

### Root cause

In `environment.js`, MCP tools are registered as sandbox globals using their original name:
```js
globals[name] = traceToolCall(name, rawMcpFn, tracer, logFn);
```
When `name` is `workable-api`, this sets `globals['workable-api']` — accessible via bracket notation but **not as a function call** in JS. The AI tries `workable-api()`, gets `"workable is not defined"` (JS interprets it as `workable - api()`), then tries `workableApi()`, `workable_api()`, `__tools___workable_api()` — none match, exhausting all retries.

### Reproduction

```js
const runtime = createDSLRuntime({
  mcpBridge: { fake: true },
  mcpTools: { 'workable-api': mockTool },
  // ...
});

// FAILS: "workable is not defined" (parsed as subtraction)
await runtime.execute(`workable-api({ endpoint: "/jobs" })`);

// WORKS (with this fix): underscore alias
await runtime.execute(`workable_api({ endpoint: "/jobs" })`);
```

### Changes

- **`environment.js`** — Register underscore alias for hyphenated MCP tool names (`workable-api` → also `workable_api`)
- **`runtime.js`** — On `"X is not defined"` errors, append available function names + hint about hyphen→underscore convention
- **`executePlan.js`** — Add DSL documentation note about the underscore convention

### Observed in production

Trace `8f62cee9ef9b2fd8cdcf955ae583a78f`: 51 delegation sub-agents all failing because `workable-api` was not callable in DSL. The AI burned through all iteration budget trying random name variants.

## Test plan

- [x] Reproduction script confirms `workable_api()` works after fix
- [x] `workable-api()` still fails but now shows helpful error with available function list
- [x] Tools without hyphens are unaffected
- [ ] E2E test with actual MCP http_client tool (workable-api)

🤖 Generated with [Claude Code](https://claude.com/claude-code)