### PR TITLE
feat: add readMedia tool with PDF support

### DIFF
--- a/docs/probe-agent/sdk/tools-reference.md
+++ b/docs/probe-agent/sdk/tools-reference.md
@@ -11,7 +11,7 @@ ProbeAgent provides a comprehensive set of tools that the AI can use to interact
 | **Search & Query** | search, query, extract | Find and retrieve code |
 | **File Operations** | edit, create, listFiles, searchFiles | Modify and explore files |
 | **Execution** | bash | Run shell commands |
-| **Analysis** | analyze_all, readImage | Comprehensive analysis |
+| **Analysis** | analyze_all, readMedia | Comprehensive analysis |
 | **Agent Control** | delegate, attempt_completion | Orchestration and completion |
 | **Skills** | listSkills, useSkill | Dynamic capabilities |
 | **Tasks** | task | Multi-step tracking |
@@ -599,23 +599,36 @@ Comprehensive codebase analysis.
 
 ---
 
-### readImage
+### readMedia
 
-Load and analyze images.
+Load and analyze media files (images and PDF documents). The `readImage` tool name is supported as a backward-compatible alias.
 
 **Parameters:**
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | Yes | Path to image file |
+| `path` | string | Yes | Path to media file (image or PDF) |
 
-**Supported Formats:** `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`
+**Supported Formats:**
+- **Images:** `.png`, `.jpg`, `.jpeg`, `.webp`, `.bmp`, `.svg`
+- **Documents:** `.pdf`
+
+**Provider Notes:**
+- PDF support is native across Claude (32MB limit), OpenAI (50MB), and Gemini (50MB)
+- SVG is not supported by Google Gemini
+- Documents are sent via the Vercel AI SDK `file` content part
 
 **Example AI Usage:**
 ```xml
-<readImage>
+<readMedia>
   <path>./docs/architecture-diagram.png</path>
-</readImage>
+</readMedia>
+```
+
+```xml
+<readMedia>
+  <path>./reports/analysis.pdf</path>
+</readMedia>
 ```
 
 ---

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -38,7 +38,7 @@ import { TokenCounter } from './tokenCounter.js';
 import { truncateForSpan } from './simpleTelemetry.js';
 import { InMemoryStorageAdapter } from './storage/InMemoryStorageAdapter.js';
 import { HookManager, HOOK_TYPES } from './hooks/HookManager.js';
-import { SUPPORTED_IMAGE_EXTENSIONS, IMAGE_MIME_TYPES, isFormatSupportedByProvider } from './imageConfig.js';
+import { SUPPORTED_IMAGE_EXTENSIONS, SUPPORTED_MEDIA_EXTENSIONS, MEDIA_MIME_TYPES, IMAGE_MIME_TYPES, isFormatSupportedByProvider, isImageExtension, isDocumentExtension } from './mediaConfig.js';
 import {
   createTools,
   searchSchema,
@@ -55,6 +55,7 @@ import {
   listFilesSchema,
   searchFilesSchema,
   readImageSchema,
+  readMediaSchema,
   listSkillsSchema,
   useSkillSchema
 } from './tools.js';
@@ -121,6 +122,8 @@ const MAX_HISTORY_MESSAGES = 100;
 
 // Maximum image file size (20MB) to prevent OOM attacks
 const MAX_IMAGE_FILE_SIZE = 20 * 1024 * 1024;
+// Maximum document file size (32MB) — Claude's limit is 32MB, OpenAI 50MB, Gemini 50MB
+const MAX_DOCUMENT_FILE_SIZE = 32 * 1024 * 1024;
 
 /**
  * Truncate a string for debug logging, showing first and last portion.
@@ -958,40 +961,43 @@ export class ProbeAgent {
       }
     }
 
-    // Image loading tool
-    if (isToolAllowed('readImage')) {
-      this.toolImplementations.readImage = {
-        execute: async (params) => {
-          const imagePath = params.path;
-          if (!imagePath) {
-            throw new Error('Image path is required');
-          }
+    // Media loading tool (images + PDFs)
+    const readMediaExecute = async (params) => {
+      const mediaPath = params.path;
+      if (!mediaPath) {
+        throw new Error('File path is required');
+      }
 
-          // Validate extension before attempting to load
-          // Use basename to prevent path traversal attacks (e.g., 'malicious.jpg/../../../etc/passwd')
-          const filename = basename(imagePath);
-          const extension = filename.toLowerCase().split('.').pop();
+      // Validate extension before attempting to load
+      // Use basename to prevent path traversal attacks (e.g., 'malicious.jpg/../../../etc/passwd')
+      const filename = basename(mediaPath);
+      const extension = filename.toLowerCase().split('.').pop();
 
-          // Always validate extension is in allowed list (defense-in-depth)
-          if (!extension || !SUPPORTED_IMAGE_EXTENSIONS.includes(extension)) {
-            throw new Error(`Invalid or unsupported image extension: ${extension}. Supported formats: ${SUPPORTED_IMAGE_EXTENSIONS.join(', ')}`);
-          }
+      // Always validate extension is in allowed list (defense-in-depth)
+      if (!extension || !SUPPORTED_MEDIA_EXTENSIONS.includes(extension)) {
+        throw new Error(`Unsupported file format: ${extension}. Supported formats: ${SUPPORTED_MEDIA_EXTENSIONS.join(', ')}`);
+      }
 
-          // Check provider-specific format restrictions (e.g., SVG not supported by Google Gemini)
-          if (this.apiType && !isFormatSupportedByProvider(extension, this.apiType)) {
-            throw new Error(`Image format '${extension}' is not supported by the current AI provider (${this.apiType}). Try using a different image format like PNG or JPEG.`);
-          }
+      // Check provider-specific format restrictions (e.g., SVG not supported by Google Gemini)
+      if (this.apiType && !isFormatSupportedByProvider(extension, this.apiType)) {
+        throw new Error(`File format '${extension}' is not supported by the current AI provider (${this.apiType}). Try converting to a different format.`);
+      }
 
-          // Load the image using the existing loadImageIfValid method
-          const loaded = await this.loadImageIfValid(imagePath);
+      // Load the media file
+      const loaded = await this.loadMediaIfValid(mediaPath);
 
-          if (!loaded) {
-            throw new Error(`Failed to load image: ${imagePath}. The file may not exist, be too large, have an unsupported format, or be outside allowed directories.`);
-          }
+      if (!loaded) {
+        throw new Error(`Failed to load file: ${mediaPath}. The file may not exist, be too large, have an unsupported format, or be outside allowed directories.`);
+      }
 
-          return `Image loaded successfully: ${imagePath}. The image is now available for analysis in the conversation.`;
-        }
-      };
+      const mediaType = isDocumentExtension(extension) ? 'Document' : 'Image';
+      return `${mediaType} loaded successfully: ${mediaPath}. The file is now available for analysis in the conversation.`;
+    };
+
+    if (isToolAllowed('readMedia') || isToolAllowed('readImage')) {
+      this.toolImplementations.readMedia = { execute: readMediaExecute };
+      // Keep readImage as backward-compatible alias
+      this.toolImplementations.readImage = { execute: readMediaExecute };
     }
 
     // Add bash tool if enabled and allowed
@@ -2219,9 +2225,9 @@ export class ProbeAgent {
         schema: searchFilesSchema,
         description: 'Find files matching a glob pattern with recursive search capability.'
       },
-      readImage: {
-        schema: readImageSchema,
-        description: 'Read and load an image file for AI analysis.'
+      readMedia: {
+        schema: readMediaSchema,
+        description: 'Read and load a media file (image or PDF document) for AI analysis. Supports: png, jpg, jpeg, webp, bmp, svg, pdf.'
       },
       listSkills: {
         schema: listSkillsSchema,
@@ -2383,7 +2389,7 @@ export class ProbeAgent {
 
     // Enhanced pattern to detect image file mentions in various contexts
     // Looks for: "image", "file", "screenshot", etc. followed by path-like strings with image extensions
-    const extensionsPattern = `(?:${SUPPORTED_IMAGE_EXTENSIONS.join('|')})`;
+    const extensionsPattern = `(?:${SUPPORTED_MEDIA_EXTENSIONS.join('|')})`;
     const imagePatterns = [
       // Direct file path mentions: "./screenshot.png", "/path/to/image.jpg", etc.
       new RegExp(`(?:\\.?\\.\\/)?[^\\s"'<>\\[\\]]+\\\.${extensionsPattern}(?!\\w)`, 'gi'),
@@ -2504,43 +2510,36 @@ export class ProbeAgent {
   }
 
   /**
-   * Load and cache an image if it's valid and accessible
-   * @param {string} imagePath - Path to the image file
-   * @returns {Promise<boolean>} - True if image was loaded successfully
+   * Load and cache a media file (image or PDF) if it's valid and accessible
+   * @param {string} mediaPath - Path to the media file
+   * @returns {Promise<boolean>} - True if file was loaded successfully
    */
-  async loadImageIfValid(imagePath) {
+  async loadMediaIfValid(mediaPath) {
     try {
       // Skip if already loaded
-      if (this.pendingImages.has(imagePath)) {
+      if (this.pendingImages.has(mediaPath)) {
         if (this.debug) {
-          console.log(`[DEBUG] Image already loaded: ${imagePath}`);
+          console.log(`[DEBUG] Media already loaded: ${mediaPath}`);
         }
         return true;
       }
 
       // Security validation: check if path is within any allowed directory
-      // Use safeRealpath() to resolve symlinks and handle path traversal attempts (e.g., '/allowed/../etc/passwd')
-      // This prevents symlink bypass attacks (e.g., /tmp -> /private/tmp on macOS)
       const allowedDirs = this.allowedFolders && this.allowedFolders.length > 0 ? this.allowedFolders : [process.cwd()];
 
       let absolutePath;
       let isPathAllowed = false;
 
-      // If absolute path, check if it's within any allowed directory
-      if (isAbsolute(imagePath)) {
-        // Use safeRealpath to resolve symlinks for security
-        absolutePath = safeRealpath(resolve(imagePath));
+      if (isAbsolute(mediaPath)) {
+        absolutePath = safeRealpath(resolve(mediaPath));
         isPathAllowed = allowedDirs.some(dir => {
           const resolvedDir = safeRealpath(dir);
-          // Ensure the path is within the allowed directory (add separator to prevent prefix attacks)
           return absolutePath === resolvedDir || absolutePath.startsWith(resolvedDir + sep);
         });
       } else {
-        // For relative paths, try resolving against each allowed directory
         for (const dir of allowedDirs) {
           const resolvedDir = safeRealpath(dir);
-          const resolvedPath = safeRealpath(resolve(dir, imagePath));
-          // Ensure the resolved path is within the allowed directory
+          const resolvedPath = safeRealpath(resolve(dir, mediaPath));
           if (resolvedPath === resolvedDir || resolvedPath.startsWith(resolvedDir + sep)) {
             absolutePath = resolvedPath;
             isPathAllowed = true;
@@ -2548,137 +2547,162 @@ export class ProbeAgent {
           }
         }
       }
-      
-      // Security check: ensure path is within at least one allowed directory
+
       if (!isPathAllowed) {
         if (this.debug) {
-          console.log(`[DEBUG] Image path outside allowed directories: ${imagePath}`);
+          console.log(`[DEBUG] Media path outside allowed directories: ${mediaPath}`);
         }
         return false;
       }
 
-      // Check if file exists and get file stats
       let fileStats;
       try {
         fileStats = await stat(absolutePath);
       } catch (error) {
         if (this.debug) {
-          console.log(`[DEBUG] Image file not found: ${absolutePath}`);
+          console.log(`[DEBUG] Media file not found: ${absolutePath}`);
         }
         return false;
       }
 
-      // Validate file size to prevent OOM attacks
-      if (fileStats.size > MAX_IMAGE_FILE_SIZE) {
-        if (this.debug) {
-          console.log(`[DEBUG] Image file too large: ${absolutePath} (${fileStats.size} bytes, max: ${MAX_IMAGE_FILE_SIZE})`);
-        }
-        return false;
-      }
-
-      // Validate file extension
       const extension = absolutePath.toLowerCase().split('.').pop();
-      if (!SUPPORTED_IMAGE_EXTENSIONS.includes(extension)) {
+      if (!SUPPORTED_MEDIA_EXTENSIONS.includes(extension)) {
         if (this.debug) {
-          console.log(`[DEBUG] Unsupported image format: ${extension}`);
+          console.log(`[DEBUG] Unsupported media format: ${extension}`);
         }
         return false;
       }
 
-      // Note: Provider-specific format validation (e.g., SVG not supported by Google Gemini)
-      // is handled by the readImage tool which provides explicit error messages.
-      // loadImageIfValid is a lower-level method that only checks general format support.
+      // Apply size limit based on media type
+      const maxSize = isDocumentExtension(extension) ? MAX_DOCUMENT_FILE_SIZE : MAX_IMAGE_FILE_SIZE;
+      if (fileStats.size > maxSize) {
+        if (this.debug) {
+          console.log(`[DEBUG] Media file too large: ${absolutePath} (${fileStats.size} bytes, max: ${maxSize})`);
+        }
+        return false;
+      }
 
-      // Determine MIME type (from shared config)
-      const mimeType = IMAGE_MIME_TYPES[extension];
-
-      // Read and encode file asynchronously
+      const mimeType = MEDIA_MIME_TYPES[extension];
       const fileBuffer = await readFile(absolutePath);
       const base64Data = fileBuffer.toString('base64');
-      const dataUrl = `data:${mimeType};base64,${base64Data}`;
 
-      // Cache the loaded image
-      this.pendingImages.set(imagePath, dataUrl);
+      if (isDocumentExtension(extension)) {
+        // Store documents as objects with metadata for the 'file' content part
+        this.pendingImages.set(mediaPath, {
+          type: 'document',
+          mimeType,
+          data: base64Data,
+          filename: basename(mediaPath)
+        });
+      } else {
+        // Store images as data URLs (backward compatible)
+        const dataUrl = `data:${mimeType};base64,${base64Data}`;
+        this.pendingImages.set(mediaPath, dataUrl);
+      }
 
       if (this.debug) {
-        console.log(`[DEBUG] Successfully loaded image: ${imagePath} (${fileBuffer.length} bytes)`);
+        console.log(`[DEBUG] Successfully loaded media: ${mediaPath} (${fileBuffer.length} bytes, ${mimeType})`);
       }
 
       return true;
     } catch (error) {
       if (this.debug) {
-        console.log(`[DEBUG] Failed to load image ${imagePath}: ${error.message}`);
+        console.log(`[DEBUG] Failed to load media ${mediaPath}: ${error.message}`);
       }
       return false;
     }
   }
 
   /**
-   * Get all currently loaded images as an array for AI model consumption
-   * @returns {Array<string>} - Array of base64 data URLs
+   * Backward-compatible alias for loadMediaIfValid
+   * @param {string} imagePath - Path to the image file
+   * @returns {Promise<boolean>}
    */
-  getCurrentImages() {
-    return Array.from(this.pendingImages.values());
+  async loadImageIfValid(imagePath) {
+    return this.loadMediaIfValid(imagePath);
   }
 
   /**
-   * Clear loaded images (useful for new conversations)
+   * Get all currently loaded images as an array for AI model consumption
+   * @returns {Array<string>} - Array of base64 data URLs (images only, for backward compat)
+   */
+  getCurrentImages() {
+    return Array.from(this.pendingImages.values()).filter(v => typeof v === 'string');
+  }
+
+  /**
+   * Get all currently loaded media as an array of content parts
+   * @returns {Array<Object>} - Array of Vercel AI SDK content parts
+   */
+  getCurrentMedia() {
+    const parts = [];
+    for (const entry of this.pendingImages.values()) {
+      if (typeof entry === 'string') {
+        // Image data URL
+        parts.push({ type: 'image', image: entry });
+      } else if (entry && entry.type === 'document') {
+        // Document (PDF) — use Vercel AI SDK 'file' content part
+        parts.push({
+          type: 'file',
+          mediaType: entry.mimeType,
+          data: entry.data,
+          filename: entry.filename
+        });
+      }
+    }
+    return parts;
+  }
+
+  /**
+   * Clear loaded media (useful for new conversations)
    */
   clearLoadedImages() {
     this.pendingImages.clear();
     this.currentImages = [];
     if (this.debug) {
-      console.log('[DEBUG] Cleared all loaded images');
+      console.log('[DEBUG] Cleared all loaded media');
     }
   }
 
   /**
-   * Prepare messages for AI consumption, adding images to the latest user message if available
+   * Prepare messages for AI consumption, adding media to the latest user message if available
    * @param {Array} messages - Current conversation messages
-   * @returns {Array} - Messages formatted for AI SDK with potential image content
+   * @returns {Array} - Messages formatted for AI SDK with potential media content
    */
   prepareMessagesWithImages(messages) {
-    const loadedImages = this.getCurrentImages();
-    
-    // If no images loaded, return messages as-is
-    if (loadedImages.length === 0) {
+    const mediaParts = this.getCurrentMedia();
+
+    if (mediaParts.length === 0) {
       return messages;
     }
 
-    // Clone messages to avoid mutating the original
-    const messagesWithImages = [...messages];
-    
-    // Find the last user message to attach images to
-    const lastUserMessageIndex = messagesWithImages.map(m => m.role).lastIndexOf('user');
-    
+    const messagesWithMedia = [...messages];
+    const lastUserMessageIndex = messagesWithMedia.map(m => m.role).lastIndexOf('user');
+
     if (lastUserMessageIndex === -1) {
       if (this.debug) {
-        console.log('[DEBUG] No user messages found to attach images to');
+        console.log('[DEBUG] No user messages found to attach media to');
       }
       return messages;
     }
 
-    const lastUserMessage = messagesWithImages[lastUserMessageIndex];
-    
-    // Convert to multimodal format if we have images
+    const lastUserMessage = messagesWithMedia[lastUserMessageIndex];
+
     if (typeof lastUserMessage.content === 'string') {
-      messagesWithImages[lastUserMessageIndex] = {
+      messagesWithMedia[lastUserMessageIndex] = {
         ...lastUserMessage,
         content: [
           { type: 'text', text: lastUserMessage.content },
-          ...loadedImages.map(imageData => ({
-            type: 'image',
-            image: imageData
-          }))
+          ...mediaParts
         ]
       };
 
       if (this.debug) {
-        console.log(`[DEBUG] Added ${loadedImages.length} images to the latest user message`);
+        console.log(`[DEBUG] Added ${mediaParts.length} media items to the latest user message`);
       }
     }
 
-    return messagesWithImages;
+    return messagesWithMedia;
   }
 
   /**

--- a/npm/src/agent/mediaConfig.js
+++ b/npm/src/agent/mediaConfig.js
@@ -1,0 +1,122 @@
+/**
+ * Shared media format configuration for Probe agent
+ *
+ * This module centralizes supported media formats (images + documents)
+ * and their MIME types to ensure consistency across all components.
+ *
+ * Supports:
+ * - Images: png, jpg, jpeg, webp, bmp, svg
+ * - Documents: pdf (native support in Claude, Gemini, OpenAI via Vercel AI SDK)
+ *
+ * Note: GIF support was intentionally removed for compatibility with
+ * AI models like Google Gemini that don't support animated images.
+ */
+
+// Supported image file extensions (without leading dot)
+export const SUPPORTED_IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'webp', 'bmp', 'svg'];
+
+// Supported document file extensions (without leading dot)
+export const SUPPORTED_DOCUMENT_EXTENSIONS = ['pdf'];
+
+// All supported media extensions (images + documents)
+export const SUPPORTED_MEDIA_EXTENSIONS = [...SUPPORTED_IMAGE_EXTENSIONS, ...SUPPORTED_DOCUMENT_EXTENSIONS];
+
+// MIME type mapping for all supported media formats
+export const MEDIA_MIME_TYPES = {
+  'png': 'image/png',
+  'jpg': 'image/jpeg',
+  'jpeg': 'image/jpeg',
+  'webp': 'image/webp',
+  'bmp': 'image/bmp',
+  'svg': 'image/svg+xml',
+  'pdf': 'application/pdf'
+};
+
+// Legacy aliases for backward compatibility
+export const IMAGE_MIME_TYPES = MEDIA_MIME_TYPES;
+
+// Provider-specific unsupported media formats
+export const PROVIDER_UNSUPPORTED_FORMATS = {
+  'google': ['svg'],  // Google Gemini doesn't support image/svg+xml
+};
+
+/**
+ * Check if a file extension is an image type
+ * @param {string} extension - File extension (without dot)
+ * @returns {boolean}
+ */
+export function isImageExtension(extension) {
+  return SUPPORTED_IMAGE_EXTENSIONS.includes(extension?.toLowerCase());
+}
+
+/**
+ * Check if a file extension is a document type (PDF, etc.)
+ * @param {string} extension - File extension (without dot)
+ * @returns {boolean}
+ */
+export function isDocumentExtension(extension) {
+  return SUPPORTED_DOCUMENT_EXTENSIONS.includes(extension?.toLowerCase());
+}
+
+/**
+ * Generate a regex pattern string for matching media file extensions
+ * @param {string[]} extensions - Array of extensions (without dots)
+ * @returns {string} Regex pattern string like "png|jpg|jpeg|webp|bmp|svg|pdf"
+ */
+export function getExtensionPattern(extensions = SUPPORTED_MEDIA_EXTENSIONS) {
+  return extensions.join('|');
+}
+
+/**
+ * Get MIME type for a file extension
+ * @param {string} extension - File extension (without dot)
+ * @returns {string|undefined} MIME type or undefined if not supported
+ */
+export function getMimeType(extension) {
+  return MEDIA_MIME_TYPES[extension?.toLowerCase()];
+}
+
+/**
+ * Check if a media extension is supported by a specific provider
+ * @param {string} extension - File extension (without dot)
+ * @param {string} provider - Provider name (e.g., 'google', 'anthropic', 'openai')
+ * @returns {boolean} True if the format is supported by the provider
+ */
+export function isFormatSupportedByProvider(extension, provider) {
+  if (!extension || typeof extension !== 'string') {
+    return false;
+  }
+  if (extension.includes('/') || extension.includes('\\') || extension.includes('..')) {
+    return false;
+  }
+
+  const ext = extension.toLowerCase();
+
+  if (!SUPPORTED_MEDIA_EXTENSIONS.includes(ext)) {
+    return false;
+  }
+
+  if (!provider || typeof provider !== 'string') {
+    return true;
+  }
+
+  const unsupportedFormats = PROVIDER_UNSUPPORTED_FORMATS[provider];
+  if (unsupportedFormats && unsupportedFormats.includes(ext)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Get supported media extensions for a specific provider
+ * @param {string} provider - Provider name (e.g., 'google', 'anthropic', 'openai')
+ * @returns {string[]} Array of supported extensions for this provider
+ */
+export function getSupportedExtensionsForProvider(provider) {
+  if (!provider || typeof provider !== 'string') {
+    return [...SUPPORTED_MEDIA_EXTENSIONS];
+  }
+  const unsupportedFormats = PROVIDER_UNSUPPORTED_FORMATS[provider] || [];
+  return SUPPORTED_MEDIA_EXTENSIONS.filter(ext => !unsupportedFormats.includes(ext));
+}

--- a/npm/src/agent/tools.js
+++ b/npm/src/agent/tools.js
@@ -26,6 +26,7 @@ import {
   listFilesSchema,
   searchFilesSchema,
   readImageSchema,
+  readMediaSchema,
   listSkillsSchema,
   useSkillSchema
 } from '../index.js';
@@ -109,6 +110,7 @@ export {
   listFilesSchema,
   searchFilesSchema,
   readImageSchema,
+  readMediaSchema,
   listSkillsSchema,
   useSkillSchema
 };

--- a/npm/src/index.js
+++ b/npm/src/index.js
@@ -32,6 +32,7 @@ import {
 	listFilesSchema,
 	searchFilesSchema,
 	readImageSchema,
+	readMediaSchema,
 	listSkillsSchema,
 	useSkillSchema
 } from './tools/common.js';
@@ -115,6 +116,7 @@ export {
 	listFilesSchema,
 	searchFilesSchema,
 	readImageSchema,
+	readMediaSchema,
 	listSkillsSchema,
 	useSkillSchema,
 	// Export task management

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -68,6 +68,10 @@ export const readImageSchema = z.object({
 	path: z.string().describe('Path to the image file to read. Supports png, jpg, jpeg, webp, bmp, and svg formats.')
 });
 
+export const readMediaSchema = z.object({
+	path: z.string().describe('Path to the media file to read. Supports images (png, jpg, jpeg, webp, bmp, svg) and documents (pdf).')
+});
+
 export const bashSchema = z.object({
 	command: z.string().describe('The bash command to execute'),
 	workingDirectory: z.string().optional().describe('Directory to execute the command in (optional)'),

--- a/npm/src/tools/index.js
+++ b/npm/src/tools/index.js
@@ -30,6 +30,7 @@ export {
 	listFilesSchema,
 	searchFilesSchema,
 	readImageSchema,
+	readMediaSchema,
 	listSkillsSchema,
 	useSkillSchema
 } from './common.js';

--- a/npm/tests/unit/readImageTool.test.js
+++ b/npm/tests/unit/readImageTool.test.js
@@ -95,7 +95,7 @@ describe('ReadImage Tool', () => {
     test('should throw error when path parameter is missing', async () => {
       await expect(
         agent.toolImplementations.readImage.execute({})
-      ).rejects.toThrow('Image path is required');
+      ).rejects.toThrow('File path is required');
     });
 
     test('should throw error when image file does not exist', async () => {
@@ -281,7 +281,7 @@ describe('ReadImage Tool', () => {
         agentWithoutApiType.toolImplementations.readImage.execute({
           path: join(testDir, 'malicious.exe')
         })
-      ).rejects.toThrow(/Invalid or unsupported image extension/);
+      ).rejects.toThrow(/Unsupported file format/);
     });
 
     test('should reject path traversal disguised as valid extension', async () => {
@@ -298,7 +298,7 @@ describe('ReadImage Tool', () => {
         restrictedAgent.toolImplementations.readImage.execute({
           path: 'malicious.png/../../../etc/passwd'
         })
-      ).rejects.toThrow(/Invalid or unsupported image extension/);
+      ).rejects.toThrow(/Unsupported file format/);
     });
   });
 
@@ -363,6 +363,102 @@ describe('ReadImage Tool', () => {
       // loadImageIfValid should succeed - it doesn't do provider-specific filtering
       const result = await agent.loadImageIfValid(svgPath);
       expect(result).toBe(true);
+    });
+  });
+
+  describe('readMedia tool and PDF support', () => {
+    test('readMedia tool should be available in toolImplementations', () => {
+      expect(agent.toolImplementations).toHaveProperty('readMedia');
+      expect(agent.toolImplementations.readMedia).toHaveProperty('execute');
+      expect(typeof agent.toolImplementations.readMedia.execute).toBe('function');
+    });
+
+    test('readImage and readMedia should point to the same execute function', () => {
+      expect(agent.toolImplementations.readImage.execute).toBe(
+        agent.toolImplementations.readMedia.execute
+      );
+    });
+
+    test('should load PDF files successfully', async () => {
+      // Create a minimal PDF file
+      const pdfContent = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF');
+      const pdfPath = join(testDir, 'test-doc.pdf');
+      writeFileSync(pdfPath, pdfContent);
+
+      const result = await agent.toolImplementations.readMedia.execute({
+        path: pdfPath
+      });
+
+      expect(result).toContain('Document loaded successfully');
+      expect(result).toContain(pdfPath);
+      expect(agent.pendingImages.has(pdfPath)).toBe(true);
+    });
+
+    test('PDF should be stored as document type in pendingImages', async () => {
+      const pdfContent = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF');
+      const pdfPath = join(testDir, 'test-type.pdf');
+      writeFileSync(pdfPath, pdfContent);
+
+      await agent.toolImplementations.readMedia.execute({ path: pdfPath });
+
+      const entry = agent.pendingImages.get(pdfPath);
+      expect(entry).toBeDefined();
+      expect(typeof entry).toBe('object');
+      expect(entry.type).toBe('document');
+      expect(entry.mimeType).toBe('application/pdf');
+      expect(entry.filename).toBe('test-type.pdf');
+      expect(typeof entry.data).toBe('string'); // base64
+    });
+
+    test('getCurrentMedia should return file parts for PDFs', async () => {
+      agent.clearLoadedImages();
+
+      const pdfContent = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF');
+      const pdfPath = join(testDir, 'test-media.pdf');
+      writeFileSync(pdfPath, pdfContent);
+
+      await agent.toolImplementations.readMedia.execute({ path: pdfPath });
+
+      const media = agent.getCurrentMedia();
+      expect(media.length).toBe(1);
+      expect(media[0].type).toBe('file');
+      expect(media[0].mediaType).toBe('application/pdf');
+      expect(media[0].filename).toBe('test-media.pdf');
+    });
+
+    test('getCurrentImages should NOT include PDFs (backward compat)', async () => {
+      agent.clearLoadedImages();
+
+      // Load a PDF
+      const pdfContent = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF');
+      const pdfPath = join(testDir, 'test-filter.pdf');
+      writeFileSync(pdfPath, pdfContent);
+      await agent.toolImplementations.readMedia.execute({ path: pdfPath });
+
+      // Load an image
+      await agent.toolImplementations.readMedia.execute({ path: testImagePath });
+
+      // getCurrentImages should only return the image
+      const images = agent.getCurrentImages();
+      expect(images.length).toBe(1);
+      expect(images[0]).toMatch(/^data:image\/png;base64,/);
+
+      // getCurrentMedia should return both
+      const media = agent.getCurrentMedia();
+      expect(media.length).toBe(2);
+    });
+
+    test('readMedia via readImage alias should work for PDFs too', async () => {
+      const pdfContent = Buffer.from('%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF');
+      const pdfPath = join(testDir, 'test-alias.pdf');
+      writeFileSync(pdfPath, pdfContent);
+
+      // Use the readImage alias to load a PDF
+      const result = await agent.toolImplementations.readImage.execute({
+        path: pdfPath
+      });
+
+      expect(result).toContain('Document loaded successfully');
     });
   });
 


### PR DESCRIPTION
## Summary

- Add unified `readMedia` tool that handles both images (png, jpg, jpeg, webp, bmp, svg) and documents (pdf)
- PDFs sent via Vercel AI SDK `file` content part, natively supported by Claude (32MB), OpenAI (50MB), and Gemini (50MB)
- `readImage` preserved as backward-compatible alias pointing to the same execute function
- New `mediaConfig.js` centralizes format/MIME config, replacing `imageConfig.js` (which is kept for external consumers)

### Backward Compatibility
- `readImage` tool name still works (alias)
- `loadImageIfValid()` still works (alias to `loadMediaIfValid()`)
- `getCurrentImages()` still returns only image data URLs (filters out documents)
- `readImageSchema` still exported at all levels

### New APIs
- `getCurrentMedia()` — returns Vercel AI SDK content parts for both images and documents
- `readMediaSchema` — exported alongside `readImageSchema`
- Documents stored as `{ type: 'document', mimeType, data, filename }` objects in `pendingImages`

## Test plan
- [x] All 27 readImage/readMedia tests pass (7 new PDF-specific tests)
- [x] Full test suite: 3092/3092 tests pass, 130 suites
- [x] Verify `readImage` alias works for both images and PDFs
- [x] Verify `getCurrentImages()` excludes PDFs (backward compat)
- [x] Verify `getCurrentMedia()` returns both image and file content parts
- [x] Verify PDF stored as document type with correct mimeType


🤖 Generated with [Claude Code](https://claude.com/claude-code)