### PR TITLE
Remove atty dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ uninlined_format_args = "allow"
 ahash = "0.8.6"  # Fast, non-cryptographic hash function
 dashmap = "5.5.3"  # Thread-safe concurrent HashMap
 anyhow = "1.0"
-atty = "0.2.13"
 colored = "3.0.0"
 dirs = "5.0.1"
 ignore = "0.4"

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -31,7 +31,7 @@ use anyhow::{anyhow, Result};
 use probe_code::extract::file_paths::{set_custom_ignores, FilePathInfo};
 use probe_code::models::SearchResult;
 use std::collections::HashSet;
-use std::io::Read;
+use std::io::{IsTerminal, Read};
 use std::ops::Deref;
 #[allow(unused_imports)]
 use std::path::PathBuf;
@@ -347,7 +347,7 @@ pub fn handle_extract(options: ExtractOptions) -> Result<()> {
         }
     } else if options.files.is_empty() {
         // Check if stdin is available (not a terminal)
-        let is_stdin_available = !atty::is(atty::Stream::Stdin);
+        let is_stdin_available = !std::io::stdin().is_terminal();
 
         if is_stdin_available {
             // Read from stdin

--- a/src/grep.rs
+++ b/src/grep.rs
@@ -6,7 +6,7 @@ use ignore::WalkBuilder;
 use regex::{Regex, RegexBuilder};
 use std::collections::VecDeque;
 use std::fs;
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -52,7 +52,7 @@ impl GrepConfig {
         let use_color = match params.color.as_str() {
             "always" => true,
             "never" => false,
-            _ => atty::is(atty::Stream::Stdout),
+            _ => io::stdout().is_terminal(),
         };
 
         Ok(Self {


### PR DESCRIPTION
## Summary
- replace `atty` terminal checks with the standard library `IsTerminal` API
- remove the direct `atty` dependency from `Cargo.toml`
- keep behavior the same for stdin detection in `extract` and stdout color detection in `grep`

## Why
`atty` is unmaintained and appears in RustSec audit output (`RUSTSEC-2024-0375`, `RUSTSEC-2021-0145`). Since this repo already requires Rust 1.88, `std::io::IsTerminal` is available and avoids carrying that dependency.

This is intentionally a narrow cleanup. A broader `cargo audit` pass still has unrelated workspace/dependency items, but this removes the direct `atty` warning without adding an allow-list entry.

## Verification
- `cargo fmt --check`
- generated a temporary `Cargo.lock` and confirmed `cargo tree -i atty` no longer finds `atty`
- `cargo test --lib --bins` with a temporary local `roaring 0.11.3` resolver pin because current fresh resolution selects `roaring 0.11.4`, which requires Rust 1.90 while the repo declares Rust 1.88
  - 364 lib tests passed, 1 ignored
  - 2 `debug-tree-sitter` bin tests passed
  - 12 `probe` bin tests passed
