### PR TITLE
[codex] Retry empty AI stream responses

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1454,30 +1454,44 @@ export class ProbeAgent {
   }
 
   /**
+   * Create a RetryManager from the agent's retry configuration.
+   * @param {Object} [overrides={}] - Retry option overrides
+   * @returns {RetryManager}
+   * @private
+   */
+  _createRetryManager(overrides = {}) {
+    return new RetryManager({
+      maxRetries: overrides.maxRetries ?? this.retryConfig.maxRetries ?? 3,
+      initialDelay: overrides.initialDelay ?? this.retryConfig.initialDelay ?? 1000,
+      maxDelay: overrides.maxDelay ?? this.retryConfig.maxDelay ?? 30000,
+      backoffFactor: overrides.backoffFactor ?? this.retryConfig.backoffFactor ?? 2,
+      retryableErrors: overrides.retryableErrors ?? this.retryConfig.retryableErrors,
+      jitter: overrides.jitter ?? this.retryConfig.jitter,
+      debug: overrides.debug ?? this.debug
+    });
+  }
+
+  /**
    * Execute streamText with Vercel AI SDK using retry/fallback logic
    * @param {Object} options - streamText options
    * @param {AbortController} controller - Abort controller for the operation
+   * @param {Function} [consumeResult] - Optional callback to consume the stream result inside the same retry budget
    * @returns {Promise<Object>} - Stream result
    * @private
    */
-  async _executeWithVercelProvider(options, controller) {
+  async _executeWithVercelProvider(options, controller, consumeResult) {
     // Initialize retry manager if not already created
     if (!this.retryManager) {
-      this.retryManager = new RetryManager({
-        maxRetries: this.retryConfig.maxRetries ?? 3,
-        initialDelay: this.retryConfig.initialDelay ?? 1000,
-        maxDelay: this.retryConfig.maxDelay ?? 30000,
-        backoffFactor: this.retryConfig.backoffFactor ?? 2,
-        retryableErrors: this.retryConfig.retryableErrors,
-        jitter: this.retryConfig.jitter,
-        debug: this.debug
-      });
+      this.retryManager = this._createRetryManager();
     }
 
     // If no fallback manager, just use retry with current provider
     if (!this.fallbackManager) {
       return await this.retryManager.executeWithRetry(
-        () => streamText({ ...options, abortSignal: controller.signal }),
+        async () => {
+          const result = streamText({ ...options, abortSignal: controller.signal });
+          return consumeResult ? await consumeResult(result) : result;
+        },
         {
           provider: this.apiType,
           model: this.model,
@@ -1511,18 +1525,15 @@ export class ProbeAgent {
           }
         }
 
-        const providerRetryManager = new RetryManager({
-          maxRetries: config.maxRetries ?? this.retryConfig.maxRetries ?? 3,
-          initialDelay: this.retryConfig.initialDelay ?? 1000,
-          maxDelay: this.retryConfig.maxDelay ?? 30000,
-          backoffFactor: this.retryConfig.backoffFactor ?? 2,
-          retryableErrors: this.retryConfig.retryableErrors,
-          jitter: this.retryConfig.jitter,
-          debug: this.debug
+        const providerRetryManager = this._createRetryManager({
+          maxRetries: config.maxRetries ?? this.retryConfig.maxRetries
         });
 
         return await providerRetryManager.executeWithRetry(
-          () => streamText(fallbackOptions),
+          async () => {
+            const result = streamText(fallbackOptions);
+            return consumeResult ? await consumeResult(result) : result;
+          },
           {
             provider: config.provider,
             model: model,
@@ -1673,10 +1684,11 @@ export class ProbeAgent {
   /**
    * Execute streamText with retry and fallback support
    * @param {Object} options - streamText options
-   * @returns {Promise<Object>} - streamText result
+   * @param {Function} [consumeResult] - Optional callback to consume the result inside the same retry attempt
+   * @returns {Promise<Object>} - streamText result or consumer result
    * @private
    */
-  async streamTextWithRetryAndFallback(options) {
+  async streamTextWithRetryAndFallback(options, consumeResult) {
     // Wrap the model with per-call concurrency gating if limiter is configured.
     // This acquires/releases the slot around each individual LLM API call (doStream/doGenerate)
     // instead of holding it for the entire multi-step agent session.
@@ -1729,6 +1741,7 @@ export class ProbeAgent {
       const useCodex = this.clientApiProvider === 'codex' || process.env.USE_CODEX === 'true';
 
       let result;
+      let usedVercelProvider = false;
       if (useClaudeCode || useCodex) {
         try {
           result = await this._tryEngineStreamPath(options, controller, timeoutState);
@@ -1749,7 +1762,12 @@ export class ProbeAgent {
 
       if (!result) {
         // Use Vercel AI SDK with retry/fallback
-        result = await this._executeWithVercelProvider(options, controller);
+        usedVercelProvider = true;
+        result = await this._executeWithVercelProvider(options, controller, consumeResult);
+      }
+
+      if (!usedVercelProvider && result && consumeResult) {
+        return await consumeResult(result);
       }
 
       return result;
@@ -3765,8 +3783,6 @@ Follow these instructions carefully:
           activeTools.delete(key);
         }
       };
-      this.events.on('toolCall', onToolCall);
-
       // Timeout observer: separate LLM call that decides whether to extend.
       // Runs independently of the main agent loop — works even when blocked by delegates.
       const runTimeoutObserver = async () => {
@@ -4428,115 +4444,99 @@ Double-check your response based on the criteria above. If everything looks good
           }
 
           const executeAIRequest = async () => {
-            const result = await this.streamTextWithRetryAndFallback(streamOptions);
+            return await this.streamTextWithRetryAndFallback(streamOptions, async (result) => {
+              this.events.on('toolCall', onToolCall);
 
-            // Set up timeout timer now that streamText is running.
-            // streamText() returns immediately — the actual tool loop runs asynchronously
-            // and completes when we await result.steps/result.text below.
-            let gracefulTimeoutId = null;
-            let hardAbortTimeoutId = null;
-            if (this.timeoutBehavior === 'graceful' && gracefulTimeoutState && this.maxOperationTimeout > 0) {
-              gracefulTimeoutId = setTimeout(() => {
-                gracefulTimeoutState.triggered = true;
-                if (this.debug) {
-                  console.log(`[DEBUG] Soft timeout after ${this.maxOperationTimeout}ms — entering wind-down mode (${gracefulTimeoutState.bonusStepsMax} bonus steps)`);
-                }
-                // Safety net: hard abort after 60s if wind-down doesn't complete
-                hardAbortTimeoutId = setTimeout(() => {
-                  if (this._abortController) {
-                    this._abortController.abort();
-                  }
+              // Set up timeout timer now that streamText is running.
+              // streamText() returns immediately — the actual tool loop runs asynchronously
+              // and completes when we await result.steps/result.text below.
+              let gracefulTimeoutId = null;
+              let hardAbortTimeoutId = null;
+              if (this.timeoutBehavior === 'graceful' && gracefulTimeoutState && this.maxOperationTimeout > 0) {
+                gracefulTimeoutId = setTimeout(() => {
+                  gracefulTimeoutState.triggered = true;
                   if (this.debug) {
-                    console.log(`[DEBUG] Hard abort — wind-down safety net expired after 60s`);
+                    console.log(`[DEBUG] Soft timeout after ${this.maxOperationTimeout}ms — entering wind-down mode (${gracefulTimeoutState.bonusStepsMax} bonus steps)`);
                   }
-                }, 60000);
-              }, this.maxOperationTimeout);
-            }
+                  // Safety net: hard abort after 60s if wind-down doesn't complete
+                  hardAbortTimeoutId = setTimeout(() => {
+                    if (this._abortController) {
+                      this._abortController.abort();
+                    }
+                    if (this.debug) {
+                      console.log(`[DEBUG] Hard abort — wind-down safety net expired after 60s`);
+                    }
+                  }, 60000);
+                }, this.maxOperationTimeout);
+              }
 
-            // Negotiated timeout: run the timeout observer (separate LLM call)
-            if (this.timeoutBehavior === 'negotiated' && this.maxOperationTimeout > 0) {
-              negotiatedTimeoutState.softTimeoutId = setTimeout(() => {
-                if (this.debug) {
-                  console.log(`[DEBUG] Soft timeout after ${this.maxOperationTimeout}ms — invoking timeout observer`);
+              // Negotiated timeout: run the timeout observer (separate LLM call)
+              if (this.timeoutBehavior === 'negotiated' && this.maxOperationTimeout > 0) {
+                negotiatedTimeoutState.softTimeoutId = setTimeout(() => {
+                  if (this.debug) {
+                    console.log(`[DEBUG] Soft timeout after ${this.maxOperationTimeout}ms — invoking timeout observer`);
+                  }
+                  runTimeoutObserver();
+                }, this.maxOperationTimeout);
+              }
+
+              try {
+                // Use only the last step's text as the final answer.
+                // result.text concatenates ALL steps (including intermediate planning text),
+                // but the user should only see the final answer from the last step.
+                const steps = await result.steps;
+                let finalText;
+                if (steps && steps.length > 1) {
+                  // Multi-step: use last step's text (the actual answer after tool calls)
+                  const lastStepText = steps[steps.length - 1].text;
+                  finalText = lastStepText || await result.text;
+                } else {
+                  finalText = await result.text;
                 }
-                runTimeoutObserver();
-              }, this.maxOperationTimeout);
-            }
 
-            try {
-              // Use only the last step's text as the final answer.
-              // result.text concatenates ALL steps (including intermediate planning text),
-              // but the user should only see the final answer from the last step.
-              const steps = await result.steps;
-              let finalText;
-              if (steps && steps.length > 1) {
-                // Multi-step: use last step's text (the actual answer after tool calls)
-                const lastStepText = steps[steps.length - 1].text;
-                finalText = lastStepText || await result.text;
-              } else {
-                finalText = await result.text;
+                // Native schema responses can legitimately carry their payload in result.output
+                // while text and steps stay empty. Plain text answers with no steps and no
+                // text are empty streams and should be retried by the active retry manager.
+                if (!options.schema && (!steps || steps.length === 0) && (!finalText || !finalText.trim())) {
+                  throw Object.assign(
+                    new Error('No output generated. Check the stream for errors.'),
+                    { name: 'AI_NoOutputGeneratedError' }
+                  );
+                }
+
+                if (this.debug) {
+                  console.log(`[DEBUG] streamText completed: ${steps?.length || 0} steps, finalText=${finalText?.length || 0} chars`);
+                }
+
+                // Record final token usage
+                const usage = await result.usage;
+                if (usage) {
+                  this.tokenCounter.recordUsage(usage, result.experimental_providerMetadata);
+                }
+
+                return { finalText, result };
+              } finally {
+                // Clean up graceful timeout timers
+                if (gracefulTimeoutId) clearTimeout(gracefulTimeoutId);
+                if (hardAbortTimeoutId) clearTimeout(hardAbortTimeoutId);
+                // Clean up negotiated timeout timer
+                if (negotiatedTimeoutState.softTimeoutId) clearTimeout(negotiatedTimeoutState.softTimeoutId);
+                // Clean up graceful stop hard abort timer
+                if (this._gracefulStopHardAbortId) {
+                  clearTimeout(this._gracefulStopHardAbortId);
+                  this._gracefulStopHardAbortId = null;
+                }
+                // Remove in-flight tool tracker
+                this.events.removeListener('toolCall', onToolCall);
               }
-
-              if (!options.schema && (!steps || steps.length === 0) && (!finalText || !finalText.trim())) {
-                const noOutputError = new Error('No output generated. Check the stream for errors.');
-                noOutputError.name = 'AI_NoOutputGeneratedError';
-                throw noOutputError;
-              }
-
-              if (this.debug) {
-                console.log(`[DEBUG] streamText completed: ${steps?.length || 0} steps, finalText=${finalText?.length || 0} chars`);
-              }
-
-              // Record final token usage
-              const usage = await result.usage;
-              if (usage) {
-                this.tokenCounter.recordUsage(usage, result.experimental_providerMetadata);
-              }
-
-              return { finalText, result };
-            } finally {
-              // Clean up graceful timeout timers
-              if (gracefulTimeoutId) clearTimeout(gracefulTimeoutId);
-              if (hardAbortTimeoutId) clearTimeout(hardAbortTimeoutId);
-              // Clean up negotiated timeout timer
-              if (negotiatedTimeoutState.softTimeoutId) clearTimeout(negotiatedTimeoutState.softTimeoutId);
-              // Clean up graceful stop hard abort timer
-              if (this._gracefulStopHardAbortId) {
-                clearTimeout(this._gracefulStopHardAbortId);
-                this._gracefulStopHardAbortId = null;
-              }
-              // Remove in-flight tool tracker
-              this.events.removeListener('toolCall', onToolCall);
-            }
-          };
-
-          const executeAIRequestWithPostStreamRetry = async () => {
-            const postStreamRetryManager = new RetryManager({
-              maxRetries: this.retryConfig.maxRetries ?? 3,
-              initialDelay: this.retryConfig.initialDelay ?? 1000,
-              maxDelay: this.retryConfig.maxDelay ?? 30000,
-              backoffFactor: this.retryConfig.backoffFactor ?? 2,
-              retryableErrors: this.retryConfig.retryableErrors,
-              jitter: this.retryConfig.jitter,
-              debug: this.debug
             });
-
-            return await postStreamRetryManager.executeWithRetry(
-              executeAIRequest,
-              {
-                provider: this.clientApiProvider || this.apiType,
-                model: this.model,
-                phase: 'stream-consumption',
-                signal: this._abortController?.signal
-              }
-            );
           };
 
           let aiResult;
           if (this.tracer) {
             const inputPreview = truncateForSpan(message, 4096);
 
-            aiResult = await this.tracer.withSpan('ai.request', executeAIRequestWithPostStreamRetry, {
+            aiResult = await this.tracer.withSpan('ai.request', executeAIRequest, {
               'ai.model': this.model,
               'ai.provider': this.clientApiProvider || 'auto',
               'ai.input': inputPreview,
@@ -4553,7 +4553,7 @@ Double-check your response based on the criteria above. If everything looks good
               });
             });
           } else {
-            aiResult = await executeAIRequestWithPostStreamRetry();
+            aiResult = await executeAIRequest();
           }
 
           // Try native JSON schema output first — Output.object() is set when no tools are active

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -1469,6 +1469,7 @@ export class ProbeAgent {
         maxDelay: this.retryConfig.maxDelay ?? 30000,
         backoffFactor: this.retryConfig.backoffFactor ?? 2,
         retryableErrors: this.retryConfig.retryableErrors,
+        jitter: this.retryConfig.jitter,
         debug: this.debug
       });
     }
@@ -1516,6 +1517,7 @@ export class ProbeAgent {
           maxDelay: this.retryConfig.maxDelay ?? 30000,
           backoffFactor: this.retryConfig.backoffFactor ?? 2,
           retryableErrors: this.retryConfig.retryableErrors,
+          jitter: this.retryConfig.jitter,
           debug: this.debug
         });
 
@@ -4475,6 +4477,12 @@ Double-check your response based on the criteria above. If everything looks good
                 finalText = await result.text;
               }
 
+              if (!options.schema && (!steps || steps.length === 0) && (!finalText || !finalText.trim())) {
+                const noOutputError = new Error('No output generated. Check the stream for errors.');
+                noOutputError.name = 'AI_NoOutputGeneratedError';
+                throw noOutputError;
+              }
+
               if (this.debug) {
                 console.log(`[DEBUG] streamText completed: ${steps?.length || 0} steps, finalText=${finalText?.length || 0} chars`);
               }
@@ -4502,11 +4510,33 @@ Double-check your response based on the criteria above. If everything looks good
             }
           };
 
+          const executeAIRequestWithPostStreamRetry = async () => {
+            const postStreamRetryManager = new RetryManager({
+              maxRetries: this.retryConfig.maxRetries ?? 3,
+              initialDelay: this.retryConfig.initialDelay ?? 1000,
+              maxDelay: this.retryConfig.maxDelay ?? 30000,
+              backoffFactor: this.retryConfig.backoffFactor ?? 2,
+              retryableErrors: this.retryConfig.retryableErrors,
+              jitter: this.retryConfig.jitter,
+              debug: this.debug
+            });
+
+            return await postStreamRetryManager.executeWithRetry(
+              executeAIRequest,
+              {
+                provider: this.clientApiProvider || this.apiType,
+                model: this.model,
+                phase: 'stream-consumption',
+                signal: this._abortController?.signal
+              }
+            );
+          };
+
           let aiResult;
           if (this.tracer) {
             const inputPreview = truncateForSpan(message, 4096);
 
-            aiResult = await this.tracer.withSpan('ai.request', executeAIRequest, {
+            aiResult = await this.tracer.withSpan('ai.request', executeAIRequestWithPostStreamRetry, {
               'ai.model': this.model,
               'ai.provider': this.clientApiProvider || 'auto',
               'ai.input': inputPreview,
@@ -4523,7 +4553,7 @@ Double-check your response based on the criteria above. If everything looks good
               });
             });
           } else {
-            aiResult = await executeAIRequest();
+            aiResult = await executeAIRequestWithPostStreamRetry();
           }
 
           // Try native JSON schema output first — Output.object() is set when no tools are active

--- a/npm/src/agent/RetryManager.js
+++ b/npm/src/agent/RetryManager.js
@@ -41,6 +41,7 @@ function isRetryableError(error, retryableErrors = DEFAULT_RETRYABLE_ERRORS) {
 
   const errorString = error.toString().toLowerCase();
   const errorMessage = (error.message || '').toLowerCase();
+  const errorName = (error.name || error.constructor?.name || '').toLowerCase();
   const errorCode = (error.code || '').toLowerCase();
   const errorType = (error.type || '').toLowerCase();
   const statusCode = error.statusCode || error.status;
@@ -51,6 +52,7 @@ function isRetryableError(error, retryableErrors = DEFAULT_RETRYABLE_ERRORS) {
 
     if (errorString.includes(lowerPattern) ||
         errorMessage.includes(lowerPattern) ||
+        errorName.includes(lowerPattern) ||
         errorCode.includes(lowerPattern) ||
         errorType.includes(lowerPattern) ||
         statusCode?.toString() === pattern) {
@@ -108,7 +110,7 @@ export class RetryManager {
     this.backoffFactor = this._validateNumber(options.backoffFactor, 2, 'backoffFactor', 1, 10);
     this.retryableErrors = options.retryableErrors || DEFAULT_RETRYABLE_ERRORS;
     this.debug = options.debug ?? false;
-    this.jitter = options.jitter ?? true; // Add random jitter by default
+    this.jitter = typeof options.jitter === 'boolean' ? options.jitter : true; // Add random jitter by default
 
     // Validate that maxDelay >= initialDelay
     if (this.maxDelay < this.initialDelay) {

--- a/npm/src/agent/RetryManager.js
+++ b/npm/src/agent/RetryManager.js
@@ -25,7 +25,9 @@ const DEFAULT_RETRYABLE_ERRORS = [
   'ECONNRESET',
   'ETIMEDOUT',
   'ENOTFOUND',
-  'api_error'
+  'api_error',
+  'No output generated',
+  'AI_NoOutputGeneratedError'
 ];
 
 /**

--- a/npm/tests/unit/answer-null-guard.test.js
+++ b/npm/tests/unit/answer-null-guard.test.js
@@ -19,6 +19,7 @@ function createAgent(opts = {}) {
 }
 
 describe('answer() null-guard (#533)', () => {
+  const EXHAUST_AFTER_ONE_RETRY = 1;
   let agent;
 
   beforeEach(() => {
@@ -32,43 +33,54 @@ describe('answer() null-guard (#533)', () => {
   test('retries and fails when non-schema stream has no steps and no text', async () => {
     agent.retryConfig = {
       ...agent.retryConfig,
-      maxRetries: 1,
+      maxRetries: EXHAUST_AFTER_ONE_RETRY,
       initialDelay: 0,
       maxDelay: 0,
       backoffFactor: 1,
       jitter: false,
     };
 
-    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async () => ({
-      text: Promise.resolve(''),
-      finishReason: Promise.resolve('stop'),
-      usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
-      response: { messages: Promise.resolve([]) },
-      experimental_providerMetadata: undefined,
-      steps: Promise.resolve([]),
-      // No output property — simulates no structured output
-    }));
+    let attempts = 0;
+    const retryManager = agent._createRetryManager();
+    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_opts, consumeResult) => {
+      return await retryManager.executeWithRetry(
+        async () => {
+          attempts += 1;
+          return await consumeResult({
+            text: Promise.resolve(''),
+            finishReason: Promise.resolve('stop'),
+            usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
+            response: { messages: Promise.resolve([]) },
+            experimental_providerMetadata: undefined,
+            steps: Promise.resolve([]),
+            // No output property — simulates no structured output
+          });
+        },
+        { provider: 'test', model: 'test-model' }
+      );
+    });
 
     await expect(agent.answer('test question'))
       .rejects
       .toThrow('Failed to get response from AI model. No output generated.');
-    expect(streamSpy).toHaveBeenCalledTimes(2);
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    expect(attempts).toBe(2);
   });
 
   test('returns empty string when schema present but outputObject is null', async () => {
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (opts) => ({
-      text: Promise.resolve(''),
-      finishReason: Promise.resolve('stop'),
-      usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
-      response: { messages: Promise.resolve([]) },
-      experimental_providerMetadata: undefined,
-      steps: Promise.resolve([]),
-      result: {
-        output: Promise.resolve(null),
+    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_opts, consumeResult) => {
+      const result = {
         text: Promise.resolve(''),
+        finishReason: Promise.resolve('stop'),
+        usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
+        response: { messages: Promise.resolve([]) },
+        experimental_providerMetadata: undefined,
         steps: Promise.resolve([]),
-      },
-    }));
+        output: Promise.resolve(null),
+      };
+
+      return consumeResult ? await consumeResult(result) : result;
+    });
 
     // Pass a schema to trigger the schema code path
     const { z } = await import('zod');
@@ -79,7 +91,7 @@ describe('answer() null-guard (#533)', () => {
   });
 
   test('returns empty string when schema output throws and finalText is empty', async () => {
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (opts) => {
+    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_opts, consumeResult) => {
       // Create the rejection lazily to avoid unhandled-rejection before await
       const outputPromise = new Promise((_, reject) => {
         setTimeout(() => reject(new Error('NoObjectGeneratedError')), 0);
@@ -87,19 +99,17 @@ describe('answer() null-guard (#533)', () => {
       // Attach a no-op catch so Node doesn't report unhandled rejection
       outputPromise.catch(() => {});
 
-      return {
+      const result = {
         text: Promise.resolve(''),
         finishReason: Promise.resolve('stop'),
         usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
         response: { messages: Promise.resolve([]) },
         experimental_providerMetadata: undefined,
         steps: Promise.resolve([]),
-        result: {
-          output: outputPromise,
-          text: Promise.resolve(''),
-          steps: Promise.resolve([]),
-        },
+        output: outputPromise,
       };
+
+      return consumeResult ? await consumeResult(result) : result;
     });
 
     const { z } = await import('zod');
@@ -110,14 +120,18 @@ describe('answer() null-guard (#533)', () => {
   });
 
   test('returns actual text when finalText is available', async () => {
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async () => ({
-      text: Promise.resolve('here is my answer'),
-      finishReason: Promise.resolve('stop'),
-      usage: Promise.resolve({ promptTokens: 10, completionTokens: 5 }),
-      response: { messages: Promise.resolve([]) },
-      experimental_providerMetadata: undefined,
-      steps: Promise.resolve([]),
-    }));
+    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_opts, consumeResult) => {
+      const result = {
+        text: Promise.resolve('here is my answer'),
+        finishReason: Promise.resolve('stop'),
+        usage: Promise.resolve({ promptTokens: 10, completionTokens: 5 }),
+        response: { messages: Promise.resolve([]) },
+        experimental_providerMetadata: undefined,
+        steps: Promise.resolve([]),
+      };
+
+      return consumeResult ? await consumeResult(result) : result;
+    });
 
     const result = await agent.answer('test question');
     expect(result).toBe('here is my answer');

--- a/npm/tests/unit/answer-null-guard.test.js
+++ b/npm/tests/unit/answer-null-guard.test.js
@@ -29,8 +29,17 @@ describe('answer() null-guard (#533)', () => {
     agent.provider = null;
   });
 
-  test('returns empty string when schema output and finalText are both null', async () => {
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async () => ({
+  test('retries and fails when non-schema stream has no steps and no text', async () => {
+    agent.retryConfig = {
+      ...agent.retryConfig,
+      maxRetries: 1,
+      initialDelay: 0,
+      maxDelay: 0,
+      backoffFactor: 1,
+      jitter: false,
+    };
+
+    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async () => ({
       text: Promise.resolve(''),
       finishReason: Promise.resolve('stop'),
       usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
@@ -40,8 +49,10 @@ describe('answer() null-guard (#533)', () => {
       // No output property — simulates no structured output
     }));
 
-    const result = await agent.answer('test question');
-    expect(typeof result).toBe('string');
+    await expect(agent.answer('test question'))
+      .rejects
+      .toThrow('Failed to get response from AI model. No output generated.');
+    expect(streamSpy).toHaveBeenCalledTimes(2);
   });
 
   test('returns empty string when schema present but outputObject is null', async () => {

--- a/npm/tests/unit/last-step-text.test.js
+++ b/npm/tests/unit/last-step-text.test.js
@@ -25,6 +25,12 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
     };
   }
 
+  function createNoOutputError() {
+    const error = new Error('No output generated. Check the stream for errors.');
+    error.name = 'AI_NoOutputGeneratedError';
+    return error;
+  }
+
   test('single-step response uses result.text as-is', async () => {
     const agent = createMockedAgent();
     const singleStep = [{ text: 'The final answer.', toolCalls: [], finishReason: 'stop' }];
@@ -86,6 +92,90 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
 
     const result = await agent.answer('Simple question');
     expect(result).toBe('Direct answer');
+    jest.restoreAllMocks();
+  });
+
+  test('retries when result.steps rejects with NoOutputGeneratedError', async () => {
+    const agent = createMockedAgent({
+      retry: {
+        maxRetries: 2,
+        initialDelay: 0,
+        maxDelay: 0,
+        backoffFactor: 1,
+        jitter: false,
+      },
+    });
+    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
+      .mockResolvedValueOnce({
+        text: Promise.resolve(''),
+        usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
+        response: { messages: Promise.resolve([]) },
+        experimental_providerMetadata: undefined,
+        steps: Promise.reject(createNoOutputError()),
+      })
+      .mockResolvedValueOnce(
+        createMockStreamResult('Recovered answer', [
+          { text: 'Recovered answer', toolCalls: [], finishReason: 'stop' },
+        ])
+      );
+
+    const result = await agent.answer('Simple greeting');
+
+    expect(result).toBe('Recovered answer');
+    expect(streamSpy).toHaveBeenCalledTimes(2);
+    jest.restoreAllMocks();
+  });
+
+  test('retries when provider resolves empty steps and empty text', async () => {
+    const agent = createMockedAgent({
+      retry: {
+        maxRetries: 2,
+        initialDelay: 0,
+        maxDelay: 0,
+        backoffFactor: 1,
+        jitter: false,
+      },
+    });
+    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
+      .mockResolvedValueOnce(
+        createMockStreamResult('', [])
+      )
+      .mockResolvedValueOnce(
+        createMockStreamResult('Recovered from empty stream', [
+          { text: 'Recovered from empty stream', toolCalls: [], finishReason: 'stop' },
+        ])
+      );
+
+    const result = await agent.answer('Simple greeting');
+
+    expect(result).toBe('Recovered from empty stream');
+    expect(streamSpy).toHaveBeenCalledTimes(2);
+    jest.restoreAllMocks();
+  });
+
+  test('stops retrying NoOutputGeneratedError after retry budget is exhausted', async () => {
+    const agent = createMockedAgent({
+      retry: {
+        maxRetries: 1,
+        initialDelay: 0,
+        maxDelay: 0,
+        backoffFactor: 1,
+        jitter: false,
+      },
+    });
+    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
+      .mockResolvedValue({
+        text: Promise.resolve(''),
+        usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
+        response: { messages: Promise.resolve([]) },
+        experimental_providerMetadata: undefined,
+        steps: Promise.reject(createNoOutputError()),
+      });
+
+    await expect(agent.answer('Simple greeting')).rejects.toThrow(
+      'Failed to get response from AI model. No output generated.'
+    );
+    expect(streamSpy).toHaveBeenCalledTimes(2);
     jest.restoreAllMocks();
   });
 });

--- a/npm/tests/unit/last-step-text.test.js
+++ b/npm/tests/unit/last-step-text.test.js
@@ -2,6 +2,9 @@ import { describe, test, expect, jest, beforeEach } from '@jest/globals';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 
 describe('ProbeAgent finalText uses last step text (no planning preamble)', () => {
+  const RECOVER_AFTER_ONE_RETRY = 1;
+  const EXHAUST_AFTER_ONE_RETRY = 1;
+
   function createMockedAgent(options = {}) {
     const agent = new ProbeAgent({
       path: process.cwd(),
@@ -31,13 +34,34 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
     return error;
   }
 
+  function mockStreamText(agent, result) {
+    return jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_options, consumeResult) => {
+      return consumeResult ? await consumeResult(result) : result;
+    });
+  }
+
+  function mockStreamTextWithRetry(agent, results) {
+    let attempts = 0;
+    const retryManager = agent._createRetryManager();
+    const spy = jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockImplementation(async (_options, consumeResult) => {
+      return await retryManager.executeWithRetry(
+        async () => {
+          const result = results[Math.min(attempts, results.length - 1)];
+          attempts += 1;
+          return consumeResult ? await consumeResult(result) : result;
+        },
+        { provider: 'test', model: 'test-model' }
+      );
+    });
+
+    return { spy, getAttempts: () => attempts };
+  }
+
   test('single-step response uses result.text as-is', async () => {
     const agent = createMockedAgent();
     const singleStep = [{ text: 'The final answer.', toolCalls: [], finishReason: 'stop' }];
 
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockResolvedValue(
-      createMockStreamResult('The final answer.', singleStep)
-    );
+    mockStreamText(agent, createMockStreamResult('The final answer.', singleStep));
 
     const result = await agent.answer('What is this?');
     expect(result).toBe('The final answer.');
@@ -54,9 +78,7 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
     // result.text concatenates all steps
     const fullText = steps.map(s => s.text).join('');
 
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockResolvedValue(
-      createMockStreamResult(fullText, steps)
-    );
+    mockStreamText(agent, createMockStreamResult(fullText, steps));
 
     const result = await agent.answer('How is rate limiting implemented?');
     // Should only contain the last step's text, not the planning preamble
@@ -73,9 +95,7 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
       { text: '', toolCalls: [], finishReason: 'stop' },
     ];
 
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockResolvedValue(
-      createMockStreamResult('Searching...', steps)
-    );
+    mockStreamText(agent, createMockStreamResult('Searching...', steps));
 
     const result = await agent.answer('Find something');
     // Falls back to full result.text when last step is empty
@@ -86,9 +106,7 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
   test('empty steps array uses result.text', async () => {
     const agent = createMockedAgent();
 
-    jest.spyOn(agent, 'streamTextWithRetryAndFallback').mockResolvedValue(
-      createMockStreamResult('Direct answer', [])
-    );
+    mockStreamText(agent, createMockStreamResult('Direct answer', []));
 
     const result = await agent.answer('Simple question');
     expect(result).toBe('Direct answer');
@@ -98,84 +116,84 @@ describe('ProbeAgent finalText uses last step text (no planning preamble)', () =
   test('retries when result.steps rejects with NoOutputGeneratedError', async () => {
     const agent = createMockedAgent({
       retry: {
-        maxRetries: 2,
+        maxRetries: RECOVER_AFTER_ONE_RETRY,
         initialDelay: 0,
         maxDelay: 0,
         backoffFactor: 1,
         jitter: false,
       },
     });
-    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
-      .mockResolvedValueOnce({
+    const { spy: streamSpy, getAttempts } = mockStreamTextWithRetry(agent, [
+      {
         text: Promise.resolve(''),
         usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
         response: { messages: Promise.resolve([]) },
         experimental_providerMetadata: undefined,
         steps: Promise.reject(createNoOutputError()),
-      })
-      .mockResolvedValueOnce(
-        createMockStreamResult('Recovered answer', [
-          { text: 'Recovered answer', toolCalls: [], finishReason: 'stop' },
-        ])
-      );
+      },
+      createMockStreamResult('Recovered answer', [
+        { text: 'Recovered answer', toolCalls: [], finishReason: 'stop' },
+      ]),
+    ]);
 
     const result = await agent.answer('Simple greeting');
 
     expect(result).toBe('Recovered answer');
-    expect(streamSpy).toHaveBeenCalledTimes(2);
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    expect(getAttempts()).toBe(2);
     jest.restoreAllMocks();
   });
 
   test('retries when provider resolves empty steps and empty text', async () => {
     const agent = createMockedAgent({
       retry: {
-        maxRetries: 2,
+        maxRetries: RECOVER_AFTER_ONE_RETRY,
         initialDelay: 0,
         maxDelay: 0,
         backoffFactor: 1,
         jitter: false,
       },
     });
-    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
-      .mockResolvedValueOnce(
-        createMockStreamResult('', [])
-      )
-      .mockResolvedValueOnce(
-        createMockStreamResult('Recovered from empty stream', [
-          { text: 'Recovered from empty stream', toolCalls: [], finishReason: 'stop' },
-        ])
-      );
+    const { spy: streamSpy, getAttempts } = mockStreamTextWithRetry(agent, [
+      createMockStreamResult('', []),
+      createMockStreamResult('Recovered from empty stream', [
+        { text: 'Recovered from empty stream', toolCalls: [], finishReason: 'stop' },
+      ]),
+    ]);
 
     const result = await agent.answer('Simple greeting');
 
     expect(result).toBe('Recovered from empty stream');
-    expect(streamSpy).toHaveBeenCalledTimes(2);
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    expect(getAttempts()).toBe(2);
     jest.restoreAllMocks();
   });
 
   test('stops retrying NoOutputGeneratedError after retry budget is exhausted', async () => {
     const agent = createMockedAgent({
       retry: {
-        maxRetries: 1,
+        maxRetries: EXHAUST_AFTER_ONE_RETRY,
         initialDelay: 0,
         maxDelay: 0,
         backoffFactor: 1,
         jitter: false,
       },
     });
-    const streamSpy = jest.spyOn(agent, 'streamTextWithRetryAndFallback')
-      .mockResolvedValue({
+    const { spy: streamSpy, getAttempts } = mockStreamTextWithRetry(agent, [
+      {
         text: Promise.resolve(''),
         usage: Promise.resolve({ promptTokens: 10, completionTokens: 0 }),
         response: { messages: Promise.resolve([]) },
         experimental_providerMetadata: undefined,
         steps: Promise.reject(createNoOutputError()),
-      });
+      },
+    ]);
 
     await expect(agent.answer('Simple greeting')).rejects.toThrow(
       'Failed to get response from AI model. No output generated.'
     );
-    expect(streamSpy).toHaveBeenCalledTimes(2);
+    expect(streamSpy).toHaveBeenCalledTimes(1);
+    expect(getAttempts()).toBe(2);
     jest.restoreAllMocks();
   });
 });

--- a/npm/tests/unit/retryManager.test.js
+++ b/npm/tests/unit/retryManager.test.js
@@ -18,6 +18,7 @@ describe('RetryManager', () => {
       expect(retry.maxDelay).toBe(30000);
       expect(retry.backoffFactor).toBe(2);
       expect(retry.debug).toBe(false);
+      expect(retry.jitter).toBe(true);
     });
 
     test('should accept custom configuration', () => {
@@ -34,6 +35,12 @@ describe('RetryManager', () => {
       expect(retry.maxDelay).toBe(10000);
       expect(retry.backoffFactor).toBe(3);
       expect(retry.debug).toBe(true);
+    });
+
+    test('should normalize jitter to a boolean', () => {
+      expect(new RetryManager({ jitter: false }).jitter).toBe(false);
+      expect(new RetryManager({ jitter: 'false' }).jitter).toBe(true);
+      expect(new RetryManager({ jitter: undefined }).jitter).toBe(true);
     });
   });
 

--- a/npm/tests/unit/retryManager.test.js
+++ b/npm/tests/unit/retryManager.test.js
@@ -81,6 +81,15 @@ describe('RetryManager', () => {
       error.type = 'api_error';
       expect(isRetryableError(error)).toBe(true);
     });
+
+    test('should identify Vercel AI SDK empty output errors', () => {
+      const messageError = new Error('No output generated. Check the stream for errors.');
+      expect(isRetryableError(messageError)).toBe(true);
+
+      const namedError = new Error('stream ended without output');
+      namedError.name = 'AI_NoOutputGeneratedError';
+      expect(isRetryableError(namedError)).toBe(true);
+    });
   });
 
   describe('executeWithRetry', () => {


### PR DESCRIPTION
## Summary

Fixes #575.

This changes the AI request path so empty-output failures that happen after `streamText()` returns are retried by the same retry budget that already handles provider stream creation. The retry scope now covers both `streamText()` and post-stream consumption (`result.steps`, `result.text`, and usage recording) without adding a nested `RetryManager`.

## What changed

- Added Vercel AI SDK empty-output failures to the default retryable error patterns:
  - `No output generated`
  - `AI_NoOutputGeneratedError`
- Extended `streamTextWithRetryAndFallback()` with an optional consumer callback so post-stream consumption can run inside the existing provider retry attempt.
- Re-invokes the full AI request when `result.steps` rejects with an empty-output error.
- Treats non-schema responses with no steps and no text as retryable empty-output failures.
- Preserves schema/null-guard behavior where structured-output paths may legitimately have empty text and empty steps while `result.output` carries the payload.
- Centralized RetryManager construction in `ProbeAgent` and normalized `jitter` handling.
- Matches retryable errors by `error.name` / constructor name as well as message, code, type, and status.
- Keeps tool-call listener registration scoped to each retry attempt so cleanup does not disable listener tracking on a retry.

## Tests

Focused tests added/updated:

- `npm/tests/unit/retryManager.test.js`
  - verifies `No output generated` and `AI_NoOutputGeneratedError` are retryable.
  - verifies `jitter` normalization.
- `npm/tests/unit/last-step-text.test.js`
  - retries when `result.steps` rejects with `AI_NoOutputGeneratedError`.
  - retries when provider resolves empty steps and empty text.
  - stops retrying after the configured retry budget is exhausted.
  - asserts the high-level stream call is made once while retry attempts happen inside the single retry manager.
- `npm/tests/unit/answer-null-guard.test.js`
  - verifies non-schema empty streams now retry and fail after budget exhaustion.
  - keeps schema-output null guards covered.

Validation run:

```bash
cd npm
npm test -- --runInBand tests/unit/retryManager.test.js tests/unit/last-step-text.test.js tests/unit/answer-null-guard.test.js
```

Result: 3 test suites passed, 36 tests passed.

Additional check:

```bash
git diff --check
```

Result: passed.

I also previously ran the broader unit suite with:

```bash
cd npm
npm test -- --runInBand tests/unit
```

That run had the new/changed tests passing, but the full suite did not complete green locally because several existing tests try to download the missing release asset `probe-v0.6.0-rc88-x86_64-unknown-linux-musl.tar.gz` from GitHub and receive 404s. It also surfaced existing symbol-edit failures unrelated to this retry change.