### PR TITLE
fix: clarify line-targeted edit guidance

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -3169,6 +3169,8 @@ Follow these instructions carefully:
 7. When modifying files, choose the appropriate tool:
     - Use 'edit' for all code modifications:
       * PREFERRED: Use start_line (and optionally end_line) for line-targeted editing — this is the safest and most precise approach.${this.hashLines ? ' Use the line:hash references from extract/search output (e.g. "42:ab") for integrity verification.' : ''} Always use extract first to see line numbers${this.hashLines ? ' and hashes' : ''}, then edit by line reference.
+      * In line-targeted mode, omitting position means replace/update the addressed lines. To insert new code near a line, you MUST set position="before" or position="after". Never express insertion as end_line < start_line.
+      * To delete lines in line-targeted mode, target the exact start_line/end_line range and set new_string to the empty string "".
       * For editing inside large functions: first use extract with the symbol target (e.g. "file.js#myFunction") to see the function with line numbers${this.hashLines ? ' and hashes' : ''}, then use start_line/end_line to surgically edit specific lines within it.
       * For rewriting entire functions/classes/methods, use the symbol parameter instead (no exact text matching needed).
       * FALLBACK ONLY: Use old_string + new_string for simple single-line changes where the text is unique. Copy old_string verbatim from the file. Keep old_string as small as possible.

--- a/npm/src/agent/shared/prompts.js
+++ b/npm/src/agent/shared/prompts.js
@@ -138,6 +138,8 @@ Bash is fine for: formatters (gofmt, prettier, black), build/test/lint commands,
 - Never expose secrets, API keys, or credentials in generated code. Never log sensitive information.
 - Do not surprise the user with unrequested changes. Do what was asked, including reasonable follow-up actions, but do not refactor surrounding code or add features that were not requested.
 - When editing files, keep edits focused and minimal. For changes spanning more than a few lines, prefer line-targeted editing (start_line/end_line) over text replacement (old_string) — it constrains scope and prevents accidental removal of adjacent content. Never include unrelated sections in an edit operation.
+- In line-targeted mode, omitting position means replace/update the addressed lines. To insert code near an existing line, you MUST use position="before" or position="after". Never express insertion as end_line < start_line.
+- To remove lines with line-targeted mode, target the exact start_line/end_line range and set new_string to the empty string "".
 - After every significant change, verify the project still builds and passes linting. Do not wait until the end to discover breakage.
 
 # Writing Tests

--- a/npm/src/tools/edit.js
+++ b/npm/src/tools/edit.js
@@ -186,6 +186,13 @@ function buildLineEditResponse(file_path, startLine, endLine, newLineCount, upda
   return msg;
 }
 
+const lineTargetedModeGuidance = `Line-targeted mode has three explicit behaviors:
+- Replace/update lines: provide start_line and optionally end_line, and omit position
+- Insert near a line: provide start_line and set position to "before" or "after"
+- Delete lines: provide start_line/end_line for the exact range and set new_string to empty string ""
+
+Inverted ranges (end_line < start_line) are always invalid and are never treated as insertion.`;
+
 /**
  * Handle line-targeted editing (replace, insert, delete by line numbers)
  * @param {Object} params - Parameters
@@ -211,12 +218,15 @@ async function handleLineEdit({ resolvedPath, file_path, start_line, end_line, n
   const endLine = endRef ? endRef.line : startLine;
 
   if (endLine < startLine) {
-    return `Error editing file: end_line (${endLine}) must be >= start_line (${startLine}).`;
+    const insertionHint = endLine === startLine - 1
+      ? ` This looks like an insertion between lines ${endLine} and ${startLine}. To insert there without replacing existing code, use start_line="${startLine}" with position="before" or start_line="${endLine}" with position="after".`
+      : ' To insert new code, choose a single anchor line in start_line and set position to "before" or "after" instead of using an inverted range.';
+    return `Error editing file: end_line (${endLine}) must be >= start_line (${startLine}). Omitting position means replace/update the addressed lines, not insert.${insertionHint} To delete lines, use new_string as the empty string "" with a valid non-inverted range.`;
   }
 
   // Validate position if provided
   if (position !== undefined && position !== null && position !== 'before' && position !== 'after') {
-    return 'Error editing file: Invalid position - must be "before" or "after". Use position="before" to insert before the line, or position="after" to insert after it.';
+    return 'Error editing file: Invalid position - must be "before" or "after". Use position="before" to insert before start_line, position="after" to insert after start_line, or omit position to replace/update the addressed lines.';
   }
 
   // Read the file
@@ -304,23 +314,25 @@ export const editTool = (options = {}) => {
 
   return tool({
     name: 'edit',
-    description: `Edit files using text replacement, AST-aware symbol operations, or line-targeted editing.
+    description: `Edit files using text replacement, AST-aware symbol operations, or line-targeted line replacement/insertion/deletion.
 
 Modes:
 1. Text edit: Provide old_string + new_string to find and replace text (with fuzzy matching fallback)
 2. Symbol replace: Provide symbol + new_string to replace an entire function/class/method by name
 3. Symbol insert: Provide symbol + new_string + position to insert code before/after a symbol
-4. Line-targeted edit: Provide start_line + new_string to edit by line number (from extract/search output)
+4. Line-targeted edit: Provide start_line + new_string to replace/update, insert, or delete lines by line number (from extract/search output)
+
+${lineTargetedModeGuidance}
 
 Parameters:
 - file_path: Path to the file to edit (absolute or relative)
-- new_string: Replacement text or new code content
+- new_string: Replacement text or new code content. Use empty string "" to delete the targeted line range.
 - old_string: (optional) Text to find and replace. If omitted, symbol or start_line must be provided.
 - replace_all: (optional) Replace all occurrences (text mode only)
 - symbol: (optional) Symbol name for AST-aware editing (e.g. "myFunction", "MyClass.myMethod")
-- position: (optional) "before" or "after" — insert code near a symbol or line instead of replacing it
-- start_line: (optional) Line reference (e.g. "42" or "42:ab") for line-targeted editing
-- end_line: (optional) End of line range, inclusive (e.g. "55" or "55:cd")`,
+- position: (optional) "before" or "after" — insert code near a symbol or line instead of replacing it. Omit position to replace/update.
+- start_line: (optional) Line reference (e.g. "42" or "42:ab") for line-targeted editing. With position, this is the insertion anchor. Without position, this is the first line to replace/update/delete.
+- end_line: (optional) End of line range, inclusive (e.g. "55" or "55:cd"). Must be >= start_line. Omit for single-line updates. Do not use inverted ranges for insertion.`,
 
     inputSchema: {
       type: 'object',
@@ -335,7 +347,7 @@ Parameters:
         },
         new_string: {
           type: 'string',
-          description: 'Replacement text or new code content'
+          description: 'Replacement text or new code content. Use empty string "" to delete the targeted line range.'
         },
         replace_all: {
           type: 'boolean',
@@ -349,15 +361,15 @@ Parameters:
         position: {
           type: 'string',
           enum: ['before', 'after'],
-          description: 'Insert before/after symbol or line (requires symbol or start_line, omit to replace)'
+          description: 'Insert before/after the target symbol or start_line anchor. Omit position to replace/update the addressed symbol or line range.'
         },
         start_line: {
           type: 'string',
-          description: 'Line reference for line-targeted editing (e.g. "42" or "42:ab" with hash)'
+          description: 'Line reference for line-targeted editing (e.g. "42" or "42:ab" with hash). With position, this is the insertion anchor. Without position, this is the first line to replace/update/delete.'
         },
         end_line: {
           type: 'string',
-          description: 'End of line range, inclusive (e.g. "55" or "55:cd"). Defaults to start_line.'
+          description: 'Inclusive end of the line range to replace/delete (e.g. "55" or "55:cd"). Must be >= start_line. Defaults to start_line.'
         }
       },
       required: ['file_path', 'new_string']
@@ -702,7 +714,7 @@ export const editSchema = {
     },
     new_string: {
       type: 'string',
-      description: 'Replacement text or new code content'
+      description: 'Replacement text or new code content. Use empty string "" to delete the targeted line range.'
     },
     replace_all: {
       type: 'boolean',
@@ -715,15 +727,15 @@ export const editSchema = {
     position: {
       type: 'string',
       enum: ['before', 'after'],
-      description: 'Insert before/after symbol or line (requires symbol or start_line, omit to replace)'
+      description: 'Insert before/after the target symbol or start_line anchor. Omit position to replace/update the addressed symbol or line range.'
     },
     start_line: {
       type: 'string',
-      description: 'Line reference for line-targeted editing (e.g. "42" or "42:ab" with hash)'
+      description: 'Line reference for line-targeted editing (e.g. "42" or "42:ab" with hash). With position, this is the insertion anchor. Without position, this is the first line to replace/update/delete.'
     },
     end_line: {
       type: 'string',
-      description: 'End of line range, inclusive (e.g. "55" or "55:cd"). Defaults to start_line.'
+      description: 'Inclusive end of the line range to replace/delete (e.g. "55" or "55:cd"). Must be >= start_line. Defaults to start_line.'
     }
   },
   required: ['file_path', 'new_string']
@@ -760,7 +772,7 @@ export const multiEditSchema = {
 };
 
 // Tool descriptions for XML definitions
-export const editDescription = 'Edit files using text replacement, AST-aware symbol operations, or line-targeted editing. Supports fuzzy matching for text edits and optional hash-based integrity verification for line edits.';
+export const editDescription = 'Edit files using text replacement, AST-aware symbol operations, or line-targeted replacement/insertion/deletion. Supports fuzzy matching for text edits and optional hash-based integrity verification for line edits.';
 export const createDescription = 'Create new files with specified content. Will create parent directories if needed.';
 export const multiEditDescription = 'Apply multiple file edits in a single tool call. Accepts a JSON array of edit operations, each supporting the same modes as the edit tool.';
 
@@ -779,15 +791,21 @@ Four editing modes — choose based on the scope of your change:
 
 4. **Line-targeted edit** (start_line + new_string): For precise edits using line numbers from extract/search output. Use start_line with a line number (e.g. "42") or line:hash (e.g. "42:ab") for integrity verification. Add end_line for multi-line ranges. Use position="before" or "after" to insert instead of replace.
 
+How line-targeted mode behaves:
+- Replace/update lines: provide start_line and optionally end_line, and omit position
+- Insert near a line: provide start_line and set position to "before" or "after"
+- Delete lines: provide start_line/end_line for the exact range and set new_string to empty string ""
+- Inverted ranges are invalid: end_line must be >= start_line and is never treated as insertion
+
 Parameters:
 - file_path: (required) Path to the file to edit
-- new_string: (required) Replacement text or new code content
+- new_string: (required) Replacement text or new code content. Use empty string "" to delete the targeted line range.
 - old_string: (optional) Text to find and replace — copy verbatim from the file, do not paraphrase or reformat
 - replace_all: (optional, default: false) Replace all occurrences of old_string (text mode only)
 - symbol: (optional) Name of a code symbol (e.g. "myFunction", "MyClass.myMethod") — must match a function, class, or method definition
-- position: (optional) "before" or "after" — insert new_string near the symbol or line instead of replacing it
-- start_line: (optional) Line reference for line-targeted editing (e.g. "42" or "42:ab")
-- end_line: (optional) End of line range, inclusive (e.g. "55" or "55:cd"). Defaults to start_line.
+- position: (optional) "before" or "after" — insert new_string near the symbol or line instead of replacing it. Omit position to replace/update.
+- start_line: (optional) Line reference for line-targeted editing (e.g. "42" or "42:ab"). With position, this is the insertion anchor. Without position, this is the first line to replace/update/delete.
+- end_line: (optional) End of line range, inclusive (e.g. "55" or "55:cd"). Defaults to start_line. Must be >= start_line. Use it for replace/update/delete ranges, not insertion.
 
 Mode selection rules (priority order):
 - If symbol is provided, symbol mode is used (old_string and start_line are ignored)
@@ -799,12 +817,15 @@ When to use each mode:
 - Small edits (a line or a few lines): use text mode with old_string
 - Replacing entire functions/classes/methods: use symbol mode — no exact text matching needed
 - Editing specific lines from extract/search output: use line-targeted mode with start_line
+- Adding a new block near an existing line: use line-targeted mode with start_line plus position="before" or position="after"
+- Removing lines entirely: use line-targeted mode with start_line/end_line and new_string=""
 - Editing inside large functions without rewriting them entirely: first use extract with the symbol target (e.g. "file.js#myFunction") to see the function with line numbers, then use start_line/end_line to edit specific lines within it
 
 Error handling:
 - If an edit fails, read the error message carefully — it contains specific instructions for how to fix the call and retry
 - Common fixes: use 'search'/'extract' to get exact file content, add more context to old_string, switch between text and symbol modes
 - Line-targeted hash mismatch: the file changed since last read; the error provides updated line:hash references
+- Inverted line ranges are invalid; the error explains how to express insertion with position="before"/"after"
 
 Examples:
 
@@ -856,6 +877,22 @@ Line-targeted edit (replace a range of lines):
 <end_line>55</end_line>
 <new_string>  // simplified implementation
   return processItems(order.items);</new_string>
+</edit>
+
+Line-targeted edit (insert before a line without replacing it):
+<edit>
+<file_path>src/main.js</file_path>
+<start_line>42</start_line>
+<position>before</position>
+<new_string>  logger.debug("starting process");</new_string>
+</edit>
+
+Line-targeted edit (delete a range of lines):
+<edit>
+<file_path>src/main.js</file_path>
+<start_line>42</start_line>
+<end_line>45</end_line>
+<new_string></new_string>
 </edit>
 
 Line-targeted edit with hash verification:

--- a/npm/tests/unit/line-edit-mode.test.js
+++ b/npm/tests/unit/line-edit-mode.test.js
@@ -44,12 +44,25 @@ describe('Line-Targeted Edit Mode', () => {
 
     test('editDescription should mention line-targeted', () => {
       expect(editDescription).toContain('line-targeted');
+      expect(editDescription).toContain('insertion');
+      expect(editDescription).toContain('deletion');
     });
 
     test('editToolDefinition should document line-targeted mode', () => {
       expect(editToolDefinition).toContain('Line-targeted edit');
       expect(editToolDefinition).toContain('start_line');
       expect(editToolDefinition).toContain('end_line');
+      expect(editToolDefinition).toContain('Replace/update lines');
+      expect(editToolDefinition).toContain('Insert near a line');
+      expect(editToolDefinition).toContain('Delete lines');
+      expect(editToolDefinition).toContain('Inverted ranges are invalid');
+    });
+
+    test('schema descriptions should explain replace, insert, and delete semantics', () => {
+      expect(editSchema.properties.new_string.description).toContain('empty string');
+      expect(editSchema.properties.position.description).toContain('Omit position to replace/update');
+      expect(editSchema.properties.start_line.description).toContain('insertion anchor');
+      expect(editSchema.properties.end_line.description).toContain('Must be >= start_line');
     });
   });
 
@@ -295,6 +308,23 @@ describe('Line-Targeted Edit Mode', () => {
       });
       expect(result).toContain('Error editing file');
       expect(result).toContain('must be >= start_line');
+      expect(result).toContain('replace/update the addressed lines, not insert');
+      expect(result).toContain('position');
+      expect(result).toContain('empty string');
+    });
+
+    test('should give explicit insertion guidance for adjacent inverted ranges', async () => {
+      const testFile = join(tempDir, 'test.js');
+      await fs.writeFile(testFile, sampleContent);
+      const result = await tool.execute({
+        file_path: testFile,
+        start_line: '4',
+        end_line: '3',
+        new_string: '  const w = 3;'
+      });
+      expect(result).toContain('This looks like an insertion between lines 3 and 4');
+      expect(result).toContain('start_line="4" with position="before"');
+      expect(result).toContain('start_line="3" with position="after"');
     });
 
     test('should error when start_line is beyond file length', async () => {

--- a/npm/tests/unit/probe-agent-delegate.test.js
+++ b/npm/tests/unit/probe-agent-delegate.test.js
@@ -761,6 +761,15 @@ describe('Delegate prompt type propagation', () => {
     expect(predefinedPrompts['engineer']).not.toContain('READ-ONLY');
   });
 
+  test('engineer prompt explains line-targeted insert vs replace semantics', async () => {
+    const { predefinedPrompts } = await import('../../src/agent/shared/prompts.js');
+
+    expect(predefinedPrompts['engineer']).toContain('omitting position means replace/update the addressed lines');
+    expect(predefinedPrompts['engineer']).toContain('position="before" or position="after"');
+    expect(predefinedPrompts['engineer']).toContain('Never express insertion as end_line < start_line');
+    expect(predefinedPrompts['engineer']).toContain('set new_string to the empty string ""');
+  });
+
   test('default promptType is code-explorer which would be inherited by delegate', () => {
     const agent = new ProbeAgent({});
     expect(agent.promptType).toBe('code-explorer');


### PR DESCRIPTION
## Problem / Task
Line-targeted edits were under-specified when the model needed to insert, replace, or delete code near a line anchor. In practice this made malformed calls like inverted ranges harder to recover from, and the tool descriptions did not clearly spell out how insertion, replacement, and deletion should be expressed.

## Changes
Updated the edit tool descriptions, schema field descriptions, and XML tool definition to state the three explicit line-targeted behaviors: replace/update without `position`, insert with `position="before"|"after"`, and delete with `new_string=""` on a valid range.
Improved the line-targeted runtime error for inverted ranges so it now explains that inverted ranges are invalid, clarifies that omission of `position` means replacement, and gives direct insertion recovery hints for adjacent-line mistakes.
Tightened the engineer prompt guidance so the model is told explicitly not to encode insertion as `end_line < start_line`, and to use empty `new_string` for deletion.
Added unit tests covering the new tool/schema wording, the explicit inverted-range insertion hint, and the updated engineer prompt guidance.

## Testing
Added and updated tests in `npm/tests/unit/line-edit-mode.test.js` and `npm/tests/unit/probe-agent-delegate.test.js` to verify the clearer insert/replace/delete guidance and inverted-range recovery message.
Confirmed related edit suites still pass with `npm test -- --runInBand tests/unit/symbol-edit-tools.test.js tests/unit/edit-create-tools.test.js tests/unit/line-edit-mode.test.js tests/unit/probe-agent-delegate.test.js`.
Verified the package still builds with `npm run build`.