### PR TITLE
fix: redirect debug/status output to stderr for json/xml output formats

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,7 +192,9 @@ fn handle_search(params: SearchParams) -> Result<()> {
 
     let use_frequency = params.frequency_search;
 
-    println!("{} {}", "Pattern:".bold().green(), params.pattern);
+    if params.format != "json" && params.format != "xml" {
+        println!("{} {}", "Pattern:".bold().green(), params.pattern);
+    }
     // Normalize the search root early. Some downstream code paths are stricter about absolute paths.
     let raw_root = params.paths.first().unwrap();
 
@@ -228,7 +230,9 @@ fn handle_search(params: SearchParams) -> Result<()> {
     } else {
         raw_root.clone()
     };
-    println!("{} {}", "Path:".bold().green(), canonical_root.display());
+    if params.format != "json" && params.format != "xml" {
+        println!("{} {}", "Path:".bold().green(), canonical_root.display());
+    }
 
     // Show advanced options if they differ from defaults
     let mut advanced_options = Vec::<String>::new();

--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -529,7 +529,7 @@ pub fn rank_documents_simd(params: &RankingParams) -> Vec<(usize, f64)> {
     let scores = simd_params.score_all_documents();
 
     if debug_mode {
-        println!("DEBUG: SIMD BM25 scoring completed");
+        eprintln!("DEBUG: SIMD BM25 scoring completed");
     }
 
     // 8) Apply boolean query logic efficiently with SIMD scores

--- a/src/search/result_ranking.rs
+++ b/src/search/result_ranking.rs
@@ -448,7 +448,7 @@ fn handle_bert_reranking(
             Ok(inner_result) => inner_result,
             Err(_) => {
                 eprintln!("BERT reranking thread panicked");
-                println!("Falling back to BM25 ranking...");
+                eprintln!("Falling back to BM25 ranking...");
                 fallback_to_bm25_ranking(results, queries, debug_mode, start_time);
                 return;
             }
@@ -473,7 +473,7 @@ fn handle_bert_reranking(
             }
             Err(e) => {
                 eprintln!("BERT reranking failed: {e}");
-                println!("Falling back to BM25 ranking...");
+                eprintln!("Falling back to BM25 ranking...");
                 fallback_to_bm25_ranking(results, queries, debug_mode, start_time);
             }
         }
@@ -483,7 +483,7 @@ fn handle_bert_reranking(
     {
         eprintln!("BERT reranker '{reranker}' is not available.");
         eprintln!("To enable BERT reranking, build with: cargo build --features bert-reranker");
-        println!("Falling back to BM25 ranking...");
+        eprintln!("Falling back to BM25 ranking...");
         fallback_to_bm25_ranking(results, queries, debug_mode, start_time);
     }
 }
@@ -534,12 +534,12 @@ fn fallback_to_bm25_ranking(
     let use_simd = std::env::var("DISABLE_SIMD_RANKING").unwrap_or_default() != "1";
     let ranked_indices = if use_simd {
         if debug_mode {
-            println!("DEBUG: Using SIMD-optimized BM25 ranking (fallback)");
+            eprintln!("DEBUG: Using SIMD-optimized BM25 ranking (fallback)");
         }
         ranking::rank_documents_simd(&ranking_params)
     } else {
         if debug_mode {
-            println!("DEBUG: Using traditional BM25 ranking (fallback)");
+            eprintln!("DEBUG: Using traditional BM25 ranking (fallback)");
         }
         ranking::rank_documents(&ranking_params)
     };


### PR DESCRIPTION
## Problem

Closes #568.

When probe is called with `--format=json` (e.g. via the MCP `symbols` tool), debug lines like `Pattern: ...`, `Path: ...`, and `Falling back to BM25 ranking...` were written to **stdout** before the JSON result. Any JSON parser downstream received:

```
Pattern: symbols
Path: '/tmp/...'
Options: Reranker: bm25
Using BM25 ranking (Okapi BM25 algorithm)
{"results": [], ...}
```

And failed with: `Unexpected token 'P', "Pattern: s"... is not valid JSON`

## Fix

**`src/main.rs`** — wrap the `Pattern:` and `Path:` `println!` blocks in a format guard so they are only printed for text output:

```rust
if params.format != "json" && params.format != "xml" {
    println!("{} {}", "Pattern:".bold().green(), params.pattern);
}
```

**`src/search/result_ranking.rs`** — change `"Falling back to BM25 ranking..."` and related debug `println!` calls to `eprintln!`.

**`src/ranking.rs`** — same for SIMD debug messages.

All status/diagnostic output now goes to stderr, leaving stdout clean JSON for downstream parsers.