### PR TITLE
fix: deduplicate contained search blocks and add is_test to JSON output

### DIFF
--- a/src/search/block_merging.rs
+++ b/src/search/block_merging.rs
@@ -4,6 +4,119 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 
+/// Deduplicates overlapping search results where one block fully contains another.
+///
+/// When multiple search hits land in the same file, the parser may emit both a
+/// comment node (with its attached declaration) and the declaration itself as
+/// separate results with overlapping line ranges. This function keeps only the
+/// larger (containing) block and drops the contained one, preserving matched
+/// keywords from both.
+///
+/// This should run regardless of the `--no-merge` flag — it is deduplication,
+/// not merging of adjacent blocks.
+pub fn deduplicate_contained_blocks(results: Vec<SearchResult>) -> Vec<SearchResult> {
+    let debug_mode = std::env::var("DEBUG").unwrap_or_default() == "1";
+
+    if results.len() <= 1 {
+        return results;
+    }
+
+    let original_count = results.len();
+
+    // Group results by file
+    let mut file_blocks: BTreeMap<String, Vec<SearchResult>> = BTreeMap::new();
+    for result in results {
+        file_blocks
+            .entry(result.file.clone())
+            .or_default()
+            .push(result);
+    }
+
+    let mut deduped_results = Vec::new();
+
+    for (_file_path, mut blocks) in file_blocks {
+        if blocks.len() == 1 {
+            deduped_results.push(blocks.remove(0));
+            continue;
+        }
+
+        // Sort by start line, then by span size descending (larger blocks first)
+        blocks.sort_by(|a, b| {
+            a.lines.0.cmp(&b.lines.0).then_with(|| {
+                let span_a = a.lines.1 - a.lines.0;
+                let span_b = b.lines.1 - b.lines.0;
+                span_b.cmp(&span_a)
+            })
+        });
+
+        // Mark blocks that are fully contained within a larger block
+        let len = blocks.len();
+        let mut removed = vec![false; len];
+
+        for i in 0..len {
+            if removed[i] {
+                continue;
+            }
+            for j in (i + 1)..len {
+                if removed[j] {
+                    continue;
+                }
+                let (outer_start, outer_end) = blocks[i].lines;
+                let (inner_start, inner_end) = blocks[j].lines;
+
+                // Check if j is fully contained within i
+                if inner_start >= outer_start && inner_end <= outer_end {
+                    // Merge matched_keywords from the contained block into the container
+                    if let Some(ref inner_kw) = blocks[j].matched_keywords {
+                        let mut merged_kw: Vec<String> =
+                            blocks[i].matched_keywords.clone().unwrap_or_default();
+                        for kw in inner_kw {
+                            if !merged_kw.contains(kw) {
+                                merged_kw.push(kw.clone());
+                            }
+                        }
+                        merged_kw.sort();
+                        blocks[i].matched_keywords = Some(merged_kw);
+                    }
+                    removed[j] = true;
+                }
+                // Check if i is fully contained within j (can happen if j has same start but larger span)
+                else if outer_start >= inner_start && outer_end <= inner_end {
+                    if let Some(ref outer_kw) = blocks[i].matched_keywords {
+                        let mut merged_kw: Vec<String> =
+                            blocks[j].matched_keywords.clone().unwrap_or_default();
+                        for kw in outer_kw {
+                            if !merged_kw.contains(kw) {
+                                merged_kw.push(kw.clone());
+                            }
+                        }
+                        merged_kw.sort();
+                        blocks[j].matched_keywords = Some(merged_kw);
+                    }
+                    removed[i] = true;
+                    break; // i is removed, no need to check further
+                }
+            }
+        }
+
+        for (idx, block) in blocks.into_iter().enumerate() {
+            if !removed[idx] {
+                deduped_results.push(block);
+            }
+        }
+    }
+
+    if debug_mode && deduped_results.len() < original_count {
+        println!(
+            "DEBUG: Deduplicated contained blocks: {} -> {} results",
+            original_count,
+            deduped_results.len()
+        );
+    }
+
+    deduped_results
+}
+
 /// Merges ranked search results that are adjacent or overlapping
 ///
 /// This function should be called AFTER ranking and limiting to merge blocks
@@ -557,5 +670,145 @@ fn merge_matched_keywords(block1: &SearchResult, block2: &SearchResult) -> Optio
         let mut keyword_vec: Vec<String> = keywords.into_iter().collect();
         keyword_vec.sort();
         Some(keyword_vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_result(file: &str, start: usize, end: usize, node_type: &str) -> SearchResult {
+        SearchResult {
+            file: file.to_string(),
+            lines: (start, end),
+            node_type: node_type.to_string(),
+            code: format!("code lines {start}-{end}"),
+            symbol_signature: None,
+            matched_by_filename: None,
+            rank: None,
+            score: None,
+            tfidf_score: None,
+            bm25_score: None,
+            tfidf_rank: None,
+            bm25_rank: None,
+            new_score: None,
+            hybrid2_rank: None,
+            combined_score_rank: None,
+            file_unique_terms: None,
+            file_total_matches: None,
+            file_match_rank: None,
+            block_unique_terms: None,
+            block_total_matches: None,
+            parent_file_id: None,
+            block_id: None,
+            matched_keywords: None,
+            matched_lines: None,
+            tokenized_content: None,
+            lsp_info: None,
+            parent_context: None,
+        }
+    }
+
+    #[test]
+    fn test_dedup_removes_contained_block() {
+        // Simulates the issue: comment block (1-4) contains function block (2-4)
+        let results = vec![
+            make_result("example.py", 1, 4, "comment"),
+            make_result("example.py", 2, 4, "function_definition"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].lines, (1, 4));
+        assert_eq!(deduped[0].node_type, "comment");
+    }
+
+    #[test]
+    fn test_dedup_preserves_non_overlapping() {
+        let results = vec![
+            make_result("example.py", 1, 4, "function_definition"),
+            make_result("example.py", 10, 15, "function_definition"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    #[test]
+    fn test_dedup_different_files_not_deduped() {
+        // Same line ranges but different files should not be deduped
+        let results = vec![
+            make_result("a.py", 1, 4, "comment"),
+            make_result("b.py", 1, 4, "comment"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    #[test]
+    fn test_dedup_merges_keywords_from_contained_block() {
+        let mut outer = make_result("example.py", 1, 4, "comment");
+        outer.matched_keywords = Some(vec!["REQ-001".to_string()]);
+
+        let mut inner = make_result("example.py", 2, 4, "function_definition");
+        inner.matched_keywords = Some(vec!["REQ-002".to_string()]);
+
+        let deduped = deduplicate_contained_blocks(vec![outer, inner]);
+        assert_eq!(deduped.len(), 1);
+        let kw = deduped[0].matched_keywords.as_ref().unwrap();
+        assert!(kw.contains(&"REQ-001".to_string()));
+        assert!(kw.contains(&"REQ-002".to_string()));
+    }
+
+    #[test]
+    fn test_dedup_keeps_larger_block_when_inner_comes_first() {
+        // Inner block sorted first but outer should win
+        let results = vec![
+            make_result("example.ts", 2, 3, "arrow_function"),
+            make_result("example.ts", 1, 3, "comment"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].lines, (1, 3));
+    }
+
+    #[test]
+    fn test_dedup_single_result_passthrough() {
+        let results = vec![make_result("a.py", 1, 10, "function_definition")];
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 1);
+    }
+
+    #[test]
+    fn test_dedup_empty_passthrough() {
+        let results: Vec<SearchResult> = vec![];
+        let deduped = deduplicate_contained_blocks(results);
+        assert!(deduped.is_empty());
+    }
+
+    #[test]
+    fn test_dedup_partially_overlapping_not_deduped() {
+        // Blocks that overlap but neither fully contains the other
+        let results = vec![
+            make_result("example.py", 1, 5, "function_definition"),
+            make_result("example.py", 3, 8, "function_definition"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 2);
+    }
+
+    #[test]
+    fn test_dedup_exact_same_range() {
+        // Two blocks with identical ranges — one should be removed
+        let results = vec![
+            make_result("example.py", 1, 4, "comment"),
+            make_result("example.py", 1, 4, "function_definition"),
+        ];
+
+        let deduped = deduplicate_contained_blocks(results);
+        assert_eq!(deduped.len(), 1);
     }
 }

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use probe_code::language::is_test_file;
 use probe_code::models::SearchResult;
 use probe_code::search::query::QueryPlan;
 use probe_code::search::search_tokens::sum_tokens_with_deduplication;
@@ -571,6 +572,9 @@ fn format_and_print_json_results(
         lines: [usize; 2],
         node_type: &'a str,
         code: &'a str,
+        // Whether this result comes from a test file or contains test code
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_test: Option<bool>,
         // Symbol signature (when symbols flag is used)
         symbol_signature: Option<&'a String>,
         // Include other relevant fields
@@ -593,20 +597,33 @@ fn format_and_print_json_results(
 
     let json_results: Vec<JsonResult> = results
         .iter()
-        .map(|r| JsonResult {
-            file: &r.file,
-            lines: [r.lines.0, r.lines.1],
-            node_type: &r.node_type,
-            code: &r.code,
-            symbol_signature: r.symbol_signature.as_ref(),
-            matched_keywords: r.matched_keywords.as_ref(),
-            score: r.score,
-            tfidf_score: r.tfidf_score,
-            bm25_score: r.bm25_score,
-            file_unique_terms: r.file_unique_terms,
-            file_total_matches: r.file_total_matches,
-            block_unique_terms: r.block_unique_terms,
-            block_total_matches: r.block_total_matches,
+        .map(|r| {
+            // Compute is_test from file path (test file naming conventions)
+            // and from code content (test function patterns)
+            let file_is_test = is_test_file(Path::new(&r.file));
+            let code_is_test = !file_is_test && is_test_code_block(&r.code, &r.node_type);
+            let is_test = if file_is_test || code_is_test {
+                Some(true)
+            } else {
+                None // omit from JSON when not a test (less noise)
+            };
+
+            JsonResult {
+                file: &r.file,
+                lines: [r.lines.0, r.lines.1],
+                node_type: &r.node_type,
+                code: &r.code,
+                is_test,
+                symbol_signature: r.symbol_signature.as_ref(),
+                matched_keywords: r.matched_keywords.as_ref(),
+                score: r.score,
+                tfidf_score: r.tfidf_score,
+                bm25_score: r.bm25_score,
+                file_unique_terms: r.file_unique_terms,
+                file_total_matches: r.file_total_matches,
+                block_unique_terms: r.block_unique_terms,
+                block_total_matches: r.block_total_matches,
+            }
         })
         .collect();
 
@@ -680,6 +697,60 @@ fn format_and_print_json_results(
 
     println!("{json}", json = serde_json::to_string_pretty(&wrapper)?);
     Ok(())
+}
+
+/// Heuristic check for test-like code blocks based on content patterns.
+///
+/// This complements `is_test_file()` (which checks file naming) by detecting
+/// individual test functions/blocks in files that aren't named as test files
+/// (e.g., inline `#[cfg(test)]` modules in Rust, or mixed test/impl files).
+fn is_test_code_block(code: &str, node_type: &str) -> bool {
+    // Skip pure type/struct declarations that aren't test constructs
+    let is_structural_only = node_type == "type_declaration"
+        || node_type == "struct_item"
+        || node_type == "struct_declaration"
+        || node_type == "package_clause"
+        || node_type == "import_declaration";
+
+    if is_structural_only {
+        return false;
+    }
+
+    // Check for common test patterns across languages in the code content.
+    // We check the code itself rather than relying only on node_type because
+    // comment-attached-to-declaration blocks may have node_type "comment"
+    // while the code includes both the comment and its owning test function.
+    let first_lines: String = code.lines().take(10).collect::<Vec<_>>().join("\n");
+
+    // Rust: #[test], #[cfg(test)]
+    if first_lines.contains("#[test]") || first_lines.contains("#[cfg(test)]") {
+        return true;
+    }
+
+    // Python: def test_
+    if first_lines.contains("def test_") {
+        return true;
+    }
+
+    // JS/TS: test(', describe(', it(', expect(
+    if first_lines.contains("test(")
+        || first_lines.contains("describe(")
+        || first_lines.contains("it(")
+    {
+        return true;
+    }
+
+    // Go: func Test
+    if first_lines.contains("func Test") {
+        return true;
+    }
+
+    // Java/C#: @Test
+    if first_lines.contains("@Test") {
+        return true;
+    }
+
+    false
 }
 
 /// Format and print search results in XML format
@@ -3018,5 +3089,90 @@ mod tests {
 
         assert_eq!(cache.get(&path1).unwrap().as_ref(), content1);
         assert_eq!(cache.get(&path2).unwrap().as_ref(), content2);
+    }
+
+    #[test]
+    fn test_is_test_code_block_rust() {
+        assert!(is_test_code_block(
+            "#[test]\nfn test_something() {}",
+            "function_item"
+        ));
+        assert!(is_test_code_block("#[cfg(test)]\nmod tests {}", "module"));
+        assert!(!is_test_code_block("fn main() {}", "function_item"));
+    }
+
+    #[test]
+    fn test_is_test_code_block_python() {
+        assert!(is_test_code_block(
+            "def test_something():\n    pass",
+            "function_definition"
+        ));
+        assert!(!is_test_code_block(
+            "def something():\n    pass",
+            "function_definition"
+        ));
+    }
+
+    #[test]
+    fn test_is_test_code_block_js() {
+        assert!(is_test_code_block(
+            "test('gamma', () => {})",
+            "call_expression"
+        ));
+        assert!(is_test_code_block(
+            "describe('suite', () => {})",
+            "call_expression"
+        ));
+        assert!(is_test_code_block(
+            "it('should work', () => {})",
+            "call_expression"
+        ));
+    }
+
+    #[test]
+    fn test_is_test_code_block_go() {
+        assert!(is_test_code_block(
+            "func TestSomething(t *testing.T) {}",
+            "function_definition"
+        ));
+        assert!(!is_test_code_block(
+            "func Something() {}",
+            "function_definition"
+        ));
+    }
+
+    #[test]
+    fn test_is_test_code_block_comment_with_test_function() {
+        // Comment nodes that include an attached test function should be detected
+        assert!(is_test_code_block(
+            "# Verifies: REQ-001\ndef test_beta():\n    pass",
+            "comment"
+        ));
+        assert!(is_test_code_block(
+            "// Verifies: REQ-001\ntest('gamma', () => {})",
+            "comment"
+        ));
+    }
+
+    #[test]
+    fn test_is_test_code_block_type_declarations_excluded() {
+        // Type declarations should never be detected as test blocks
+        assert!(!is_test_code_block(
+            "type TestStruct struct{}",
+            "type_declaration"
+        ));
+        assert!(!is_test_code_block(
+            "// Verifies: REQ-001\npackage workflow\ntype Foo struct{}",
+            "type_declaration"
+        ));
+    }
+
+    #[test]
+    fn test_is_test_code_block_plain_comment_not_test() {
+        // A comment without test function code should not be detected as test
+        assert!(!is_test_code_block(
+            "// Verifies: REQ-001\n// Some regular comment",
+            "comment"
+        ));
     }
 }

--- a/src/search/search_runner.rs
+++ b/src/search/search_runner.rs
@@ -1527,6 +1527,23 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
         );
     }
 
+    // Always deduplicate contained blocks (overlapping results from the same
+    // file where one fully contains the other). This is NOT merging — it
+    // removes true duplicates regardless of --no-merge.
+    let limited = if !limited.results.is_empty() {
+        use probe_code::search::block_merging::deduplicate_contained_blocks;
+        let deduped = deduplicate_contained_blocks(limited.results);
+        LimitedSearchResults {
+            results: deduped,
+            skipped_files: limited.skipped_files,
+            limits_applied: limited.limits_applied,
+            cached_blocks_skipped: limited.cached_blocks_skipped,
+            files_skipped_early_termination: limited.files_skipped_early_termination,
+        }
+    } else {
+        limited
+    };
+
     // Optional block merging - AFTER initial caching
     let bm_start = Instant::now();
     if debug_mode && !limited.results.is_empty() && !*no_merge {


### PR DESCRIPTION
## Summary

Fixes #553 — two improvements to `probe search --allow-tests --exact --no-merge -o json` for requirement-annotation indexing:

- **Deduplicate contained blocks**: When the parser emits both a comment node (with attached declaration) and the declaration itself as separate overlapping results, the contained block is now removed. This runs unconditionally regardless of `--no-merge`, reducing 4 results to 2 in the reported repro case. Matched keywords from removed blocks are preserved on the surviving block.
- **Add `is_test` field to JSON output**: Computed at serialization time from file naming conventions (`is_test_file()`) and code content patterns (`is_test_code_block()`). Only present when `true` (omitted for non-test blocks). Structural declarations (`type_declaration`, `struct_item`) are excluded from test detection, letting consumers distinguish top-level `Verifies:` comments on implementation code from actual test/witness blocks.

## Test plan

- [x] 9 unit tests for `deduplicate_contained_blocks()` (containment, partial overlap, different files, keyword merging, same-range, edge cases)
- [x] 7 unit tests for `is_test_code_block()` (Rust, Python, JS/TS, Go, comment-with-function, type declarations, plain comments)
- [x] Manual verification with exact repro cases from issue:
  - Repro 1: 2 results instead of 4 (duplicates eliminated)
  - Repro 2: Go `type_declaration` has no `is_test`, Python/TS test blocks have `"is_test": true`
- [x] All 337 unit tests pass, 11 integration tests pass, 21 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)