### PR TITLE
fix: exact search fails for camelCase symbols (#525)

### DIFF
--- a/src/search/elastic_query.rs
+++ b/src/search/elastic_query.rs
@@ -224,7 +224,8 @@ impl Expr {
                     } else {
                         // No required terms: treat multiple keywords within a Term as alternatives
                         // This avoids false negatives for stemming variants (e.g., repository/repositori).
-                        keywords.iter().any(|kw| {
+                        // Use lowercase_keywords for lookup since term_indices stores lowercase keys.
+                        lowercase_keywords.iter().any(|kw| {
                             term_indices
                                 .get(kw)
                                 .map(|idx| matched_terms.contains(idx))

--- a/src/search/elastic_query_evaluate_tests.rs
+++ b/src/search/elastic_query_evaluate_tests.rs
@@ -494,3 +494,62 @@ fn test_required_term_in_or_bug() {
     println!("Test 4 - No terms present: matched_terms={matched_terms:?}, result={result}");
     assert!(!result, "Should return false when no terms are present");
 }
+
+#[test]
+fn test_exact_camel_case_evaluate_uses_lowercase_keywords() {
+    // Issue #525: exact search for camelCase symbols fails because evaluate()
+    // uses `keywords` (original case) for term_indices lookup instead of
+    // `lowercase_keywords`. term_indices stores lowercase keys, so lookup
+    // with original case like "cleanupScopeMappings" returns None.
+    //
+    // This is the root cause of --exact missing real camelCase symbols.
+
+    // term_indices always stores lowercase keys (built from lowercase_keywords)
+    let term_indices = create_term_indices(&["cleanupscopemappings"]);
+
+    // Exact term preserves original case in `keywords` but lowercase in `lowercase_keywords`
+    let expr = create_exact_term("cleanupScopeMappings");
+
+    // The regex pattern finds the symbol in source → matched_terms = {0}
+    let matched_terms = create_matched_terms(&[0]);
+
+    // This SHOULD return true: the term was found by regex search
+    let result = expr.evaluate(&matched_terms, &term_indices, false);
+    assert!(
+        result,
+        "Exact camelCase term should match when term index 0 is present in matched_terms. \
+         Bug: evaluate() uses original-case keywords for term_indices lookup instead of lowercase_keywords."
+    );
+
+    // Also test with ignore_negatives=true (used in early filtering)
+    let result_ignore_neg = expr.evaluate(&matched_terms, &term_indices, true);
+    assert!(
+        result_ignore_neg,
+        "Exact camelCase term should match with ignore_negatives=true"
+    );
+}
+
+#[test]
+fn test_exact_camel_case_all_present_uses_lowercase() {
+    // Verify that the `all_present` check (used for required terms) also works
+    // for exact camelCase terms
+    let term_indices = create_term_indices(&["cleanupscopemappings"]);
+
+    let expr = Expr::Term {
+        keywords: vec!["cleanupScopeMappings".to_string()],
+        lowercase_keywords: vec!["cleanupscopemappings".to_string()],
+        field: None,
+        required: true,
+        excluded: false,
+        exact: true,
+    };
+
+    let matched_terms = create_matched_terms(&[0]);
+
+    // Required exact camelCase term should match
+    let result = expr.evaluate(&matched_terms, &term_indices, false);
+    assert!(
+        result,
+        "Required exact camelCase term should match via lowercase_keywords lookup"
+    );
+}


### PR DESCRIPTION
## Summary

- `--exact` and quoted search silently failed for mixed-case symbols like `cleanupScopeMappings`
- Root cause: one evaluation path in `Expr::evaluate()` used `keywords` (original case) for `term_indices` lookup, but `term_indices` always stores lowercase keys
- Fix: use `lowercase_keywords` instead, consistent with all other lookup paths in the same function

## Details

The regex search correctly found the symbol (case-insensitive via `(?i)`), but `evaluate()` couldn't map the keyword back to its term index because `term_indices.get("cleanupScopeMappings")` returned `None` — the key is stored as `"cleanupscopemappings"`.

This only affected exact/quoted search with mixed-case terms. Non-exact search was unaffected because tokenization already lowercases keywords.

## Test plan

- [x] Added `test_exact_camel_case_evaluate_uses_lowercase_keywords` — verifies the core bug
- [x] Added `test_exact_camel_case_all_present_uses_lowercase` — verifies required exact terms
- [x] End-to-end: `probe search --exact cleanupScopeMappings` now returns results
- [x] End-to-end: `probe search '"cleanupScopeMappings"'` now returns results
- [x] All 309 unit tests + 10 integration tests pass (pre-commit hook verified)

Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)