### PR TITLE
fix: resolve base URL in createLanguageModel for API gateway support

### DIFF
--- a/npm/src/utils/provider.js
+++ b/npm/src/utils/provider.js
@@ -85,8 +85,31 @@ export function resolveApiKey(providerName) {
 }
 
 /**
+ * Resolve base URL for a provider from environment variables.
+ * Mirrors the env-var resolution in ProbeAgent and FallbackManager so that
+ * lightweight LLM calls (dedup, etc.) route through the same API gateway.
+ * @param {string} providerName
+ * @returns {string|undefined}
+ */
+export function resolveBaseUrl(providerName) {
+	const llmBaseUrl = process.env.LLM_BASE_URL;
+	switch (providerName) {
+		case 'anthropic':
+			return process.env.ANTHROPIC_API_URL || process.env.ANTHROPIC_BASE_URL || llmBaseUrl;
+		case 'openai':
+			return process.env.OPENAI_API_URL || llmBaseUrl;
+		case 'google':
+			return process.env.GOOGLE_API_URL || llmBaseUrl;
+		case 'bedrock':
+			return process.env.AWS_BEDROCK_BASE_URL || llmBaseUrl;
+		default:
+			return llmBaseUrl;
+	}
+}
+
+/**
  * Create a language model instance from provider name + model name.
- * Resolves API keys from environment automatically.
+ * Resolves API keys and base URLs from environment automatically.
  * Returns null on failure (graceful degradation for optional features).
  * @param {string} providerName - 'anthropic' | 'openai' | 'google' | 'bedrock'
  * @param {string} modelName - Model identifier (e.g., 'gemini-2.0-flash')
@@ -98,7 +121,8 @@ export async function createLanguageModel(providerName, modelName) {
 	if (!resolvedModel) return null;
 	try {
 		const apiKey = resolveApiKey(providerName);
-		const provider = createProviderInstance({ provider: providerName, ...(apiKey ? { apiKey } : {}) });
+		const baseURL = resolveBaseUrl(providerName);
+		const provider = createProviderInstance({ provider: providerName, ...(apiKey ? { apiKey } : {}), ...(baseURL ? { baseURL } : {}) });
 		return provider(resolvedModel);
 	} catch {
 		return null;


### PR DESCRIPTION
## Summary
- `createLanguageModel()` in `npm/src/utils/provider.js` resolved API keys but not base URLs from env vars
- This caused dedup LLM calls to bypass API gateways and hit provider endpoints directly, failing with "API key not valid" when using gateway-issued keys
- Added `resolveBaseUrl()` mirroring the env-var pattern already used by `ProbeAgent` and `FallbackManager`

## Problem
When `GOOGLE_API_URL` points to an API gateway and `GOOGLE_API_KEY` is a gateway-issued key (not a raw Google key), the main AI calls work fine (they pass `baseURL`), but dedup calls fail because `createLanguageModel()` only passed `apiKey` without `baseURL`. Every dedup failure silently falls back to `allow`, letting all redundant searches through — causing tasks to run 5-6x longer than necessary.

## Test plan
- [ ] Verify dedup calls route through `GOOGLE_API_URL` when set
- [ ] Verify no regression when `GOOGLE_API_URL` is not set (hits provider default)
- [ ] Verify `LLM_BASE_URL` fallback works for all providers

Fixes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)