### PR TITLE
fix: non-blocking circuit breaker, language-aware dedup, delegate NaN guard

### DIFF
--- a/npm/src/delegate.js
+++ b/npm/src/delegate.js
@@ -20,13 +20,14 @@ import { ProbeAgent } from './agent/ProbeAgent.js';
  */
 class DelegationManager {
 	constructor(options = {}) {
+		const parseSafe = (val, fallback) => { const n = parseInt(val, 10); return Number.isNaN(n) ? fallback : n; };
 		this.maxConcurrent = options.maxConcurrent
-			?? parseInt(process.env.MAX_CONCURRENT_DELEGATIONS || '3', 10);
+			?? parseSafe(process.env.MAX_CONCURRENT_DELEGATIONS, 3);
 		this.maxPerSession = options.maxPerSession
-			?? parseInt(process.env.MAX_DELEGATIONS_PER_SESSION || '10', 10);
+			?? parseSafe(process.env.MAX_DELEGATIONS_PER_SESSION, 10);
 		// Default queue timeout: 60 seconds. Set DELEGATION_QUEUE_TIMEOUT=0 to disable.
 		this.defaultQueueTimeout = options.queueTimeout
-			?? parseInt(process.env.DELEGATION_QUEUE_TIMEOUT || '60000', 10);
+			?? parseSafe(process.env.DELEGATION_QUEUE_TIMEOUT, 60000);
 
 		// Track delegations per session with timestamp for potential TTL cleanup
 		// Map<string, { count: number, lastUpdated: number }>
@@ -545,6 +546,9 @@ export async function delegate({
 		// Phase 2: Hard cancel after deadline if subagent hasn't finished
 		let parentAbortHandler;
 		let parentAbortHardCancelId = null;
+		// Track whether the race has settled so late abort signals don't create
+		// unhandled promise rejections.
+		let raceSettled = false;
 		const parentAbortPromise = new Promise((_, reject) => {
 			if (parentAbortSignal) {
 				if (parentAbortSignal.aborted) {
@@ -553,6 +557,8 @@ export async function delegate({
 					return;
 				}
 				parentAbortHandler = () => {
+					// If the race already settled, the answer won — don't reject.
+					if (raceSettled) return;
 					// Phase 1: graceful wind-down — let subagent finish its current step
 					subagent.triggerGracefulWindDown();
 					if (debug) {
@@ -567,6 +573,7 @@ export async function delegate({
 					}
 					// Phase 2: hard cancel after 30s if subagent hasn't finished
 					parentAbortHardCancelId = setTimeout(() => {
+						if (raceSettled) return;
 						if (debug) {
 							console.error(`[DELEGATE] Graceful wind-down deadline expired — hard cancelling subagent ${sessionId}`);
 						}
@@ -594,6 +601,8 @@ export async function delegate({
 		try {
 			response = await Promise.race(racers);
 		} finally {
+			// Mark race as settled so late abort signals are ignored
+			raceSettled = true;
 			// Clean up parent abort listener and hard cancel timer to prevent memory leaks
 			if (parentAbortHandler && parentAbortSignal) {
 				parentAbortSignal.removeEventListener('abort', parentAbortHandler);

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -508,7 +508,8 @@ export const searchTool = (options = {}) => {
 				// Block duplicate non-paginated searches (models sometimes repeat the exact same call)
 				// Allow pagination: only nextPage=true is a legitimate repeat of the same query
 				// Include path in dedup key so same query across different repos is allowed (#520)
-				const searchKey = `${searchPath}::${searchQuery}::${exact || false}`;
+				const searchKey = `${searchPath}::${searchQuery}::${exact || false}::${language || ''}`;
+				let circuitBreakerWarning = '';
 				if (!nextPage) {
 					if (previousSearches.has(searchKey)) {
 						const blockCount = (dupBlockCounts.get(searchKey) || 0) + 1;
@@ -548,16 +549,20 @@ export const searchTool = (options = {}) => {
 					}
 
 					// Circuit breaker: too many consecutive no-result searches means the model
-					// is stuck in a loop guessing names that don't exist
+					// is stuck in a loop guessing names that don't exist.
+					// Not permanent: allow the search through but prepend a strong warning.
+					// If it succeeds, consecutiveNoResults resets to 0 (line ~598).
+					// If it fails, the counter keeps climbing and subsequent attempts
+					// get increasingly stern warnings.
 					if (consecutiveNoResults >= MAX_CONSECUTIVE_NO_RESULTS) {
 						if (debug) {
-							console.error(`[CIRCUIT-BREAKER] ${consecutiveNoResults} consecutive no-result searches, blocking: "${searchQuery}"`);
+							console.error(`[CIRCUIT-BREAKER] ${consecutiveNoResults} consecutive no-result searches, warning: "${searchQuery}"`);
 						}
 						const isSubfolderCB = path && path !== effectiveSearchCwd && path !== '.';
 						const cbScopeHint = isSubfolderCB
-							? `\n- You have been searching in "${path}" — try searching from the workspace root or a different directory`
+							? ` You have been searching in "${path}" — consider searching from the workspace root or a different directory.`
 							: '';
-						return `CIRCUIT BREAKER: Your last ${consecutiveNoResults} searches ALL returned no results. You appear to be guessing function/type names that don't match what's actually in the code.\n\nChange your approach:${cbScopeHint}\n1. Use extract on files you already found — read the actual code to discover real function names\n2. Use listFiles to browse directories and see what files/functions actually exist\n3. If you found some results earlier, those are likely sufficient — provide your final answer\n\nRetrying search query variations will not help. Discover real names from real code instead.`;
+						circuitBreakerWarning = `\n\n⚠️ CIRCUIT BREAKER: Your last ${consecutiveNoResults} searches ALL returned no results.${cbScopeHint} You MUST change your approach: use extract on files you already found, use listFiles to browse directories, or provide your final answer. Guessing names will not help.`;
 					}
 				} else {
 					// Cap pagination to prevent runaway page-through of broad queries
@@ -583,10 +588,10 @@ export const searchTool = (options = {}) => {
 						}
 						// Append contextual hint for ticket/issue ID queries
 						if (/^[A-Z]+-\d+$/.test(searchQuery.trim()) || /^[A-Z]+-\d+$/.test(searchQuery.replace(/"/g, '').trim())) {
-							return result + '\n\n⚠️ Your query looks like a ticket/issue ID (e.g., JIRA-1234). Ticket IDs are rarely present in source code. Search for the technical concepts described in the ticket instead (e.g., function names, error messages, variable names).';
+							return result + '\n\n⚠️ Your query looks like a ticket/issue ID (e.g., JIRA-1234). Ticket IDs are rarely present in source code. Search for the technical concepts described in the ticket instead (e.g., function names, error messages, variable names).' + circuitBreakerWarning;
 						}
 						// Add a hint when approaching the circuit breaker threshold
-						if (consecutiveNoResults >= MAX_CONSECUTIVE_NO_RESULTS - 1) {
+						if (consecutiveNoResults >= MAX_CONSECUTIVE_NO_RESULTS - 1 && !circuitBreakerWarning) {
 							const isSubfolderWarn = path && path !== effectiveSearchCwd && path !== '.';
 							const warnScopeHint = isSubfolderWarn
 								? ` You are searching in "${path}" — consider searching from the workspace root or a different directory.`
@@ -603,7 +608,7 @@ export const searchTool = (options = {}) => {
 					if (options.fileTracker && typeof result === 'string') {
 						options.fileTracker.trackFilesFromOutput(result, effectiveSearchCwd).catch(() => {});
 					}
-					return result;
+					return typeof result === 'string' ? result + circuitBreakerWarning : result;
 				} catch (error) {
 					console.error('Error executing search command:', error);
 					const formatted = formatErrorForAI(error);

--- a/npm/tests/unit/concept-dedup-counter.test.js
+++ b/npm/tests/unit/concept-dedup-counter.test.js
@@ -102,6 +102,17 @@ describe('Concept dedup counter', () => {
 		expect(mockSearch).toHaveBeenCalledTimes(3); // all 3 ran real searches
 	});
 
+	test('same query with different language param is not deduped', async () => {
+		// Search for "class Foo" in python
+		await tool.execute({ query: 'class Foo', path: '/test', language: 'python' });
+
+		// Same query in java — different language, should NOT be blocked
+		const r = await tool.execute({ query: 'class Foo', path: '/test', language: 'java' });
+		expect(r).toContain('No results found');
+		expect(r).not.toContain('DUPLICATE SEARCH BLOCKED');
+		expect(mockSearch).toHaveBeenCalledTimes(2);
+	});
+
 	test('same concept in different paths tracked independently', async () => {
 		// Fail in path /test/src twice
 		await tool.execute({ query: 'ctxGetData', path: '/test/src' });
@@ -130,18 +141,40 @@ describe('Concept dedup counter', () => {
 		expect(r).not.toContain('CIRCUIT BREAKER');
 	});
 
-	test('circuit breaker triggers after 4 consecutive no-result searches', async () => {
+	test('circuit breaker warns after 4 consecutive no-result searches but still executes', async () => {
 		// 4 consecutive no-result searches with different concepts
 		await tool.execute({ query: 'missing1', path: '/test' });
 		await tool.execute({ query: 'missing2', path: '/test' });
 		await tool.execute({ query: 'missing3', path: '/test' });
 		await tool.execute({ query: 'missing4', path: '/test' });
 
-		// 5th should be blocked by circuit breaker
+		// 5th gets circuit breaker WARNING appended, but search still runs
 		const r = await tool.execute({ query: 'missing5', path: '/test' });
 		expect(r).toContain('CIRCUIT BREAKER');
-		// Search was NOT executed for the 5th
+		expect(r).toContain('No results found');
+		// Search WAS executed — circuit breaker is non-blocking
+		expect(mockSearch).toHaveBeenCalledTimes(5);
+	});
+
+	test('circuit breaker resets when a search succeeds after threshold', async () => {
+		// 4 consecutive no-result searches
+		await tool.execute({ query: 'missing1', path: '/test' });
+		await tool.execute({ query: 'missing2', path: '/test' });
+		await tool.execute({ query: 'missing3', path: '/test' });
+		await tool.execute({ query: 'missing4', path: '/test' });
 		expect(mockSearch).toHaveBeenCalledTimes(4);
+
+		// 5th search succeeds — should reset the counter
+		mockSearchResult = 'Found: function realCode() { ... }';
+		const r5 = await tool.execute({ query: 'realCode', path: '/test' });
+		expect(r5).toContain('Found: function realCode');
+		expect(mockSearch).toHaveBeenCalledTimes(5);
+
+		// After reset, new no-result search should NOT have circuit breaker warning
+		mockSearchResult = 'No results found';
+		const r6 = await tool.execute({ query: 'anotherMissing', path: '/test' });
+		expect(r6).toContain('No results found');
+		expect(r6).not.toContain('CIRCUIT BREAKER');
 	});
 
 	test('concept dedup fires before circuit breaker when applicable', async () => {

--- a/npm/tests/unit/delegate-limits.test.js
+++ b/npm/tests/unit/delegate-limits.test.js
@@ -28,7 +28,7 @@ jest.unstable_mockModule(probeAgentPath, () => ({
 }));
 
 // Import after mocking
-const { delegate, cleanupDelegationManager, getDelegationStats } = await import(delegatePath);
+const { delegate, cleanupDelegationManager, getDelegationStats, DelegationManager } = await import(delegatePath);
 
 describe('Delegate Tool Security and Limits (SDK-based)', () => {
   beforeEach(() => {
@@ -631,6 +631,42 @@ describe('Delegate Tool Security and Limits (SDK-based)', () => {
       // Aborting after completion should NOT trigger cancel
       controller.abort();
       expect(mockCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DelegationManager NaN protection', () => {
+    it('should use defaults when env vars are non-numeric', () => {
+      const origConcurrent = process.env.MAX_CONCURRENT_DELEGATIONS;
+      const origPerSession = process.env.MAX_DELEGATIONS_PER_SESSION;
+      const origQueueTimeout = process.env.DELEGATION_QUEUE_TIMEOUT;
+      try {
+        process.env.MAX_CONCURRENT_DELEGATIONS = 'abc';
+        process.env.MAX_DELEGATIONS_PER_SESSION = 'not-a-number';
+        process.env.DELEGATION_QUEUE_TIMEOUT = '';
+        const mgr = new DelegationManager();
+        expect(mgr.maxConcurrent).toBe(3);
+        expect(mgr.maxPerSession).toBe(10);
+        expect(mgr.defaultQueueTimeout).toBe(60000);
+      } finally {
+        if (origConcurrent === undefined) delete process.env.MAX_CONCURRENT_DELEGATIONS;
+        else process.env.MAX_CONCURRENT_DELEGATIONS = origConcurrent;
+        if (origPerSession === undefined) delete process.env.MAX_DELEGATIONS_PER_SESSION;
+        else process.env.MAX_DELEGATIONS_PER_SESSION = origPerSession;
+        if (origQueueTimeout === undefined) delete process.env.DELEGATION_QUEUE_TIMEOUT;
+        else process.env.DELEGATION_QUEUE_TIMEOUT = origQueueTimeout;
+      }
+    });
+
+    it('should use valid env var values when provided', () => {
+      const origConcurrent = process.env.MAX_CONCURRENT_DELEGATIONS;
+      try {
+        process.env.MAX_CONCURRENT_DELEGATIONS = '5';
+        const mgr = new DelegationManager();
+        expect(mgr.maxConcurrent).toBe(5);
+      } finally {
+        if (origConcurrent === undefined) delete process.env.MAX_CONCURRENT_DELEGATIONS;
+        else process.env.MAX_CONCURRENT_DELEGATIONS = origConcurrent;
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Circuit breaker is no longer permanent**: Previously, after 4 consecutive no-result searches, all future searches were blocked for the entire session with no way to recover. Now the circuit breaker appends a strong warning but lets the search execute — if it succeeds, the counter resets to 0.
- **Language-aware dedup key**: Search dedup key now includes the `language` parameter, so `search("class Foo", language=python)` followed by `search("class Foo", language=java)` is no longer incorrectly blocked as a duplicate.
- **Delegate NaN guard**: `DelegationManager` env var parsing (`MAX_CONCURRENT_DELEGATIONS`, `MAX_DELEGATIONS_PER_SESSION`, `DELEGATION_QUEUE_TIMEOUT`) now guards against `NaN` from invalid values (e.g. `abc`), falling back to defaults instead of silently disabling concurrency limits.
- **Delegate abort race condition**: Late abort signals that fire after `Promise.race` settles no longer create unhandled promise rejections that could crash Node.js.

## Test plan

- [x] Updated circuit breaker test: verifies warning is appended but search still executes (5 calls, not 4)
- [x] New test: circuit breaker resets when a search succeeds after threshold
- [x] New test: same query with different `language` param is not deduped
- [x] New test: DelegationManager uses defaults when env vars are non-numeric
- [x] New test: DelegationManager uses valid env var values when provided
- [x] Full test suite: 3060/3061 pass (1 flaky LLM integration test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)