### PR TITLE
fix: gate concurrency limiter per-LLM-call instead of per-session (#512)

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1490,6 +1490,38 @@ export class ProbeAgent {
   }
 
   /**
+   * Wrap an engine stream result so its textStream async generator acquires
+   * and releases a concurrency limiter slot. Acquire happens when iteration
+   * begins; release happens in finally (completion, error, or break).
+   *
+   * @param {Object} result - Engine result with { textStream, usage, ... }
+   * @param {Object} limiter - Concurrency limiter with acquire/release/getStats
+   * @param {boolean} debug - Enable debug logging
+   * @returns {Object} Result with wrapped textStream
+   * @private
+   */
+  static _wrapEngineStreamWithLimiter(result, limiter, debug) {
+    const originalStream = result.textStream;
+    async function* gatedStream() {
+      await limiter.acquire(null);
+      if (debug) {
+        const stats = limiter.getStats();
+        console.log(`[DEBUG] Acquired AI slot for engine stream (${stats.globalActive}/${stats.maxConcurrent}, queue: ${stats.queueSize})`);
+      }
+      try {
+        yield* originalStream;
+      } finally {
+        limiter.release(null);
+        if (debug) {
+          const stats = limiter.getStats();
+          console.log(`[DEBUG] Released AI slot after engine stream (${stats.globalActive}/${stats.maxConcurrent})`);
+        }
+      }
+    }
+    return { ...result, textStream: gatedStream() };
+  }
+
+  /**
    * Execute streamText with retry and fallback support
    * @param {Object} options - streamText options
    * @returns {Promise<Object>} - streamText result
@@ -1540,6 +1572,12 @@ export class ProbeAgent {
       if (useClaudeCode || useCodex) {
         try {
           result = await this._tryEngineStreamPath(options, controller, timeoutState);
+          // Gate engine stream with concurrency limiter if configured.
+          // Engine paths bypass the Vercel model wrapper, so we wrap the
+          // textStream async generator with acquire/release instead.
+          if (result && limiter) {
+            result = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, this.debug);
+          }
         } catch (error) {
           if (this.debug) {
             const engineType = useClaudeCode ? 'Claude Code' : 'Codex';

--- a/npm/tests/unit/concurrency-per-call.test.js
+++ b/npm/tests/unit/concurrency-per-call.test.js
@@ -509,6 +509,77 @@ describe('Per-LLM-call concurrency limiter — issue #512', () => {
       expect(limiter.totalReleases).toBe(1);
     });
 
+    test('engine stream wrapper acquires and releases slot', async () => {
+      async function* fakeEngineStream() {
+        yield 'chunk1';
+        yield 'chunk2';
+        yield 'chunk3';
+      }
+      const result = { textStream: fakeEngineStream(), usage: Promise.resolve({}) };
+      const wrapped = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, false);
+
+      expect(limiter.active).toBe(0);
+      const chunks = [];
+      for await (const chunk of wrapped.textStream) {
+        // Slot should be held while iterating
+        expect(limiter.active).toBe(1);
+        chunks.push(chunk);
+      }
+      expect(chunks).toEqual(['chunk1', 'chunk2', 'chunk3']);
+      expect(limiter.active).toBe(0);
+      expect(limiter.totalAcquires).toBe(1);
+      expect(limiter.totalReleases).toBe(1);
+    });
+
+    test('engine stream wrapper releases slot on error', async () => {
+      async function* failingEngineStream() {
+        yield 'ok';
+        throw new Error('engine error');
+      }
+      const result = { textStream: failingEngineStream(), usage: Promise.resolve({}) };
+      const wrapped = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, false);
+
+      const chunks = [];
+      try {
+        for await (const chunk of wrapped.textStream) {
+          chunks.push(chunk);
+        }
+      } catch (err) {
+        expect(err.message).toBe('engine error');
+      }
+      expect(chunks).toEqual(['ok']);
+      expect(limiter.active).toBe(0);
+      expect(limiter.totalReleases).toBe(1);
+    });
+
+    test('engine stream wrapper releases slot on early break', async () => {
+      async function* longEngineStream() {
+        yield 'a';
+        yield 'b';
+        yield 'c';
+        yield 'd';
+        yield 'e';
+      }
+      const result = { textStream: longEngineStream(), usage: Promise.resolve({}) };
+      const wrapped = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, false);
+
+      for await (const chunk of wrapped.textStream) {
+        if (chunk === 'b') break; // early exit
+      }
+      expect(limiter.active).toBe(0);
+      expect(limiter.totalReleases).toBe(1);
+    });
+
+    test('engine stream wrapper preserves other result properties', () => {
+      async function* emptyStream() {}
+      const usage = Promise.resolve({ tokens: 100 });
+      const result = { textStream: emptyStream(), usage, extra: 'metadata' };
+      const wrapped = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, false);
+
+      expect(wrapped.usage).toBe(usage);
+      expect(wrapped.extra).toBe('metadata');
+    });
+
     test('each retry attempt independently acquires and releases', async () => {
       let callCount = 0;
       const model = createMockModel();


### PR DESCRIPTION
## Summary
- Fixes #512: `concurrencyLimiter` was holding the slot for the entire multi-step agent session (`streamText` with `maxSteps`), blocking all other sessions during tool execution time
- Wraps the LanguageModelV1 model with a Proxy that intercepts `doStream`/`doGenerate` to acquire/release the concurrency slot per individual LLM API call
- Stream completion, error, and cancellation all properly release the slot via ReadableStream wrapping
- Fallback model paths also get the per-call limiter wrapper

## Test plan
- [x] 19 new unit tests in `concurrency-per-call.test.js` covering:
  - doStream acquire/release lifecycle
  - Stream error and cancellation release slots
  - doStream throw releases slot
  - Property passthrough (specificationVersion, provider, modelId, custom methods)
  - doGenerate acquire/release and error handling
  - Multi-step simulation verifying slot released between steps
  - Concurrent session interleaving with queuing
  - Tool execution does not hold a slot
  - Debug logging toggle
  - Edge cases: empty stream, 50-call leak test, mixed doStream/doGenerate
- [x] All 29 concurrency-related tests pass (19 new + 10 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)