### PR TITLE
feat: add query owner context metadata

### DIFF
--- a/docs/probe-agent/sdk/tools-reference.md
+++ b/docs/probe-agent/sdk/tools-reference.md
@@ -163,6 +163,7 @@ AST-based structural queries using tree-sitter patterns.
 | `path` | string | No | Directory to search |
 | `language` | string | No | Programming language |
 | `limit` | number | No | Maximum results |
+| `with_context` | boolean | No | Include owning source-block context in JSON output |
 
 **Example AI Usage:**
 ```xml
@@ -170,6 +171,17 @@ AST-based structural queries using tree-sitter patterns.
   <pattern>fn $NAME($PARAMS) { $$$BODY }</pattern>
   <language>rust</language>
   <path>./src</path>
+</query>
+```
+
+Use `with_context` when the exact AST match needs its enclosing function, method, class, attached comments, or call context for downstream analysis:
+
+```xml
+<query>
+  <pattern>fetch($$$ARGS)</pattern>
+  <language>typescript</language>
+  <path>./src</path>
+  <with_context>true</with_context>
 </query>
 ```
 

--- a/docs/probe-cli/query.md
+++ b/docs/probe-cli/query.md
@@ -119,6 +119,7 @@ probe query "go $FUNC($$$ARGS)" ./src -l go
 | `--allow-tests` | Boolean | false | Include test files |
 | `-i`, `--ignore` | String[] | - | Patterns to ignore |
 | `--no-gitignore` | Boolean | false | Don't respect .gitignore |
+| `--with-context`, `--owner-context` | Boolean | false | Include owning source-block context in JSON output |
 
 ### Language Options
 
@@ -156,9 +157,67 @@ probe query "fn $NAME()" ./src --format markdown
 # JSON for tooling
 probe query "fn $NAME()" ./src --format json
 
+# JSON with owning source-block context
+probe query "fetch($$$ARGS)" ./src --language typescript --format json --with-context
+
 # Plain text
 probe query "fn $NAME()" ./src --format plain
 ```
+
+### Owner Context JSON
+
+Use `--with-context` when a structural match is not enough by itself and the caller also needs the source block a human would inspect. This keeps `query` precise while adding neutral source facts such as the owning function, method, class, attached comments, and enclosing calls.
+
+```bash
+probe query "fetch($$$ARGS)" ./src --language typescript --format json --with-context
+```
+
+The default JSON fields remain available. With context enabled, each result can also include:
+
+```json
+{
+  "schema_version": "probe.query.context.v1",
+  "results": [
+    {
+      "file": "src/api.ts",
+      "lines": [4, 4],
+      "node_type": "match",
+      "content": "fetch(url)",
+      "column_start": 10,
+      "column_end": 20,
+      "language": "typescript",
+      "pattern": {
+        "source": "fetch($$$ARGS)",
+        "id": null
+      },
+      "match": {
+        "node_type": "call_expression",
+        "content": "fetch(url)",
+        "lines": [4, 4],
+        "columns": [10, 20]
+      },
+      "owner": {
+        "symbol": "loadProfile",
+        "qualified_symbol": "loadProfile",
+        "node_type": "function_declaration",
+        "scope": "function",
+        "lines": [2, 5],
+        "columns": [1, 2],
+        "comments": [
+          {
+            "kind": "leading",
+            "start_line": 1,
+            "end_line": 1,
+            "text": "// Network boundary: user profile API client."
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Probe does not interpret comment contents or apply domain policy. Downstream tools decide whether a comment is a requirement, security annotation, checklist marker, or ordinary text.
 
 ---
 

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -125,6 +125,61 @@ The `query` command's JSON output is similar to the search command but includes 
 }
 ```
 
+When `--with-context` or `--owner-context` is used with `--format json`, Probe keeps the compatible result fields and adds source-block context for each structural match:
+
+```json
+{
+  "schema_version": "probe.query.context.v1",
+  "results": [
+    {
+      "file": "/path/to/api.ts",
+      "lines": [4, 4],
+      "node_type": "match",
+      "content": "fetch(url)",
+      "column_start": 10,
+      "column_end": 20,
+      "language": "typescript",
+      "pattern": {
+        "source": "fetch($$$ARGS)",
+        "id": null
+      },
+      "match": {
+        "node_type": "call_expression",
+        "content": "fetch(url)",
+        "lines": [4, 4],
+        "columns": [10, 20]
+      },
+      "owner": {
+        "symbol": "requestJSON",
+        "qualified_symbol": "requestJSON",
+        "node_type": "function_declaration",
+        "scope": "function",
+        "lines": [1, 5],
+        "columns": [1, 2],
+        "comments": [
+          {
+            "kind": "leading",
+            "start_line": 1,
+            "end_line": 1,
+            "text": "// Handles outbound API calls."
+          }
+        ],
+        "enclosing_symbols": [],
+        "enclosing_calls": []
+      }
+    }
+  ],
+  "summary": {
+    "count": 1,
+    "total_bytes": 10,
+    "total_tokens": 3
+  },
+  "version": "0.0.0"
+}
+```
+
+The context fields are intentionally source facts only. Probe reports owner, match, comment, symbol, and enclosing-call metadata; it does not interpret requirements, policies, test frameworks, or annotation formats.
+
 #### Example: Query JSON Output
 
 ```bash

--- a/docs/reference/output-formats.md
+++ b/docs/reference/output-formats.md
@@ -56,6 +56,29 @@ The `search` command's JSON output includes the following fields for each result
       "lines": [10, 20],                // Start and end line numbers
       "node_type": "function",          // Type of code block (function, class, struct, etc.)
       "code": "fn example() { ... }",   // The actual code content
+      "language": "rust",               // Inferred language when available
+      "scope": "function",              // Generic block scope classification
+      "owner_symbol": "example",        // Owning symbol when available
+      "owner_qualified_symbol": "mod.example", // Qualified owner when available
+      "enclosing_symbols": [            // Containing classes/modules/impls when available
+        { "kind": "module", "name": "mod", "line": 1 }
+      ],
+      "enclosing_calls": [              // Generic call chain for callbacks/call contexts
+        { "callee": "it", "first_arg_literal": "works", "line": 12 }
+      ],
+      "leading_comments": [             // Raw leading comments attached to the block
+        { "kind": "leading", "start_line": 9, "end_line": 9, "text": "// ..." }
+      ],
+      "matches": [                      // Classified textual matches in this result block
+        {
+          "text": "example",
+          "start_line": 10,
+          "start_column": 4,
+          "end_line": 10,
+          "end_column": 11,
+          "kind": "code"
+        }
+      ],
       "matched_keywords": [             // Keywords that matched (if available)
         "example",
         "function"
@@ -72,6 +95,8 @@ The `search` command's JSON output includes the following fields for each result
   }
 }
 ```
+
+Search context fields are source facts only. For example, a match inside a string literal is reported as `matches[].kind == "string"`, and a match in a leading comment is reported as `matches[].kind == "comment"` with `comment_role == "leading"`. Probe does not interpret requirement IDs, test framework names, policy annotations, or comment semantics.
 
 #### Example: Search JSON Output
 

--- a/npm/src/query.js
+++ b/npm/src/query.js
@@ -18,6 +18,7 @@ const QUERY_FLAG_MAP = {
 	language: '--language',
 	ignore: '--ignore',
 	allowTests: '--allow-tests',
+	withContext: '--with-context',
 	maxResults: '--max-results',
 	format: '--format'
 };
@@ -32,6 +33,7 @@ const QUERY_FLAG_MAP = {
  * @param {string} [options.language] - Programming language to search in
  * @param {string[]} [options.ignore] - Patterns to ignore
  * @param {boolean} [options.allowTests] - Include test files
+ * @param {boolean} [options.withContext] - Include owning source-block context in JSON output
  * @param {number} [options.maxResults] - Maximum number of results
  * @param {string} [options.format] - Output format ('markdown', 'plain', 'json', 'color')
  * @param {Object} [options.binaryOptions] - Options for getting the binary

--- a/npm/src/tools/common.js
+++ b/npm/src/tools/common.js
@@ -33,7 +33,8 @@ export const querySchema = z.object({
 	pattern: z.string().describe('AST pattern to search for. Use $NAME for variable names, $$$PARAMS for parameter lists, etc.'),
 	path: z.string().optional().default('.').describe('Path to search in'),
 	language: z.string().optional().default('rust').describe('Programming language to use for parsing'),
-	allow_tests: z.boolean().optional().default(true).describe('Allow test files in search results')
+	allow_tests: z.boolean().optional().default(true).describe('Allow test files in search results'),
+	with_context: z.boolean().optional().default(false).describe('Include owning source-block context in JSON output')
 });
 
 export const extractSchema = z.object({

--- a/npm/src/tools/vercel.js
+++ b/npm/src/tools/vercel.js
@@ -936,7 +936,7 @@ export const queryTool = (options = {}) => {
 		name: 'query',
 		description: queryDescription,
 		inputSchema: querySchema,
-		execute: async ({ pattern, path, language, allow_tests }) => {
+		execute: async ({ pattern, path, language, allow_tests, with_context }) => {
 			try {
 				// Parse and resolve paths (supports comma-separated and relative paths)
 				let queryPaths;
@@ -962,6 +962,7 @@ export const queryTool = (options = {}) => {
 					cwd: options.cwd, // Working directory for resolving relative paths
 					language,
 					allowTests: allow_tests ?? true,
+					withContext: with_context ?? false,
 					json: false
 				});
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -370,6 +370,10 @@ pub enum Commands {
         #[arg(long = "max-results")]
         max_results: Option<usize>,
 
+        /// Include owning source-block context in JSON output
+        #[arg(long = "with-context", alias = "owner-context")]
+        with_context: bool,
+
         /// Output format (default: color)
         /// Use 'json' or 'xml' for machine-readable output with structured data
         #[arg(short = 'o', long = "format", default_value = "color", value_parser = ["markdown", "plain", "json", "xml", "color", "outline-xml"])]

--- a/src/extract/symbols.rs
+++ b/src/extract/symbols.rs
@@ -106,22 +106,23 @@ fn collect_symbols(
         }
 
         if lang.is_symbol_node(&child) {
+            let semantic_child = semantic_symbol_node(&child, lang, source).unwrap_or(child);
             let signature = lang
                 .get_symbol_signature(&child, source)
                 .unwrap_or_else(|| {
                     // Fallback: use the first line of the node text
-                    let text = child.utf8_text(source).unwrap_or("");
+                    let text = semantic_child.utf8_text(source).unwrap_or("");
                     text.lines().next().unwrap_or("").trim().to_string()
                 });
 
-            let name = extract_symbol_name(&child, source);
-            let kind = normalize_kind(child.kind());
-            let start_line = child.start_position().row + 1;
-            let end_line = child.end_position().row + 1;
+            let name = extract_symbol_name(&semantic_child, source);
+            let kind = normalize_kind(semantic_child.kind());
+            let start_line = semantic_child.start_position().row + 1;
+            let end_line = semantic_child.end_position().row + 1;
 
             // Recursively collect children for container nodes
-            let children = if is_container_node(child.kind()) && depth < MAX_SYMBOL_DEPTH {
-                collect_children_symbols(&child, source, lang, allow_tests, depth + 1)
+            let children = if is_container_node(semantic_child.kind()) && depth < MAX_SYMBOL_DEPTH {
+                collect_children_symbols(&semantic_child, source, lang, allow_tests, depth + 1)
             } else {
                 Vec::new()
             };
@@ -138,6 +139,24 @@ fn collect_symbols(
     }
 
     symbols
+}
+
+/// Return the actual declaration represented by wrapper nodes such as
+/// TypeScript/JavaScript `export_statement`.
+fn semantic_symbol_node<'a>(
+    node: &Node<'a>,
+    lang: &dyn crate::language::language_trait::LanguageImpl,
+    source: &[u8],
+) -> Option<Node<'a>> {
+    if !matches!(node.kind(), "export_statement" | "declare_statement") {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    let found = node.children(&mut cursor).find(|child| {
+        lang.is_symbol_node(child) && extract_symbol_name(child, source) != child.kind()
+    });
+    found
 }
 
 /// Collect child symbols from inside a container node's body.
@@ -608,6 +627,46 @@ func (c *Config) Validate() bool {
         let json = serde_json::to_string(&result).unwrap();
         assert!(json.contains("\"kind\":\"function\""));
         assert!(json.contains("\"name\":\"hello\""));
+    }
+
+    #[test]
+    fn test_exported_typescript_symbols_use_inner_declaration_names() {
+        let content = r#"
+export class PolicyService {
+    async evaluatePolicy(input: string): Promise<boolean> {
+        return input.length > 0;
+    }
+}
+
+export const normalizeDecision = (raw: string) => {
+    return raw.trim().toLowerCase();
+};
+"#;
+        let file = create_temp_file(content, "ts");
+        let result = extract_symbols(file.path(), false).unwrap();
+        let names: Vec<&str> = result.symbols.iter().map(|s| s.name.as_str()).collect();
+        let kinds: Vec<&str> = result.symbols.iter().map(|s| s.kind.as_str()).collect();
+
+        assert!(
+            names.contains(&"PolicyService"),
+            "exported class should use class name, got: {:?}",
+            names
+        );
+        assert!(
+            names.contains(&"normalizeDecision"),
+            "exported const arrow should use variable name, got: {:?}",
+            names
+        );
+        assert!(
+            !names.contains(&"export_statement"),
+            "export wrappers should not leak as symbol names: {:?}",
+            names
+        );
+        assert!(
+            kinds.contains(&"class") && kinds.contains(&"variable"),
+            "expected semantic kinds for exported declarations, got: {:?}",
+            kinds
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,13 @@
 //! let options = QueryOptions {
 //!     path: Path::new("."),
 //!     pattern: "fn $NAME($$$PARAMS) { $$$BODY }",
-//!     language: Some("rust".to_string()),
+//!     language: Some("rust"),
 //!     ignore: &[],
 //!     allow_tests: false,
 //!     max_results: None,
-//!     format: "text".to_string(),
+//!     with_context: false,
+//!     format: "text",
+//!     no_gitignore: false,
 //! };
 //!
 //! let matches = perform_query(&options).unwrap();
@@ -108,6 +110,7 @@ pub mod path_safety;
 pub mod query;
 pub mod ranking;
 pub mod search;
+pub mod semantic_context;
 pub mod simd_ranking;
 pub mod simd_test;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -846,6 +846,7 @@ async fn main() -> Result<()> {
             ignore,
             allow_tests,
             max_results,
+            with_context,
             format,
             no_gitignore,
         }) => probe_code::query::handle_query(
@@ -870,6 +871,7 @@ async fn main() -> Result<()> {
             max_results,
             &format,
             no_gitignore || std::env::var("PROBE_NO_GITIGNORE").unwrap_or_default() == "1",
+            with_context,
         )?,
         Some(Commands::Benchmark {
             bench,

--- a/src/query.rs
+++ b/src/query.rs
@@ -12,6 +12,8 @@ use std::time::Instant;
 /// Represents a match found by ast-grep
 pub struct AstMatch {
     pub file_path: PathBuf,
+    pub byte_start: usize,
+    pub byte_end: usize,
     pub line_start: usize,
     pub line_end: usize,
     pub column_start: usize,
@@ -27,6 +29,7 @@ pub struct QueryOptions<'a> {
     pub ignore: &'a [String],
     pub allow_tests: bool,
     pub max_results: Option<usize>,
+    pub with_context: bool,
     #[allow(dead_code)]
     pub format: &'a str,
     pub no_gitignore: bool,
@@ -204,6 +207,8 @@ fn query_file(file_path: &Path, options: &QueryOptions) -> Result<Vec<AstMatch>>
 
         ast_matches.push(AstMatch {
             file_path: file_path.to_path_buf(),
+            byte_start: range.start,
+            byte_end: range.end,
             line_start,
             line_end,
             column_start,
@@ -322,7 +327,12 @@ fn escape_xml(s: &str) -> String {
 }
 
 /// Format and print the query results
-pub fn format_and_print_query_results(matches: &[AstMatch], format: &str) -> Result<()> {
+pub fn format_and_print_query_results(
+    matches: &[AstMatch],
+    format: &str,
+    pattern: &str,
+    with_context: bool,
+) -> Result<()> {
     match format {
         "color" | "terminal" => {
             for m in matches {
@@ -386,19 +396,42 @@ pub fn format_and_print_query_results(matches: &[AstMatch], format: &str) -> Res
             let json_matches_standardized: Vec<_> = matches
                 .iter()
                 .map(|m| {
-                    serde_json::json!({
+                    let mut result = serde_json::json!({
                         "file": m.file_path.to_string_lossy(),
                         "lines": [m.line_start, m.line_end],
                         "node_type": "match",
                         "content": m.matched_text,
                         "column_start": m.column_start,
                         "column_end": m.column_end
-                    })
+                    });
+
+                    if with_context {
+                        if let Some(context) =
+                            probe_code::semantic_context::build_query_source_context(
+                                &m.file_path,
+                                m.byte_start,
+                                m.byte_end,
+                                &m.matched_text,
+                            )
+                        {
+                            result["language"] = serde_json::json!(context.language);
+                            result["pattern"] = serde_json::json!({
+                                "source": pattern,
+                                "id": serde_json::Value::Null,
+                            });
+                            result["match"] = serde_json::json!(context.r#match);
+                            if let Some(owner) = context.owner {
+                                result["owner"] = serde_json::json!(owner);
+                            }
+                        }
+                    }
+
+                    result
                 })
                 .collect();
 
             // Create the wrapper object
-            let wrapper = serde_json::json!({
+            let mut wrapper = serde_json::json!({
                 "results": json_matches_standardized,
                 "summary": {
                     "count": matches.len(),
@@ -407,6 +440,9 @@ pub fn format_and_print_query_results(matches: &[AstMatch], format: &str) -> Res
                 },
                 "version": probe_code::version::get_version()
             });
+            if with_context {
+                wrapper["schema_version"] = serde_json::json!("probe.query.context.v1");
+            }
 
             println!("{}", serde_json::to_string_pretty(&wrapper)?);
         }
@@ -455,7 +491,7 @@ pub fn format_and_print_query_results(matches: &[AstMatch], format: &str) -> Res
         }
         _ => {
             // Default to color format
-            format_and_print_query_results(matches, "color")?;
+            format_and_print_query_results(matches, "color", pattern, with_context)?;
         }
     }
 
@@ -473,6 +509,7 @@ pub fn handle_query(
     max_results: Option<usize>,
     format: &str,
     no_gitignore: bool,
+    with_context: bool,
 ) -> Result<()> {
     // Print version at the start for text-based formats
     if format != "json" && format != "xml" {
@@ -521,6 +558,7 @@ pub fn handle_query(
         ignore,
         allow_tests,
         max_results,
+        with_context,
         format,
         no_gitignore,
     };
@@ -533,7 +571,7 @@ pub fn handle_query(
     if matches.is_empty() {
         // For JSON and XML formats, still call format_and_print_query_results
         if format == "json" || format == "xml" {
-            format_and_print_query_results(&matches, format)?;
+            format_and_print_query_results(&matches, format, pattern, with_context)?;
         } else {
             // For other formats, print the "No results found" message
             println!("{}", "No results found.".yellow().bold());
@@ -546,7 +584,7 @@ pub fn handle_query(
             println!();
         }
 
-        format_and_print_query_results(&matches, format)?;
+        format_and_print_query_results(&matches, format, pattern, with_context)?;
 
         // Skip summary for JSON and XML formats
         if format != "json" && format != "xml" {

--- a/src/query.rs
+++ b/src/query.rs
@@ -385,12 +385,19 @@ pub fn format_and_print_query_results(
             }
         }
         "json" => {
+            use std::collections::HashMap;
+
             // BATCH TOKENIZATION WITH DEDUPLICATION OPTIMIZATION for query JSON output:
             // Process all matched text in batch to leverage content deduplication
             use probe_code::search::search_tokens::sum_tokens_with_deduplication;
+            use probe_code::semantic_context::ParsedSourceContext;
+
             let matched_texts: Vec<&str> =
                 matches.iter().map(|m| m.matched_text.as_str()).collect();
             let total_tokens = sum_tokens_with_deduplication(&matched_texts);
+
+            let mut parsed_files: HashMap<std::path::PathBuf, Option<ParsedSourceContext>> =
+                HashMap::new();
 
             // Create standardized results
             let json_matches_standardized: Vec<_> = matches
@@ -406,14 +413,12 @@ pub fn format_and_print_query_results(
                     });
 
                     if with_context {
-                        if let Some(context) =
-                            probe_code::semantic_context::build_query_source_context(
-                                &m.file_path,
-                                m.byte_start,
-                                m.byte_end,
-                                &m.matched_text,
-                            )
-                        {
+                        let parsed = parsed_files
+                            .entry(m.file_path.clone())
+                            .or_insert_with(|| ParsedSourceContext::parse(&m.file_path));
+                        if let Some(context) = parsed.as_ref().and_then(|parsed| {
+                            parsed.query_source_context(m.byte_start, m.byte_end, &m.matched_text)
+                        }) {
                             result["language"] = serde_json::json!(context.language);
                             result["pattern"] = serde_json::json!({
                                 "source": pattern,

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -8,6 +8,10 @@ use probe_code::language::is_test_file;
 use probe_code::models::SearchResult;
 use probe_code::search::query::QueryPlan;
 use probe_code::search::search_tokens::sum_tokens_with_deduplication;
+use probe_code::semantic_context::{
+    classify_scope_from_node, classify_text_matches_in_block, extract_owner_symbol_from_source,
+    language_name_for_path, leading_comments_from_block, SourceComment, SourceMatch,
+};
 
 /// Create a cache of file contents for outline formatters to avoid redundant I/O
 pub fn create_file_content_cache(results: &[&SearchResult]) -> HashMap<PathBuf, Arc<String>> {
@@ -569,6 +573,8 @@ fn format_and_print_json_results(
     #[derive(serde::Serialize)]
     struct JsonResult<'a> {
         file: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        language: Option<&'static str>,
         lines: [usize; 2],
         node_type: &'a str,
         code: &'a str,
@@ -586,6 +592,12 @@ fn format_and_print_json_results(
         // The owning symbol name (function, class, method) for this block
         #[serde(skip_serializing_if = "Option::is_none")]
         owner_symbol: Option<String>,
+        // Raw source comments attached at the start of this block.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        leading_comments: Vec<SourceComment>,
+        // Classified textual match locations within this returned block.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        matches: Vec<SourceMatch>,
         // Symbol signature (when symbols flag is used)
         symbol_signature: Option<&'a String>,
         // Include other relevant fields
@@ -630,9 +642,17 @@ fn format_and_print_json_results(
                 is_test.is_some(),
             );
             let owner = extract_owner_symbol(&r.code, &r.node_type);
+            let leading_comments = leading_comments_from_block(&r.code, r.lines.0);
+            let matches = classify_text_matches_in_block(
+                &r.code,
+                r.lines.0,
+                r.matched_keywords.as_ref(),
+                &leading_comments,
+            );
 
             JsonResult {
                 file: &r.file,
+                language: language_name_for_path(file_path),
                 lines: [r.lines.0, r.lines.1],
                 node_type: &r.node_type,
                 code: &r.code,
@@ -641,6 +661,8 @@ fn format_and_print_json_results(
                 is_doc: if doc { Some(true) } else { None },
                 is_example: if fenced_example { Some(true) } else { None },
                 owner_symbol: owner,
+                leading_comments,
+                matches,
                 symbol_signature: r.symbol_signature.as_ref(),
                 matched_keywords: r.matched_keywords.as_ref(),
                 score: r.score,
@@ -818,51 +840,9 @@ fn classify_scope<'a>(
     is_example: bool,
     is_test: bool,
 ) -> &'a str {
-    if is_test {
-        return "test";
-    }
-    if is_example {
-        return "example";
-    }
-    if is_doc {
-        return "doc";
-    }
-
-    // Function-like blocks
-    if node_type.contains("function")
-        || node_type.contains("method")
-        || node_type.contains("fn")
-        || node_type.contains("func")
-        || node_type.contains("arrow_function")
-        || node_type.contains("closure")
-    {
-        return "function";
-    }
-
-    // Module/package level
-    if node_type.contains("module")
-        || node_type == "program"
-        || node_type == "source_file"
-        || node_type == "compilation_unit"
-        || node_type.contains("package")
-        || node_type.contains("namespace")
-    {
-        return "module";
-    }
-
-    // Declaration-level (types, structs, classes, interfaces, enums, consts)
-    if node_type.contains("class")
-        || node_type.contains("struct")
-        || node_type.contains("type_declaration")
-        || node_type.contains("interface")
-        || node_type.contains("enum")
-        || node_type.contains("impl")
-        || node_type.contains("trait")
-        || node_type.contains("const")
-        || node_type.contains("var_declaration")
-        || node_type.contains("lexical_declaration")
-    {
-        return "declaration";
+    let shared_scope = classify_scope_from_node(node_type, code, is_doc, is_example, is_test);
+    if shared_scope != "declaration" {
+        return shared_scope;
     }
 
     // Comment blocks attached to functions — check code content for function signature
@@ -894,6 +874,10 @@ fn extract_owner_symbol(code: &str, node_type: &str) -> Option<String> {
         || node_type == "heading"
     {
         return None;
+    }
+
+    if let Some(owner) = extract_owner_symbol_from_source(code, node_type) {
+        return Some(owner);
     }
 
     for line in code.lines().take(15) {
@@ -3668,6 +3652,24 @@ mod tests {
         assert_eq!(
             extract_owner_symbol("async function fetchData() {}", "function_declaration"),
             Some("fetchData".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_owner_ts_method_and_exported_arrow() {
+        assert_eq!(
+            extract_owner_symbol(
+                "  // Implements: SYS-REQ-424\n  async evaluatePolicy(input: string): Promise<boolean> {\n    return true;\n  }",
+                "method_definition"
+            ),
+            Some("evaluatePolicy".to_string())
+        );
+        assert_eq!(
+            extract_owner_symbol(
+                "// Implements: SYS-REQ-425\nexport const normalizeDecision = (raw: string) => {\n  return raw.trim();\n};",
+                "export_statement"
+            ),
+            Some("normalizeDecision".to_string())
         );
     }
 

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -9,9 +9,9 @@ use probe_code::models::SearchResult;
 use probe_code::search::query::QueryPlan;
 use probe_code::search::search_tokens::sum_tokens_with_deduplication;
 use probe_code::semantic_context::{
-    build_search_owner_context, classify_scope_from_node, classify_text_matches_in_block,
-    extract_owner_symbol_from_source, language_name_for_path, leading_comments_from_block,
-    EnclosingCall, EnclosingSymbol, SourceComment, SourceMatch,
+    classify_scope_from_node, classify_text_matches_in_block, extract_owner_symbol_from_source,
+    language_name_for_path, leading_comments_from_block, EnclosingCall, EnclosingSymbol,
+    ParsedSourceContext, SourceComment, SourceMatch,
 };
 
 /// Create a cache of file contents for outline formatters to avoid redundant I/O
@@ -627,6 +627,11 @@ fn format_and_print_json_results(
         all: usize,
     }
 
+    let mut parsed_files: std::collections::HashMap<
+        std::path::PathBuf,
+        Option<ParsedSourceContext>,
+    > = std::collections::HashMap::new();
+
     let json_results: Vec<JsonResult> = results
         .iter()
         .map(|r| {
@@ -651,8 +656,14 @@ fn format_and_print_json_results(
                 is_test.is_some(),
             );
             let owner = extract_owner_symbol(&r.code, &r.node_type);
-            let owner_context =
-                build_search_owner_context(file_path, r.lines.0, r.lines.1, &r.code);
+            let owner_context = {
+                let parsed = parsed_files
+                    .entry(file_path.to_path_buf())
+                    .or_insert_with(|| ParsedSourceContext::parse(file_path));
+                parsed
+                    .as_ref()
+                    .and_then(|parsed| parsed.search_owner_context(r.lines.0, r.lines.1, &r.code))
+            };
             let leading_comments = leading_comments_from_block(&r.code, r.lines.0);
             let matches = classify_text_matches_in_block(
                 &r.code,
@@ -671,11 +682,10 @@ fn format_and_print_json_results(
                 is_test,
                 is_doc: if doc { Some(true) } else { None },
                 is_example: if fenced_example { Some(true) } else { None },
-                owner_symbol: owner.or_else(|| {
-                    owner_context
-                        .as_ref()
-                        .and_then(|context| context.symbol.clone())
-                }),
+                owner_symbol: owner_context
+                    .as_ref()
+                    .and_then(|context| context.symbol.clone())
+                    .or(owner),
                 owner_qualified_symbol: owner_context
                     .as_ref()
                     .and_then(|context| context.qualified_symbol.clone()),

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -9,8 +9,9 @@ use probe_code::models::SearchResult;
 use probe_code::search::query::QueryPlan;
 use probe_code::search::search_tokens::sum_tokens_with_deduplication;
 use probe_code::semantic_context::{
-    classify_scope_from_node, classify_text_matches_in_block, extract_owner_symbol_from_source,
-    language_name_for_path, leading_comments_from_block, SourceComment, SourceMatch,
+    build_search_owner_context, classify_scope_from_node, classify_text_matches_in_block,
+    extract_owner_symbol_from_source, language_name_for_path, leading_comments_from_block,
+    EnclosingCall, EnclosingSymbol, SourceComment, SourceMatch,
 };
 
 /// Create a cache of file contents for outline formatters to avoid redundant I/O
@@ -592,6 +593,14 @@ fn format_and_print_json_results(
         // The owning symbol name (function, class, method) for this block
         #[serde(skip_serializing_if = "Option::is_none")]
         owner_symbol: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        owner_qualified_symbol: Option<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        enclosing_symbols: Vec<EnclosingSymbol>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        enclosing_call: Option<EnclosingCall>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        enclosing_calls: Vec<EnclosingCall>,
         // Raw source comments attached at the start of this block.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         leading_comments: Vec<SourceComment>,
@@ -642,6 +651,8 @@ fn format_and_print_json_results(
                 is_test.is_some(),
             );
             let owner = extract_owner_symbol(&r.code, &r.node_type);
+            let owner_context =
+                build_search_owner_context(file_path, r.lines.0, r.lines.1, &r.code);
             let leading_comments = leading_comments_from_block(&r.code, r.lines.0);
             let matches = classify_text_matches_in_block(
                 &r.code,
@@ -660,7 +671,25 @@ fn format_and_print_json_results(
                 is_test,
                 is_doc: if doc { Some(true) } else { None },
                 is_example: if fenced_example { Some(true) } else { None },
-                owner_symbol: owner,
+                owner_symbol: owner.or_else(|| {
+                    owner_context
+                        .as_ref()
+                        .and_then(|context| context.symbol.clone())
+                }),
+                owner_qualified_symbol: owner_context
+                    .as_ref()
+                    .and_then(|context| context.qualified_symbol.clone()),
+                enclosing_symbols: owner_context
+                    .as_ref()
+                    .map(|context| context.enclosing_symbols.clone())
+                    .unwrap_or_default(),
+                enclosing_call: owner_context
+                    .as_ref()
+                    .and_then(|context| context.enclosing_call.clone()),
+                enclosing_calls: owner_context
+                    .as_ref()
+                    .map(|context| context.enclosing_calls.clone())
+                    .unwrap_or_default(),
                 leading_comments,
                 matches,
                 symbol_signature: r.symbol_signature.as_ref(),

--- a/src/semantic_context.rs
+++ b/src/semantic_context.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 use std::path::Path;
-use tree_sitter::Node;
+use tree_sitter::{Node, Tree};
 
 use crate::language::{factory::get_language_impl, get_pooled_parser, return_pooled_parser};
 
@@ -110,44 +110,7 @@ pub fn build_query_source_context(
     byte_end: usize,
     fallback_text: &str,
 ) -> Option<QuerySourceContext> {
-    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-    let language = language_name_for_path(path)?.to_string();
-    let source = std::fs::read_to_string(path).ok()?;
-    let source_bytes = source.as_bytes();
-
-    let _language_impl = get_language_impl(extension)?;
-    let mut parser = get_pooled_parser(extension).ok()?;
-    let tree = parser.parse(&source, None)?;
-    let root = tree.root_node();
-    let matched = find_smallest_covering_node(root, byte_start, byte_end).unwrap_or(root);
-
-    let matched_text = matched
-        .utf8_text(source_bytes)
-        .map(|text| text.to_string())
-        .unwrap_or_else(|_| fallback_text.to_string());
-
-    let owner = find_owner_node(matched)
-        .map(|owner_node| build_owner_context(owner_node, matched, &source, source_bytes));
-
-    let context = QuerySourceContext {
-        language,
-        r#match: MatchContext {
-            node_type: matched.kind().to_string(),
-            content: matched_text,
-            lines: [
-                matched.start_position().row + 1,
-                matched.end_position().row + 1,
-            ],
-            columns: [
-                matched.start_position().column + 1,
-                matched.end_position().column + 1,
-            ],
-        },
-        owner,
-    };
-
-    return_pooled_parser(extension, parser);
-    Some(context)
+    ParsedSourceContext::parse(path)?.query_source_context(byte_start, byte_end, fallback_text)
 }
 
 pub fn build_search_owner_context(
@@ -156,27 +119,88 @@ pub fn build_search_owner_context(
     end_line: usize,
     fallback_code: &str,
 ) -> Option<OwnerContext> {
-    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-    let source = std::fs::read_to_string(path).ok()?;
-    let source_bytes = source.as_bytes();
+    ParsedSourceContext::parse(path)?.search_owner_context(start_line, end_line, fallback_code)
+}
 
-    let _language_impl = get_language_impl(extension)?;
-    let mut parser = get_pooled_parser(extension).ok()?;
-    let tree = parser.parse(&source, None)?;
-    let root = tree.root_node();
-    let owner = find_search_owner_node(root, start_line, end_line);
-    let context = owner.map(|owner| build_owner_context(owner, owner, &source, source_bytes));
+pub struct ParsedSourceContext {
+    language: String,
+    source: String,
+    tree: Tree,
+}
 
-    return_pooled_parser(extension, parser);
+impl ParsedSourceContext {
+    pub fn parse(path: &Path) -> Option<Self> {
+        let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+        let language = language_name_for_path(path)?.to_string();
+        let source = std::fs::read_to_string(path).ok()?;
 
-    let context = context?;
-    if context.content.is_some() {
-        Some(context)
-    } else {
-        Some(OwnerContext {
-            content: Some(fallback_code.to_string()),
-            ..context
+        let _language_impl = get_language_impl(extension)?;
+        let mut parser = get_pooled_parser(extension).ok()?;
+        let tree = parser.parse(&source, None);
+        return_pooled_parser(extension, parser);
+
+        Some(Self {
+            language,
+            source,
+            tree: tree?,
         })
+    }
+
+    pub fn query_source_context(
+        &self,
+        byte_start: usize,
+        byte_end: usize,
+        fallback_text: &str,
+    ) -> Option<QuerySourceContext> {
+        let source_bytes = self.source.as_bytes();
+        let root = self.tree.root_node();
+        let matched = find_smallest_covering_node(root, byte_start, byte_end).unwrap_or(root);
+
+        let matched_text = matched
+            .utf8_text(source_bytes)
+            .map(|text| text.to_string())
+            .unwrap_or_else(|_| fallback_text.to_string());
+
+        let owner = find_owner_node(matched)
+            .map(|owner_node| build_owner_context(owner_node, matched, &self.source, source_bytes));
+
+        Some(QuerySourceContext {
+            language: self.language.clone(),
+            r#match: MatchContext {
+                node_type: matched.kind().to_string(),
+                content: matched_text,
+                lines: [
+                    matched.start_position().row + 1,
+                    matched.end_position().row + 1,
+                ],
+                columns: [
+                    matched.start_position().column + 1,
+                    matched.end_position().column + 1,
+                ],
+            },
+            owner,
+        })
+    }
+
+    pub fn search_owner_context(
+        &self,
+        start_line: usize,
+        end_line: usize,
+        fallback_code: &str,
+    ) -> Option<OwnerContext> {
+        let source_bytes = self.source.as_bytes();
+        let root = self.tree.root_node();
+        let owner = find_search_owner_node(root, start_line, end_line)?;
+        let context = build_owner_context(owner, owner, &self.source, source_bytes);
+
+        if context.content.is_some() {
+            Some(context)
+        } else {
+            Some(OwnerContext {
+                content: Some(fallback_code.to_string()),
+                ..context
+            })
+        }
     }
 }
 

--- a/src/semantic_context.rs
+++ b/src/semantic_context.rs
@@ -265,6 +265,7 @@ pub fn extract_owner_symbol_from_source(code: &str, node_type: &str) -> Option<S
 pub fn leading_comments_from_block(code: &str, start_line: usize) -> Vec<SourceComment> {
     let mut comments = Vec::new();
     let mut pending: Option<(usize, usize, Vec<String>)> = None;
+    let mut in_block_comment = false;
 
     for (idx, line) in code.lines().enumerate() {
         let line_no = start_line + idx;
@@ -275,7 +276,9 @@ pub fn leading_comments_from_block(code: &str, start_line: usize) -> Vec<SourceC
             }
             continue;
         }
-        if is_comment_line(trimmed) {
+
+        let starts_comment = is_comment_line(trimmed) || in_block_comment;
+        if starts_comment {
             match &mut pending {
                 Some((_, end, lines)) => {
                     *end = line_no;
@@ -284,6 +287,13 @@ pub fn leading_comments_from_block(code: &str, start_line: usize) -> Vec<SourceC
                 None => {
                     pending = Some((line_no, line_no, vec![trimmed.to_string()]));
                 }
+            }
+
+            if starts_block_comment(trimmed) && !ends_block_comment(trimmed) {
+                in_block_comment = true;
+            }
+            if in_block_comment && ends_block_comment(trimmed) {
+                in_block_comment = false;
             }
             continue;
         }
@@ -325,7 +335,7 @@ pub fn classify_text_matches_in_block(
                 let byte_start = search_start + relative_pos;
                 let byte_end = byte_start + needle.len();
                 let line_no = start_line + line_idx;
-                let kind = classify_line_match_kind(line, byte_start);
+                let kind = classify_match_kind_at(code, line_idx, byte_start);
                 let comment_role = if kind == "comment"
                     && leading_comments
                         .iter()
@@ -380,28 +390,6 @@ pub fn classify_scope_from_node(
         return "module";
     }
     "declaration"
-}
-
-fn classify_line_match_kind(line: &str, byte_start: usize) -> String {
-    let before = line.get(..byte_start).unwrap_or("");
-    let trimmed_before = before.trim_start();
-    if trimmed_before.starts_with("//")
-        || trimmed_before.starts_with('#')
-        || trimmed_before.starts_with('*')
-        || trimmed_before.starts_with("/*")
-    {
-        return "comment".to_string();
-    }
-
-    let quote_count = before
-        .chars()
-        .filter(|ch| matches!(ch, '"' | '\'' | '`'))
-        .count();
-    if quote_count % 2 == 1 {
-        return "string".to_string();
-    }
-
-    "code".to_string()
 }
 
 fn build_owner_context(
@@ -712,6 +700,118 @@ fn is_comment_line(trimmed: &str) -> bool {
         || trimmed.starts_with("*")
         || trimmed.starts_with("/*")
         || trimmed.starts_with("*/")
+        || trimmed.starts_with("<!--")
+        || trimmed.starts_with("-->")
+}
+
+fn starts_block_comment(trimmed: &str) -> bool {
+    trimmed.starts_with("/*") || trimmed.starts_with("<!--")
+}
+
+fn ends_block_comment(trimmed: &str) -> bool {
+    trimmed.contains("*/") || trimmed.contains("-->")
+}
+
+fn classify_match_kind_at(code: &str, target_line_idx: usize, target_byte_start: usize) -> String {
+    let mut state = LexicalState::default();
+
+    for (line_idx, line) in code.lines().enumerate() {
+        state.line_comment = false;
+        let stop_at = if line_idx == target_line_idx {
+            Some(target_byte_start)
+        } else {
+            None
+        };
+
+        if scan_line_until(line, stop_at, &mut state) {
+            return if state.block_comment_end.is_some() {
+                "comment".to_string()
+            } else if state.line_comment {
+                "comment".to_string()
+            } else if state.quote.is_some() {
+                "string".to_string()
+            } else {
+                "code".to_string()
+            };
+        }
+    }
+
+    "code".to_string()
+}
+
+fn scan_line_until(line: &str, stop_at: Option<usize>, state: &mut LexicalState) -> bool {
+    let mut idx = 0;
+    let line_len = line.len();
+    let stop = stop_at.unwrap_or(line_len).min(line_len);
+
+    while idx < stop {
+        let rest = &line[idx..];
+
+        if let Some(end_marker) = state.block_comment_end {
+            if let Some(end_offset) = rest.find(end_marker) {
+                let end_idx = idx + end_offset + end_marker.len();
+                if end_idx > stop {
+                    return true;
+                }
+                state.block_comment_end = None;
+                idx = end_idx;
+                continue;
+            }
+            return stop_at.is_some();
+        }
+
+        if let Some(quote) = state.quote {
+            let Some(ch) = rest.chars().next() else {
+                break;
+            };
+            if state.escaped {
+                state.escaped = false;
+            } else if ch == '\\' {
+                state.escaped = true;
+            } else if ch == quote {
+                state.quote = None;
+            }
+            idx += ch.len_utf8();
+            continue;
+        }
+
+        if rest.starts_with("//") || rest.starts_with('#') {
+            if stop_at.is_none() {
+                return false;
+            }
+            state.line_comment = true;
+            return true;
+        }
+        if rest.starts_with("/*") {
+            state.block_comment_end = Some("*/");
+            idx += 2;
+            continue;
+        }
+        if rest.starts_with("<!--") {
+            state.block_comment_end = Some("-->");
+            idx += 4;
+            continue;
+        }
+
+        let Some(ch) = rest.chars().next() else {
+            break;
+        };
+        if matches!(ch, '"' | '\'' | '`') {
+            state.quote = Some(ch);
+            state.escaped = false;
+        }
+        idx += ch.len_utf8();
+    }
+
+    stop_at.is_some()
+}
+
+#[derive(Default)]
+struct LexicalState {
+    block_comment_end: Option<&'static str>,
+    line_comment: bool,
+    quote: Option<char>,
+    escaped: bool,
 }
 
 fn extract_name_after_keyword(line: &str, prefix: &str) -> Option<String> {
@@ -745,24 +845,41 @@ mod tests {
 
     #[test]
     fn test_classify_text_matches_in_comments_and_strings() {
-        let code = r#"// Implements: SYS-REQ-1
+        let code = r#"/*
+ * Implements: SYS-REQ-0
+ */
+// Implements: SYS-REQ-1
 export const literalOnly = "SYS-REQ-2";
+const templateLiteral = `
+  SYS-REQ-4
+`;
 export function run() {
   return SYS_REQ_3;
 }"#;
         let comments = leading_comments_from_block(code, 10);
         let keywords = vec![
+            "SYS-REQ-0".to_string(),
             "SYS-REQ-1".to_string(),
             "SYS-REQ-2".to_string(),
             "SYS_REQ_3".to_string(),
+            "SYS-REQ-4".to_string(),
         ];
 
         let matches = classify_text_matches_in_block(code, 10, Some(&keywords), &comments);
 
-        assert_eq!(matches.len(), 3);
+        assert_eq!(matches.len(), 5);
         assert_eq!(matches[0].kind, "comment");
         assert_eq!(matches[0].comment_role.as_deref(), Some("leading"));
-        assert_eq!(matches[1].kind, "string");
-        assert_eq!(matches[2].kind, "code");
+        assert_eq!(matches[1].kind, "comment");
+        assert_eq!(matches[1].comment_role.as_deref(), Some("leading"));
+        assert_eq!(matches[2].kind, "string");
+        assert_eq!(matches[3].kind, "code");
+        assert_eq!(matches[4].kind, "string");
+
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].start_line, 10);
+        assert_eq!(comments[0].end_line, 13);
+        assert!(comments[0].text.contains("SYS-REQ-0"));
+        assert!(comments[0].text.contains("SYS-REQ-1"));
     }
 }

--- a/src/semantic_context.rs
+++ b/src/semantic_context.rs
@@ -150,6 +150,36 @@ pub fn build_query_source_context(
     Some(context)
 }
 
+pub fn build_search_owner_context(
+    path: &Path,
+    start_line: usize,
+    end_line: usize,
+    fallback_code: &str,
+) -> Option<OwnerContext> {
+    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+    let source = std::fs::read_to_string(path).ok()?;
+    let source_bytes = source.as_bytes();
+
+    let _language_impl = get_language_impl(extension)?;
+    let mut parser = get_pooled_parser(extension).ok()?;
+    let tree = parser.parse(&source, None)?;
+    let root = tree.root_node();
+    let owner = find_search_owner_node(root, start_line, end_line);
+    let context = owner.map(|owner| build_owner_context(owner, owner, &source, source_bytes));
+
+    return_pooled_parser(extension, parser);
+
+    let context = context?;
+    if context.content.is_some() {
+        Some(context)
+    } else {
+        Some(OwnerContext {
+            content: Some(fallback_code.to_string()),
+            ..context
+        })
+    }
+}
+
 pub fn extract_owner_symbol_from_source(code: &str, node_type: &str) -> Option<String> {
     if matches!(node_type, "section" | "document" | "paragraph" | "heading") {
         return None;
@@ -470,6 +500,49 @@ fn find_owner_node<'a>(node: Node<'a>) -> Option<Node<'a>> {
         current = candidate.parent();
     }
     None
+}
+
+fn find_search_owner_node<'a>(
+    root: Node<'a>,
+    start_line: usize,
+    end_line: usize,
+) -> Option<Node<'a>> {
+    let mut candidates = Vec::new();
+    collect_owner_nodes_in_line_range(root, start_line, end_line, &mut candidates);
+
+    candidates
+        .into_iter()
+        .min_by_key(|node| {
+            let line_span = node
+                .end_position()
+                .row
+                .saturating_sub(node.start_position().row);
+            (line_span, node.end_byte().saturating_sub(node.start_byte()))
+        })
+        .map(normalize_owner_node)
+}
+
+fn collect_owner_nodes_in_line_range<'a>(
+    node: Node<'a>,
+    start_line: usize,
+    end_line: usize,
+    candidates: &mut Vec<Node<'a>>,
+) {
+    let node_start = node.start_position().row + 1;
+    let node_end = node.end_position().row + 1;
+
+    if node_end < start_line || node_start > end_line {
+        return;
+    }
+
+    if is_owner_node(node) && node_start >= start_line && node_end <= end_line {
+        candidates.push(node);
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_owner_nodes_in_line_range(child, start_line, end_line, candidates);
+    }
 }
 
 fn normalize_owner_node(node: Node) -> Node {

--- a/src/semantic_context.rs
+++ b/src/semantic_context.rs
@@ -1,0 +1,768 @@
+use serde::Serialize;
+use std::path::Path;
+use tree_sitter::Node;
+
+use crate::language::{factory::get_language_impl, get_pooled_parser, return_pooled_parser};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceRange {
+    pub lines: [usize; 2],
+    pub columns: [usize; 2],
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceComment {
+    pub kind: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SourceMatch {
+    pub text: String,
+    pub start_line: usize,
+    pub start_column: usize,
+    pub end_line: usize,
+    pub end_column: usize,
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment_role: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EnclosingSymbol {
+    pub kind: String,
+    pub name: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EnclosingCall {
+    pub callee: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_arg_literal: Option<String>,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MatchContext {
+    pub node_type: String,
+    pub content: String,
+    pub lines: [usize; 2],
+    pub columns: [usize; 2],
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OwnerContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub qualified_symbol: Option<String>,
+    pub node_type: String,
+    pub scope: String,
+    pub lines: [usize; 2],
+    pub columns: [usize; 2],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<SourceComment>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub enclosing_symbols: Vec<EnclosingSymbol>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enclosing_call: Option<EnclosingCall>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub enclosing_calls: Vec<EnclosingCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QuerySourceContext {
+    pub language: String,
+    pub r#match: MatchContext,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<OwnerContext>,
+}
+
+pub fn language_name_for_path(path: &Path) -> Option<&'static str> {
+    match path.extension().and_then(|ext| ext.to_str()).unwrap_or("") {
+        "rs" => Some("rust"),
+        "js" | "jsx" | "mjs" => Some("javascript"),
+        "ts" | "tsx" => Some("typescript"),
+        "py" => Some("python"),
+        "go" => Some("go"),
+        "c" | "h" => Some("c"),
+        "cpp" | "cc" | "cxx" | "hpp" | "hxx" => Some("cpp"),
+        "java" => Some("java"),
+        "rb" => Some("ruby"),
+        "php" => Some("php"),
+        "swift" => Some("swift"),
+        "cs" => Some("csharp"),
+        "html" | "htm" => Some("html"),
+        "md" | "markdown" => Some("markdown"),
+        "yaml" | "yml" => Some("yaml"),
+        _ => None,
+    }
+}
+
+pub fn build_query_source_context(
+    path: &Path,
+    byte_start: usize,
+    byte_end: usize,
+    fallback_text: &str,
+) -> Option<QuerySourceContext> {
+    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+    let language = language_name_for_path(path)?.to_string();
+    let source = std::fs::read_to_string(path).ok()?;
+    let source_bytes = source.as_bytes();
+
+    let _language_impl = get_language_impl(extension)?;
+    let mut parser = get_pooled_parser(extension).ok()?;
+    let tree = parser.parse(&source, None)?;
+    let root = tree.root_node();
+    let matched = find_smallest_covering_node(root, byte_start, byte_end).unwrap_or(root);
+
+    let matched_text = matched
+        .utf8_text(source_bytes)
+        .map(|text| text.to_string())
+        .unwrap_or_else(|_| fallback_text.to_string());
+
+    let owner = find_owner_node(matched)
+        .map(|owner_node| build_owner_context(owner_node, matched, &source, source_bytes));
+
+    let context = QuerySourceContext {
+        language,
+        r#match: MatchContext {
+            node_type: matched.kind().to_string(),
+            content: matched_text,
+            lines: [
+                matched.start_position().row + 1,
+                matched.end_position().row + 1,
+            ],
+            columns: [
+                matched.start_position().column + 1,
+                matched.end_position().column + 1,
+            ],
+        },
+        owner,
+    };
+
+    return_pooled_parser(extension, parser);
+    Some(context)
+}
+
+pub fn extract_owner_symbol_from_source(code: &str, node_type: &str) -> Option<String> {
+    if matches!(node_type, "section" | "document" | "paragraph" | "heading") {
+        return None;
+    }
+
+    for line in code.lines().take(20) {
+        let trimmed = line.trim();
+
+        if let Some(name) = extract_name_after_keyword(trimmed, "func ") {
+            return Some(name);
+        }
+        if trimmed.starts_with("func (") {
+            if let Some(after_recv) = trimmed.split(')').nth(1) {
+                let name = after_recv.trim().split('(').next().unwrap_or("").trim();
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        if let Some(fn_pos) = trimmed.find("fn ") {
+            let valid_prefix = fn_pos == 0
+                || trimmed
+                    .as_bytes()
+                    .get(fn_pos - 1)
+                    .map_or(false, |&b| b == b' ' || b == b')');
+            if valid_prefix {
+                let name = trimmed[fn_pos + 3..]
+                    .split(|c: char| c == '(' || c == '<' || c == ' ')
+                    .next()
+                    .unwrap_or("")
+                    .trim();
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "def ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "class ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "export class ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "interface ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "export interface ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "type ") {
+            return Some(name);
+        }
+        if let Some(name) = extract_name_after_keyword(trimmed, "export type ") {
+            return Some(name);
+        }
+        for prefix in [
+            "function ",
+            "async function ",
+            "export function ",
+            "export default function ",
+            "export async function ",
+            "export default async function ",
+        ] {
+            if let Some(name) = extract_name_after_keyword(trimmed, prefix) {
+                return Some(name);
+            }
+        }
+        for prefix in [
+            "export const ",
+            "export let ",
+            "export var ",
+            "const ",
+            "let ",
+            "var ",
+        ] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                let name = rest
+                    .split(|c: char| c == '=' || c == ':' || c == '(' || c.is_whitespace())
+                    .next()
+                    .unwrap_or("")
+                    .trim();
+                if !name.is_empty() {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        if node_type == "method_definition" || node_type.contains("method") {
+            let without_modifiers = trimmed
+                .trim_start_matches("async ")
+                .trim_start_matches("public ")
+                .trim_start_matches("private ")
+                .trim_start_matches("protected ")
+                .trim_start_matches("static ");
+            let name = without_modifiers
+                .split(|c: char| c == '(' || c == '<' || c == ':')
+                .next()
+                .unwrap_or("")
+                .trim();
+            if !name.is_empty()
+                && !matches!(name, "if" | "for" | "while" | "switch" | "return")
+                && !name.starts_with("//")
+            {
+                return Some(name.to_string());
+            }
+        }
+    }
+
+    None
+}
+
+pub fn leading_comments_from_block(code: &str, start_line: usize) -> Vec<SourceComment> {
+    let mut comments = Vec::new();
+    let mut pending: Option<(usize, usize, Vec<String>)> = None;
+
+    for (idx, line) in code.lines().enumerate() {
+        let line_no = start_line + idx;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if pending.is_some() {
+                break;
+            }
+            continue;
+        }
+        if is_comment_line(trimmed) {
+            match &mut pending {
+                Some((_, end, lines)) => {
+                    *end = line_no;
+                    lines.push(trimmed.to_string());
+                }
+                None => {
+                    pending = Some((line_no, line_no, vec![trimmed.to_string()]));
+                }
+            }
+            continue;
+        }
+        break;
+    }
+
+    if let Some((start, end, lines)) = pending {
+        comments.push(SourceComment {
+            kind: "leading".to_string(),
+            start_line: start,
+            end_line: end,
+            text: lines.join("\n"),
+        });
+    }
+
+    comments
+}
+
+pub fn classify_text_matches_in_block(
+    code: &str,
+    start_line: usize,
+    matched_keywords: Option<&Vec<String>>,
+    leading_comments: &[SourceComment],
+) -> Vec<SourceMatch> {
+    let mut matches = Vec::new();
+    let Some(keywords) = matched_keywords else {
+        return matches;
+    };
+
+    for keyword in keywords {
+        if keyword.is_empty() {
+            continue;
+        }
+        let needle = keyword.to_lowercase();
+        for (line_idx, line) in code.lines().enumerate() {
+            let haystack = line.to_lowercase();
+            let mut search_start = 0;
+            while let Some(relative_pos) = haystack[search_start..].find(&needle) {
+                let byte_start = search_start + relative_pos;
+                let byte_end = byte_start + needle.len();
+                let line_no = start_line + line_idx;
+                let kind = classify_line_match_kind(line, byte_start);
+                let comment_role = if kind == "comment"
+                    && leading_comments
+                        .iter()
+                        .any(|comment| line_no >= comment.start_line && line_no <= comment.end_line)
+                {
+                    Some("leading".to_string())
+                } else {
+                    None
+                };
+
+                matches.push(SourceMatch {
+                    text: line
+                        .get(byte_start..byte_end)
+                        .unwrap_or(keyword.as_str())
+                        .to_string(),
+                    start_line: line_no,
+                    start_column: byte_start + 1,
+                    end_line: line_no,
+                    end_column: byte_end + 1,
+                    kind,
+                    comment_role,
+                });
+
+                search_start = byte_end;
+            }
+        }
+    }
+
+    matches
+}
+
+pub fn classify_scope_from_node(
+    node_type: &str,
+    code: &str,
+    is_doc: bool,
+    is_example: bool,
+    is_test: bool,
+) -> &'static str {
+    if is_test {
+        return "test";
+    }
+    if is_example {
+        return "example";
+    }
+    if is_doc {
+        return "doc";
+    }
+    if is_function_like(node_type) || code.lines().take(5).any(|line| line.contains("=>")) {
+        return "function";
+    }
+    if is_module_like(node_type) {
+        return "module";
+    }
+    "declaration"
+}
+
+fn classify_line_match_kind(line: &str, byte_start: usize) -> String {
+    let before = line.get(..byte_start).unwrap_or("");
+    let trimmed_before = before.trim_start();
+    if trimmed_before.starts_with("//")
+        || trimmed_before.starts_with('#')
+        || trimmed_before.starts_with('*')
+        || trimmed_before.starts_with("/*")
+    {
+        return "comment".to_string();
+    }
+
+    let quote_count = before
+        .chars()
+        .filter(|ch| matches!(ch, '"' | '\'' | '`'))
+        .count();
+    if quote_count % 2 == 1 {
+        return "string".to_string();
+    }
+
+    "code".to_string()
+}
+
+fn build_owner_context(
+    owner: Node,
+    matched: Node,
+    source: &str,
+    source_bytes: &[u8],
+) -> OwnerContext {
+    let symbol = extract_symbol_name_from_node(owner, source_bytes);
+    let enclosing_symbols = collect_enclosing_symbols(owner, source_bytes);
+    let qualified_symbol = symbol.as_ref().map(|name| {
+        let mut parts: Vec<String> = enclosing_symbols
+            .iter()
+            .filter(|sym| sym.kind == "class" || sym.kind == "module" || sym.kind == "impl")
+            .map(|sym| sym.name.clone())
+            .collect();
+        parts.push(name.clone());
+        parts.join(".")
+    });
+    let comments = leading_comments_before_node(owner, source);
+    let owner_start_line = comments
+        .first()
+        .map(|comment| comment.start_line)
+        .unwrap_or_else(|| owner.start_position().row + 1);
+    let owner_text_start_byte =
+        line_start_byte(source, owner_start_line).unwrap_or(owner.start_byte());
+    let owner_content = source
+        .get(owner_text_start_byte..owner.end_byte())
+        .map(|text| text.to_string());
+    let enclosing_calls = collect_enclosing_calls(matched, source_bytes);
+
+    OwnerContext {
+        symbol,
+        qualified_symbol,
+        node_type: owner.kind().to_string(),
+        scope: classify_scope_from_node(
+            owner.kind(),
+            owner_content.as_deref().unwrap_or(""),
+            false,
+            false,
+            false,
+        )
+        .to_string(),
+        lines: [owner_start_line, owner.end_position().row + 1],
+        columns: [
+            owner.start_position().column + 1,
+            owner.end_position().column + 1,
+        ],
+        comments,
+        enclosing_symbols,
+        enclosing_call: enclosing_calls.last().cloned(),
+        enclosing_calls,
+        content: owner_content,
+    }
+}
+
+fn find_smallest_covering_node<'a>(node: Node<'a>, start: usize, end: usize) -> Option<Node<'a>> {
+    if node.start_byte() > start || node.end_byte() < end {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_smallest_covering_node(child, start, end) {
+            return Some(found);
+        }
+    }
+
+    Some(node)
+}
+
+fn find_owner_node<'a>(node: Node<'a>) -> Option<Node<'a>> {
+    let mut current = Some(node);
+    while let Some(candidate) = current {
+        if is_owner_node(candidate) {
+            return Some(normalize_owner_node(candidate));
+        }
+        current = candidate.parent();
+    }
+    None
+}
+
+fn normalize_owner_node(node: Node) -> Node {
+    if is_function_like(node.kind()) {
+        if let Some(parent) = node.parent() {
+            if parent.kind() == "variable_declarator" {
+                return parent;
+            }
+            if parent.kind() == "arguments" {
+                if let Some(call) = parent.parent() {
+                    if call.kind() == "call_expression" {
+                        return node;
+                    }
+                }
+            }
+        }
+    }
+    node
+}
+
+fn is_owner_node(node: Node) -> bool {
+    let kind = node.kind();
+    if matches!(
+        kind,
+        "function_declaration"
+            | "function_definition"
+            | "function_item"
+            | "method_definition"
+            | "method_declaration"
+            | "class_declaration"
+            | "class_definition"
+            | "struct_item"
+            | "type_declaration"
+            | "impl_item"
+            | "variable_declarator"
+            | "arrow_function"
+            | "function_expression"
+    ) {
+        return true;
+    }
+    false
+}
+
+fn is_function_like(kind: &str) -> bool {
+    kind.contains("function")
+        || kind.contains("method")
+        || kind.contains("fn")
+        || kind.contains("func")
+        || kind == "arrow_function"
+        || kind == "closure"
+}
+
+fn is_module_like(kind: &str) -> bool {
+    kind.contains("module")
+        || matches!(
+            kind,
+            "program" | "source_file" | "compilation_unit" | "package_clause"
+        )
+}
+
+fn extract_symbol_name_from_node(node: Node, source: &[u8]) -> Option<String> {
+    if let Some(name_node) = node
+        .child_by_field_name("name")
+        .or_else(|| node.child_by_field_name("type"))
+    {
+        return name_node
+            .utf8_text(source)
+            .ok()
+            .map(|text| text.to_string());
+    }
+
+    if node.kind() == "variable_declarator" {
+        if let Some(name_node) = node.child_by_field_name("name") {
+            return name_node
+                .utf8_text(source)
+                .ok()
+                .map(|text| text.to_string());
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "identifier" | "type_identifier" | "property_identifier"
+        ) {
+            return child.utf8_text(source).ok().map(|text| text.to_string());
+        }
+    }
+
+    None
+}
+
+fn collect_enclosing_symbols(node: Node, source: &[u8]) -> Vec<EnclosingSymbol> {
+    let mut symbols = Vec::new();
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if matches!(
+            parent.kind(),
+            "class_declaration"
+                | "class_definition"
+                | "impl_item"
+                | "mod_item"
+                | "module_declaration"
+                | "namespace_declaration"
+        ) {
+            if let Some(name) = extract_symbol_name_from_node(parent, source) {
+                symbols.push(EnclosingSymbol {
+                    kind: normalize_symbol_kind(parent.kind()).to_string(),
+                    name,
+                    line: parent.start_position().row + 1,
+                });
+            }
+        }
+        current = parent.parent();
+    }
+    symbols.reverse();
+    symbols
+}
+
+fn collect_enclosing_calls(node: Node, source: &[u8]) -> Vec<EnclosingCall> {
+    let mut calls = Vec::new();
+    let mut current = Some(node);
+    while let Some(candidate) = current {
+        if candidate.kind() == "call_expression" {
+            if let Some(call) = build_enclosing_call(candidate, source) {
+                calls.push(call);
+            }
+        }
+        current = candidate.parent();
+    }
+    calls.reverse();
+    calls
+}
+
+fn build_enclosing_call(node: Node, source: &[u8]) -> Option<EnclosingCall> {
+    let callee_node = node
+        .child_by_field_name("function")
+        .or_else(|| node.named_child(0))?;
+    let callee = callee_node.utf8_text(source).ok()?.to_string();
+    let first_arg_literal = first_string_literal_arg(node, source);
+
+    Some(EnclosingCall {
+        callee,
+        first_arg_literal,
+        line: node.start_position().row + 1,
+    })
+}
+
+fn first_string_literal_arg(node: Node, source: &[u8]) -> Option<String> {
+    let arguments = node.child_by_field_name("arguments").or_else(|| {
+        let mut cursor = node.walk();
+        let found = node
+            .children(&mut cursor)
+            .find(|child| child.kind() == "arguments");
+        found
+    })?;
+    let mut cursor = arguments.walk();
+    for child in arguments.named_children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "string" | "string_fragment" | "interpreted_string_literal"
+        ) {
+            let raw = child.utf8_text(source).ok()?.trim();
+            return Some(raw.trim_matches(['"', '\'', '`']).to_string());
+        }
+    }
+    None
+}
+
+fn leading_comments_before_node(node: Node, source: &str) -> Vec<SourceComment> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut idx = node.start_position().row;
+    let mut comments = Vec::new();
+
+    while idx > 0 {
+        let line = lines.get(idx - 1).copied().unwrap_or("");
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            if comments.is_empty() {
+                idx -= 1;
+                continue;
+            }
+            break;
+        }
+        if !is_comment_line(trimmed) {
+            break;
+        }
+        comments.push((idx, trimmed.to_string()));
+        idx -= 1;
+    }
+
+    comments.reverse();
+    comments
+        .into_iter()
+        .map(|(line, text)| SourceComment {
+            kind: "leading".to_string(),
+            start_line: line,
+            end_line: line,
+            text,
+        })
+        .collect()
+}
+
+fn line_start_byte(source: &str, one_based_line: usize) -> Option<usize> {
+    if one_based_line == 0 {
+        return None;
+    }
+    if one_based_line == 1 {
+        return Some(0);
+    }
+    let mut line = 1;
+    for (idx, ch) in source.char_indices() {
+        if ch == '\n' {
+            line += 1;
+            if line == one_based_line {
+                return Some(idx + 1);
+            }
+        }
+    }
+    None
+}
+
+fn is_comment_line(trimmed: &str) -> bool {
+    trimmed.starts_with("//")
+        || trimmed.starts_with("///")
+        || trimmed.starts_with("#")
+        || trimmed.starts_with("*")
+        || trimmed.starts_with("/*")
+        || trimmed.starts_with("*/")
+}
+
+fn extract_name_after_keyword(line: &str, prefix: &str) -> Option<String> {
+    let rest = line.strip_prefix(prefix)?;
+    let name = rest
+        .split(|c: char| c == '(' || c == '<' || c == ':' || c.is_whitespace())
+        .next()
+        .unwrap_or("")
+        .trim();
+    if name.is_empty() {
+        None
+    } else {
+        Some(name.to_string())
+    }
+}
+
+fn normalize_symbol_kind(kind: &str) -> &'static str {
+    match kind {
+        "class_declaration" | "class_definition" => "class",
+        "impl_item" => "impl",
+        "mod_item" | "module_declaration" | "namespace_declaration" => "module",
+        "method_definition" | "method_declaration" => "method",
+        kind if is_function_like(kind) => "function",
+        _ => "declaration",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_classify_text_matches_in_comments_and_strings() {
+        let code = r#"// Implements: SYS-REQ-1
+export const literalOnly = "SYS-REQ-2";
+export function run() {
+  return SYS_REQ_3;
+}"#;
+        let comments = leading_comments_from_block(code, 10);
+        let keywords = vec![
+            "SYS-REQ-1".to_string(),
+            "SYS-REQ-2".to_string(),
+            "SYS_REQ_3".to_string(),
+        ];
+
+        let matches = classify_text_matches_in_block(code, 10, Some(&keywords), &comments);
+
+        assert_eq!(matches.len(), 3);
+        assert_eq!(matches[0].kind, "comment");
+        assert_eq!(matches[0].comment_role.as_deref(), Some("leading"));
+        assert_eq!(matches[1].kind, "string");
+        assert_eq!(matches[2].kind, "code");
+    }
+}

--- a/tests/json_format_tests.rs
+++ b/tests/json_format_tests.rs
@@ -323,6 +323,24 @@ fn test_search_json_no_merge_reports_req_id_source_metadata() {
         Some("evaluatePolicy")
     );
     assert_eq!(
+        method_result
+            .get("owner_qualified_symbol")
+            .and_then(Value::as_str),
+        Some("PolicyService.evaluatePolicy")
+    );
+    let enclosing_symbols = method_result
+        .get("enclosing_symbols")
+        .and_then(Value::as_array)
+        .expect("method result should expose containing symbols");
+    assert_eq!(
+        enclosing_symbols[0].get("kind").and_then(Value::as_str),
+        Some("class")
+    );
+    assert_eq!(
+        enclosing_symbols[0].get("name").and_then(Value::as_str),
+        Some("PolicyService")
+    );
+    assert_eq!(
         method_result.get("scope").and_then(Value::as_str),
         Some("function")
     );
@@ -339,6 +357,12 @@ fn test_search_json_no_merge_reports_req_id_source_metadata() {
     );
     assert_eq!(
         arrow_result.get("owner_symbol").and_then(Value::as_str),
+        Some("normalizeDecision")
+    );
+    assert_eq!(
+        arrow_result
+            .get("owner_qualified_symbol")
+            .and_then(Value::as_str),
         Some("normalizeDecision")
     );
     assert_eq!(
@@ -363,6 +387,20 @@ fn test_search_json_no_merge_reports_req_id_source_metadata() {
     assert_eq!(
         callback_result.get("is_test").and_then(Value::as_bool),
         Some(true)
+    );
+    let enclosing_calls = callback_result
+        .get("enclosing_calls")
+        .and_then(Value::as_array)
+        .expect("callback result should expose enclosing call context");
+    assert_eq!(
+        enclosing_calls[0].get("callee").and_then(Value::as_str),
+        Some("test")
+    );
+    assert_eq!(
+        enclosing_calls[0]
+            .get("first_arg_literal")
+            .and_then(Value::as_str),
+        Some("accepts valid policy")
     );
 
     let leading_comments = callback_result
@@ -389,6 +427,131 @@ fn test_search_json_no_merge_reports_req_id_source_metadata() {
     assert_eq!(
         matches[0].get("comment_role").and_then(Value::as_str),
         Some("leading")
+    );
+
+    let nested_callback_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("it(\"normalizes decisions\""))
+    });
+    let nested_calls = nested_callback_result
+        .get("enclosing_calls")
+        .and_then(Value::as_array)
+        .expect("nested callback result should expose enclosing call chain");
+    assert_eq!(
+        nested_calls[0].get("callee").and_then(Value::as_str),
+        Some("describe")
+    );
+    assert_eq!(
+        nested_calls[0]
+            .get("first_arg_literal")
+            .and_then(Value::as_str),
+        Some("normalization")
+    );
+    assert_eq!(
+        nested_calls[1].get("callee").and_then(Value::as_str),
+        Some("it")
+    );
+    assert_eq!(
+        nested_calls[1]
+            .get("first_arg_literal")
+            .and_then(Value::as_str),
+        Some("normalizes decisions")
+    );
+}
+
+#[test]
+fn test_search_json_classifies_req_id_noise_without_policy_interpretation() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    create_requirement_fixture(&temp_dir);
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "search",
+            "--allow-tests",
+            "--strict-elastic-syntax",
+            "--max-results",
+            "20",
+            "--no-merge",
+            "--format",
+            "json",
+            r#""SYS-REQ-427" OR "SYS-REQ-428" OR "SYS-REQ-429""#,
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "search command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_str = extract_json_from_output(&stdout);
+    let json_result: Value = serde_json::from_str(json_str).expect("Failed to parse JSON output");
+    let results = json_result
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("results should be an array");
+
+    let literal_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("SYS-REQ-427"))
+    });
+    let literal_matches = literal_result
+        .get("matches")
+        .and_then(Value::as_array)
+        .expect("literal result should expose classified matches");
+    assert_eq!(
+        literal_matches[0].get("kind").and_then(Value::as_str),
+        Some("string")
+    );
+
+    let string_return_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("SYS-REQ-428"))
+    });
+    let string_return_matches = string_return_result
+        .get("matches")
+        .and_then(Value::as_array)
+        .expect("string return result should expose classified matches");
+    assert_eq!(
+        string_return_matches[0].get("kind").and_then(Value::as_str),
+        Some("string")
+    );
+
+    let loose_comment_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("SYS-REQ-429"))
+    });
+    let loose_comment_matches = loose_comment_result
+        .get("matches")
+        .and_then(Value::as_array)
+        .expect("loose comment result should expose classified matches");
+    assert_eq!(
+        loose_comment_matches[0].get("kind").and_then(Value::as_str),
+        Some("comment")
+    );
+    assert_eq!(
+        loose_comment_matches[0]
+            .get("comment_role")
+            .and_then(Value::as_str),
+        Some("leading")
+    );
+    assert!(
+        loose_comment_result.get("requirement_policy").is_none(),
+        "Probe should not add domain-specific requirement interpretation"
     );
 }
 

--- a/tests/json_format_tests.rs
+++ b/tests/json_format_tests.rs
@@ -95,6 +95,76 @@ function validateTerm(term) {
     create_test_file(root_dir, "src/multi_term.js", multi_term_content);
 }
 
+fn create_requirement_fixture(root_dir: &TempDir) {
+    let service_ts = r#"export class PolicyService {
+  // Implements: SYS-REQ-424
+  async evaluatePolicy(input: string): Promise<boolean> {
+    return input.length > 0 && input !== "deny";
+  }
+}
+
+// Implements: SYS-REQ-425
+export const normalizeDecision = (raw: string) => {
+  return raw.trim().toLowerCase();
+};
+"#;
+    create_test_file(root_dir, "web/src/service.ts", service_ts);
+
+    let service_test_ts = r#"import { describe, it, expect, test } from "vitest";
+
+// Verifies: SYS-REQ-424 [boundary]
+test("accepts valid policy", () => {
+  expect(true && true).toBe(true);
+});
+
+// MCDC SYS-REQ-424: input_valid=T, not_denied=T => TRUE
+it("records witness row", () => {
+  expect(true).toBe(true);
+});
+
+describe("normalization", () => {
+  // Verifies: SYS-REQ-425
+  it("normalizes decisions", () => {
+    expect(" ALLOW ".trim().toLowerCase()).toBe("allow");
+  });
+});
+"#;
+    create_test_file(
+        root_dir,
+        "web/src/__tests__/service.test.ts",
+        service_test_ts,
+    );
+
+    let demo_go = r#"package demo
+
+// Implements: SYS-REQ-426
+func RunDemo(flag bool) bool {
+    return flag
+}
+"#;
+    create_test_file(root_dir, "pkg/demo/demo.go", demo_go);
+
+    let noise_ts = r#"export const literalOnly = "Implements: SYS-REQ-427";
+
+export function unrelated() {
+  return "SYS-REQ-428";
+}
+
+// SYS-REQ-429 appears here without an annotation verb.
+export function looseComment() {
+  return true;
+}
+"#;
+    create_test_file(root_dir, "web/src/noise.ts", noise_ts);
+}
+
+fn find_result<'a>(results: &'a [Value], predicate: impl Fn(&'a Value) -> bool) -> &'a Value {
+    results
+        .iter()
+        .find(|result| predicate(result))
+        .expect("expected search result was not found")
+}
+
 #[test]
 fn test_json_output_format_basic() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -187,6 +257,138 @@ fn test_json_output_format_basic() {
     assert_eq!(
         count, results_count,
         "The 'count' in summary should match the number of results"
+    );
+}
+
+#[test]
+fn test_search_json_no_merge_reports_req_id_source_metadata() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    create_requirement_fixture(&temp_dir);
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--quiet",
+            "--",
+            "search",
+            "--allow-tests",
+            "--strict-elastic-syntax",
+            "--max-results",
+            "20",
+            "--no-merge",
+            "--format",
+            "json",
+            r#""SYS-REQ-424" OR "SYS-REQ-425""#,
+            temp_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "search command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_str = extract_json_from_output(&stdout);
+    let json_result: Value = serde_json::from_str(json_str).expect("Failed to parse JSON output");
+    let results = json_result
+        .get("results")
+        .and_then(Value::as_array)
+        .expect("results should be an array");
+
+    assert_eq!(
+        results.len(),
+        5,
+        "expected one result per semantic-ish block"
+    );
+
+    let method_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("evaluatePolicy") && code.contains("SYS-REQ-424"))
+    });
+    assert_eq!(
+        method_result.get("language").and_then(Value::as_str),
+        Some("typescript")
+    );
+    assert_eq!(
+        method_result.get("node_type").and_then(Value::as_str),
+        Some("method_definition")
+    );
+    assert_eq!(
+        method_result.get("owner_symbol").and_then(Value::as_str),
+        Some("evaluatePolicy")
+    );
+    assert_eq!(
+        method_result.get("scope").and_then(Value::as_str),
+        Some("function")
+    );
+
+    let arrow_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("normalizeDecision") && code.contains("SYS-REQ-425"))
+    });
+    assert_eq!(
+        arrow_result.get("node_type").and_then(Value::as_str),
+        Some("export_statement")
+    );
+    assert_eq!(
+        arrow_result.get("owner_symbol").and_then(Value::as_str),
+        Some("normalizeDecision")
+    );
+    assert_eq!(
+        arrow_result.get("scope").and_then(Value::as_str),
+        Some("function")
+    );
+
+    let callback_result = find_result(results, |result| {
+        result
+            .get("code")
+            .and_then(Value::as_str)
+            .is_some_and(|code| code.contains("test(\"accepts valid policy\""))
+    });
+    assert_eq!(
+        callback_result.get("node_type").and_then(Value::as_str),
+        Some("arrow_function")
+    );
+    assert_eq!(
+        callback_result.get("scope").and_then(Value::as_str),
+        Some("test")
+    );
+    assert_eq!(
+        callback_result.get("is_test").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let leading_comments = callback_result
+        .get("leading_comments")
+        .and_then(Value::as_array)
+        .expect("callback result should expose leading comments");
+    assert_eq!(
+        leading_comments[0].get("text").and_then(Value::as_str),
+        Some("// Verifies: SYS-REQ-424 [boundary]")
+    );
+
+    let matches = callback_result
+        .get("matches")
+        .and_then(Value::as_array)
+        .expect("callback result should expose classified matches");
+    assert_eq!(
+        matches[0].get("text").and_then(Value::as_str),
+        Some("SYS-REQ-424")
+    );
+    assert_eq!(
+        matches[0].get("kind").and_then(Value::as_str),
+        Some("comment")
+    );
+    assert_eq!(
+        matches[0].get("comment_role").and_then(Value::as_str),
+        Some("leading")
     );
 }
 

--- a/tests/lib_usage.rs
+++ b/tests/lib_usage.rs
@@ -48,6 +48,7 @@ mod tests {
             ignore: &[],
             allow_tests: true,
             max_results: Some(5),
+            with_context: false,
             format: "text",
             no_gitignore: false,
         };

--- a/tests/query_command_json_tests.rs
+++ b/tests/query_command_json_tests.rs
@@ -312,6 +312,90 @@ fn test_query_json_output_with_special_characters() {
 }
 
 #[test]
+fn test_query_json_with_context_reports_owner_block() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+
+    let ts_content = r#"
+// Verifies: APP-REQ-123
+// Handles timeout behavior for outbound calls.
+export async function requestJSON(url: string) {
+  return fetch(url, { signal: AbortSignal.timeout(1000) });
+}
+"#;
+    create_test_file(&temp_dir, "src/api.ts", ts_content);
+
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "--",
+            "query",
+            "fetch($$$ARGS)",
+            temp_dir.path().to_str().unwrap(),
+            "--language",
+            "typescript",
+            "--format",
+            "json",
+            "--with-context",
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json_str = extract_json_from_output(&stdout);
+    let json_result: Value = serde_json::from_str(json_str).expect("Failed to parse JSON output");
+
+    assert_eq!(
+        json_result.get("schema_version").and_then(Value::as_str),
+        Some("probe.query.context.v1")
+    );
+
+    let result = &json_result.get("results").unwrap().as_array().unwrap()[0];
+    assert_eq!(
+        result.get("language").and_then(Value::as_str),
+        Some("typescript")
+    );
+    assert_eq!(
+        result
+            .get("match")
+            .and_then(|m| m.get("node_type"))
+            .and_then(Value::as_str),
+        Some("call_expression")
+    );
+
+    let owner = result
+        .get("owner")
+        .expect("owner context should be present");
+    assert_eq!(
+        owner.get("symbol").and_then(Value::as_str),
+        Some("requestJSON")
+    );
+    assert_eq!(
+        owner.get("node_type").and_then(Value::as_str),
+        Some("function_declaration")
+    );
+    assert_eq!(owner.get("scope").and_then(Value::as_str), Some("function"));
+    assert!(
+        owner
+            .get("comments")
+            .and_then(Value::as_array)
+            .unwrap()
+            .iter()
+            .any(|comment| comment
+                .get("text")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .contains("APP-REQ-123")),
+        "owner comments should include leading source comments"
+    );
+}
+
+#[test]
 fn test_query_json_output_with_multiple_languages() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
     create_test_directory_structure(&temp_dir);

--- a/tests/query_command_tests.rs
+++ b/tests/query_command_tests.rs
@@ -30,6 +30,7 @@ fn add(a: i32, b: i32) -> i32 {
         ignore: &[],
         allow_tests: true,
         max_results: None,
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };
@@ -82,6 +83,7 @@ const multiply = (a, b) => a * b;
         ignore: &[],
         allow_tests: true,
         max_results: None,
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };
@@ -102,6 +104,7 @@ const multiply = (a, b) => a * b;
         ignore: &[],
         allow_tests: true,
         max_results: None,
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };
@@ -142,6 +145,7 @@ fn func5() {}
         ignore: &[],
         allow_tests: true,
         max_results: Some(3),
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };
@@ -179,6 +183,7 @@ fn test_query_ignore_patterns() -> Result<()> {
         ignore: &["test".to_string()],
         allow_tests: false,
         max_results: None,
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };
@@ -217,6 +222,7 @@ fn auto_detected_function() {
         ignore: &[],
         allow_tests: true,
         max_results: None,
+        with_context: false,
         format: "plain",
         no_gitignore: false,
     };


### PR DESCRIPTION
## Summary
- add `probe query --with-context` / `--owner-context` for opt-in JSON owner-block metadata
- introduce a shared language-agnostic source context layer for AST match, owner, comments, enclosing symbols, and enclosing calls
- reuse parsed source context per file while formatting query/search JSON, avoiding parse-per-match behavior
- improve search JSON metadata with language, owner symbols, qualified owners, enclosing symbols/calls, leading comments, and classified text matches
- improve JS/TS `symbols` output by unwrapping exported declarations to their semantic inner names
- handle multiline block comments, HTML comments, and multiline strings when classifying search match metadata
- document the implemented query/search JSON context surfaces
- add mixed TS/Go req-id search JSON regressions for the `--no-merge` evidence path, including negative string/comment hit classification

## Implemented: `probe query --with-context`
`probe query` now has a new opt-in flag:

```bash
probe query 'fetch($$$ARGS)' ./src -l typescript --format json --with-context
```

The default query JSON remains backward-compatible. With `--with-context`, each result keeps the existing fields and additionally includes:

- `schema_version: "probe.query.context.v1"` at the top level
- `language`: inferred source language
- `pattern`: source pattern and nullable pattern ID
- `match`: exact AST match node type, content, line range, and column range
- `owner`: smallest useful enclosing source block where available
- `owner.symbol` and `owner.qualified_symbol`
- `owner.node_type`, `owner.scope`, `owner.lines`, and `owner.columns`
- `owner.comments`: attached leading/source comments as raw source facts
- `owner.enclosing_symbols`: containing class/module/impl-style symbols where knowable
- `owner.enclosing_call` / `owner.enclosing_calls`: generic call context for callback/call nesting where knowable
- `owner.content`: owning block source text when available

This is intentionally generic. Probe reports source facts only; it does not parse requirement IDs, policy annotations, checklist semantics, test frameworks, or security meanings.

## Implemented: search JSON source metadata
Search JSON keeps its existing shape but now includes additional source facts useful for text-first evidence discovery:

- `language`
- `owner_symbol` for common owner blocks, including TS/JS methods and exported const arrows
- `owner_qualified_symbol`, e.g. `PolicyService.evaluatePolicy`
- `enclosing_symbols`, e.g. containing class/module/impl symbols
- `enclosing_call` / `enclosing_calls`, e.g. generic `describe(...)` / `it(...)` callback call chains without framework interpretation
- `leading_comments` with line ranges and raw text
- `matches` with text, line/column range, `kind` (`comment`, `string`, `code`), and `comment_role` when applicable

The added regressions cover the intended search path:

```bash
probe search --allow-tests --strict-elastic-syntax --max-results 20 --no-merge \
  --format json '"SYS-REQ-424" OR "SYS-REQ-425"' ./fixture
```

They verify TS method ownership, exported const arrow ownership, qualified class-method identity, nested callback call chains, test callback scope, leading comments, classified comment matches, string-literal hits, and loose comment hits. Probe still does not interpret which comments are valid evidence; downstream tools decide that from the raw source facts.

## Performance / maintainability notes
- Query/search context generation now uses a reusable `ParsedSourceContext` abstraction.
- JSON formatting keeps a per-command `HashMap<PathBuf, Option<ParsedSourceContext>>`, so each source file is parsed at most once per formatting pass.
- Unsupported or unparseable files are cached as `None`, so repeated results from the same unsupported file do not retry parsing.
- This keeps the PR scoped: no new product mode or global parser cache, just efficient reuse inside the existing output path.

## JS/TS fixes
- `probe search -o json` can now report owner symbols for TS/JS `method_definition` blocks.
- `probe search -o json` can now report owner symbols for exported const arrow functions even when the returned block is an `export_statement`.
- `probe symbols` now unwraps common TS/JS `export_statement` / `declare_statement` wrappers and returns semantic names like `PolicyService` and `normalizeDecision` instead of generic `export_statement` names.

## Architecture notes
- Keeps existing default output compatible; richer query metadata is opt-in via `--with-context`.
- Uses existing parser/language abstractions rather than adopting the issue contract verbatim.
- Shares source-context helpers between query and search while keeping their JSON contracts compatible with existing command behavior.
- Treats this as the strong Probe-native slice: structural query context and neutral search/source metadata.

## Out of scope for this PR
- batch pattern execution / `--patterns-file`
- new `search --semantic-blocks` behavior
- new `extract --semantic-block` behavior
- wildcard query syntax changes beyond existing ast-grep support
- policy interpretation of comments, requirement IDs, frameworks, or checklist semantics

## Tests
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib
- cargo test --test integration_tests
- cargo test --test query_command_tests
- cargo test --test query_command_json_tests test_query_json_with_context_reports_owner_block
- cargo test --test json_format_tests test_search_json_no_merge_reports_req_id_source_metadata
- cargo test --test json_format_tests test_search_json_classifies_req_id_noise_without_policy_interpretation
- npm test -- --runInBand npm/tests/unit/search-delegate.test.js
- git diff --check

Refs #557
Refs #558
