### PR TITLE
Fix/ranking correctness and stability

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -363,12 +363,25 @@ fn handle_search(params: SearchParams) -> Result<()> {
                 // Genuinely no results found - show helpful tips
                 println!("{}", "No results found.".yellow().bold());
                 println!();
-                println!("💡 Tips to improve your search:");
-                println!("  - Try synonyms or related terms (e.g., \"fetch\" instead of \"get\")");
-                println!("  - Use broader terms without AND operators");
-                println!("  - Check spelling of function/class names");
-                println!("  - Remove file type filters to search all files");
-                println!("  - Use exact:false (default) for stemming, or exact:true for precise symbol lookup");
+                if params.exact && params.pattern.trim().contains(char::is_whitespace) {
+                    // --exact turns a multi-word query into a single literal phrase (no
+                    // tokenization), so conceptual/multi-word queries almost always miss.
+                    // Call this out specifically instead of the generic tips below.
+                    println!(
+                        "💡 {} --exact matched your whole query as one literal phrase (\"{}\"), with no tokenization or stemming",
+                        "Hint:".dimmed(),
+                        params.pattern
+                    );
+                    println!("  - For multi-word/conceptual searches, drop --exact so each word is tokenized and matched individually");
+                    println!("  - Keep --exact for precise, single-term symbol lookups (e.g. an exact function or variable name)");
+                } else {
+                    println!("💡 Tips to improve your search:");
+                    println!("  - Try synonyms or related terms (e.g., \"fetch\" instead of \"get\")");
+                    println!("  - Use broader terms without AND operators");
+                    println!("  - Check spelling of function/class names");
+                    println!("  - Remove file type filters to search all files");
+                    println!("  - Use exact:false (default) for stemming, or exact:true for precise symbol lookup");
+                }
             }
             if params.verbose {
                 println!();

--- a/src/search/block_merging.rs
+++ b/src/search/block_merging.rs
@@ -237,6 +237,17 @@ pub fn merge_ranked_blocks(
                             next_block.node_type.clone()
                         };
 
+                        // Keep the best (numerically lowest = most relevant) individual rank
+                        // among the merged blocks. Without this, the merged block silently kept
+                        // whichever block happened to start the chain (chosen by start line, not
+                        // by rank), which could be far worse-ranked than a block it absorbed -
+                        // making post-merge relevance sorting unreliable.
+                        let merged_rank = match (current_block.rank, next_block.rank) {
+                            (Some(r1), Some(r2)) => Some(r1.min(r2)),
+                            (Some(r), None) | (None, Some(r)) => Some(r),
+                            (None, None) => None,
+                        };
+
                         // Combine scores and term statistics
                         let merged_score = merge_scores(&current_block, next_block);
                         let merged_term_stats = merge_term_statistics(&current_block, next_block);
@@ -253,6 +264,7 @@ pub fn merge_ranked_blocks(
                         current_block.lines = (merged_start, merged_end);
                         current_block.code = merged_code;
                         current_block.node_type = merged_node_type;
+                        current_block.rank = merged_rank;
                         current_block.score = merged_score.0;
                         current_block.tfidf_score = merged_score.1;
                         current_block.bm25_score = merged_score.2;

--- a/src/search/search_output.rs
+++ b/src/search/search_output.rs
@@ -2681,9 +2681,19 @@ fn format_and_print_outline_results(
             .push(result);
     }
 
-    // Sort files for consistent output
+    // Sort file groups by their best (lowest = most relevant) individual result rank, not
+    // alphabetically by path. `results` is already in relevance order by the time it gets here,
+    // so grouping-then-alphabetizing was silently discarding that order: which files appear
+    // depends on --max-results, so an alphabetical re-sort meant a larger --max-results could
+    // shuffle files that were already being displayed instead of simply revealing more of the
+    // same ordering. Fall back to the path for a deterministic tie-break when ranks are equal
+    // or unavailable.
     let mut files: Vec<(String, Vec<&SearchResult>)> = files_map.into_iter().collect();
-    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files.sort_by(|a, b| {
+        let rank_a = a.1.iter().filter_map(|r| r.rank).min().unwrap_or(usize::MAX);
+        let rank_b = b.1.iter().filter_map(|r| r.rank).min().unwrap_or(usize::MAX);
+        rank_a.cmp(&rank_b).then_with(|| a.0.cmp(&b.0))
+    });
 
     // Sort results within each file by line number (not by score)
     for (_, file_results) in &mut files {
@@ -2864,9 +2874,19 @@ fn format_and_print_outline_xml_results(
             .push(result);
     }
 
-    // Sort files for consistent output
+    // Sort file groups by their best (lowest = most relevant) individual result rank, not
+    // alphabetically by path. `results` is already in relevance order by the time it gets here,
+    // so grouping-then-alphabetizing was silently discarding that order: which files appear
+    // depends on --max-results, so an alphabetical re-sort meant a larger --max-results could
+    // shuffle files that were already being displayed instead of simply revealing more of the
+    // same ordering. Fall back to the path for a deterministic tie-break when ranks are equal
+    // or unavailable.
     let mut files: Vec<(String, Vec<&SearchResult>)> = files_map.into_iter().collect();
-    files.sort_by(|a, b| a.0.cmp(&b.0));
+    files.sort_by(|a, b| {
+        let rank_a = a.1.iter().filter_map(|r| r.rank).min().unwrap_or(usize::MAX);
+        let rank_b = b.1.iter().filter_map(|r| r.rank).min().unwrap_or(usize::MAX);
+        rank_a.cmp(&rank_b).then_with(|| a.0.cmp(&b.0))
+    });
 
     // Sort results within each file by line number (not by score)
     for (_, file_results) in &mut files {

--- a/src/search/search_runner.rs
+++ b/src/search/search_runner.rs
@@ -896,6 +896,15 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
         250, // Average tokens per result estimate
     );
 
+    // The scoring pool (how many early-ranked files actually get full AST parsing + BM25
+    // ranking) must not be driven solely by the display limit (--max-results): BM25 statistics
+    // (IDF, avg doc length) are computed over whatever ends up in this pool, so a smaller
+    // max_results shrinking the pool can change the relative order of results, not just how
+    // many are shown. Give the pool a generous, max_results-independent floor so relevance
+    // ordering stays stable as --max-results is increased.
+    const MIN_SCORING_POOL_FILES: usize = 300;
+    let scoring_pool_files = estimated_files_needed.max(MIN_SCORING_POOL_FILES);
+
     let mut files_processed = 0;
     let mut batch_number = 0;
     let mut should_continue = true;
@@ -903,9 +912,14 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
     // Track total files available for accurate skipped file count
     let total_ranked_files = ranked_files.len();
 
-    // Use dynamic batch size: min of BATCH_SIZE and estimated_files_needed
-    // This prevents processing way more files than needed when limits are strict
-    let effective_batch_size = BATCH_SIZE.min(estimated_files_needed);
+    // Use dynamic batch size: min of BATCH_SIZE and the scoring pool size (not
+    // estimated_files_needed directly). Sizing the batch off estimated_files_needed made the
+    // batch granularity itself track --max-results, so different --max-results values walked
+    // the same globally-ranked file list in differently-sized steps and could overshoot the
+    // results-count safety valve below at different file counts - silently rescoring a
+    // different candidate set (and thus a different relevance order) per --max-results.
+    // Basing it on scoring_pool_files keeps the step size max_results-independent.
+    let effective_batch_size = BATCH_SIZE.min(scoring_pool_files);
     if debug_mode {
         println!(
             "DEBUG: Using batch size {} (BATCH_SIZE={}, estimated_files_needed={})",
@@ -1181,23 +1195,28 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
         final_results.append(&mut batch_results);
 
         // Check if we have enough results or files processed
-        if files_processed >= estimated_files_needed {
+        if files_processed >= scoring_pool_files {
             if debug_mode {
                 println!(
-                    "DEBUG: Stopping batch processing - processed {files_processed} files (estimated need: {estimated_files_needed})"
+                    "DEBUG: Stopping batch processing - processed {files_processed} files (scoring pool: {scoring_pool_files})"
                 );
             }
             should_continue = false;
         }
 
-        // Also check if we already have way more results than needed
-        // Use a more conservative multiplier aligned with our 1.5x buffer strategy
+        // Also check if we already have way more results than needed.
+        // This results-count buffer must scale with scoring_pool_files (files), not directly
+        // with max_results, or it reintroduces max_results-dependent reordering: the same
+        // "~2.5 results per file" estimate used to size the pool is applied here, so this
+        // valve trips around the same file count regardless of --max-results. It still grows
+        // for very large --max-results requests via the max_res*2.0 term.
         if let Some(max_res) = max_results {
-            let buffered_max_results = (*max_res as f64 * 2.0).ceil() as usize; // 2x buffer for safety
+            let buffered_max_results = ((scoring_pool_files as f64 * 2.5).ceil() as usize)
+                .max((*max_res as f64 * 2.0).ceil() as usize); // 2x buffer for safety
             if final_results.len() > buffered_max_results {
                 if debug_mode {
                     println!(
-                        "DEBUG: Stopping batch processing - have {} results (2x buffered max_results: {})",
+                        "DEBUG: Stopping batch processing - have {} results (buffered max_results: {})",
                         final_results.len(),
                         buffered_max_results
                     );
@@ -1316,64 +1335,49 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
             format_duration(remaining_time)
         );
     }
-    // Rank results (skip if exact flag is set or all AST terms are exact like quoted queries)
+    // Rank results. Note: the exact flag (and ast_all_exact for quoted queries) only controls
+    // how terms are matched against content/filenames (no stemming/fuzzy expansion) - it does
+    // not imply relevance ranking should be skipped. Previously exact searches fell back to
+    // alphabetical path order instead of BM25 relevance, so we rank exact matches too.
     let rr_start = Instant::now();
-    let skip_ranking = *exact || ast_all_exact;
     if debug_mode {
-        if skip_ranking {
-            println!("DEBUG: Skipping result ranking due to exact flag being set");
-        } else {
-            println!("DEBUG: Starting result ranking...");
-        }
+        println!("DEBUG: Starting result ranking...");
     }
 
-    if !skip_ranking {
-        // Only perform ranking if exact flag is not set
-        rank_search_results(&mut final_results, queries, reranker, *question);
+    rank_search_results(&mut final_results, queries, reranker, *question);
 
-        // Apply deterministic secondary sort to ensure consistent ordering for results with equal scores
-        // This prevents non-deterministic behavior when results have the same ranking score
-        final_results.sort_by(|a, b| {
-            // First sort by score (if available), then by file path, then by line number
-            match (a.rank, b.rank) {
-                (Some(rank_a), Some(rank_b)) => {
-                    // If ranks are different, use rank ordering
-                    match rank_a.cmp(&rank_b) {
-                        std::cmp::Ordering::Equal => {
-                            // If ranks are equal, use deterministic secondary sort
-                            (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0))
-                        }
-                        other => other,
+    // Apply deterministic secondary sort to ensure consistent ordering for results with equal scores
+    // This prevents non-deterministic behavior when results have the same ranking score
+    final_results.sort_by(|a, b| {
+        // First sort by score (if available), then by file path, then by line number
+        match (a.rank, b.rank) {
+            (Some(rank_a), Some(rank_b)) => {
+                // If ranks are different, use rank ordering
+                match rank_a.cmp(&rank_b) {
+                    std::cmp::Ordering::Equal => {
+                        // If ranks are equal, use deterministic secondary sort
+                        (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0))
                     }
-                }
-                (Some(_), None) => std::cmp::Ordering::Less,
-                (None, Some(_)) => std::cmp::Ordering::Greater,
-                (None, None) => {
-                    // If no ranks, sort by file path and line number
-                    (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0))
+                    other => other,
                 }
             }
-        });
-    } else {
-        // For exact searches, always apply deterministic sort
-        final_results.sort_by(|a, b| (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0)));
-    }
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => {
+                // If no ranks, sort by file path and line number
+                (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0))
+            }
+        }
+    });
 
     let rr_duration = rr_start.elapsed();
     timings.result_ranking = Some(rr_duration);
 
     if debug_mode {
-        if *exact {
-            println!(
-                "DEBUG: Result ranking skipped in {}",
-                format_duration(rr_duration)
-            );
-        } else {
-            println!(
-                "DEBUG: Result ranking completed in {}",
-                format_duration(rr_duration)
-            );
-        }
+        println!(
+            "DEBUG: Result ranking completed in {}",
+            format_duration(rr_duration)
+        );
     }
 
     // We'll move the caching step AFTER limiting results
@@ -1570,6 +1574,26 @@ pub fn perform_probe(options: &SearchOptions) -> Result<LimitedSearchResults> {
 
         limited
     };
+
+    // Restore relevance order for display. deduplicate_contained_blocks (always applied above)
+    // and merge_ranked_blocks (applied unless --no-merge) both group blocks by file path via a
+    // BTreeMap to do their per-file work, and neither re-sorts the flattened output afterward -
+    // BTreeMap iteration is alphabetical by file path, so the final list would otherwise come
+    // back ordered alphabetically among the (correctly rank-selected) top max_results results
+    // instead of by relevance. Since which files land in that already-limited set changes with
+    // --max-results, the apparent position of any given result would drift with --max-results
+    // even though the underlying ranking never changed. Re-apply the same rank-based order (with
+    // the same deterministic tie-break) used right after ranking, above.
+    let mut final_results = final_results;
+    final_results.results.sort_by(|a, b| match (a.rank, b.rank) {
+        (Some(rank_a), Some(rank_b)) => match rank_a.cmp(&rank_b) {
+            std::cmp::Ordering::Equal => (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0)),
+            other => other,
+        },
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => (&a.file, a.lines.0).cmp(&(&b.file, b.lines.0)),
+    });
 
     // Print the session ID to the console if it was generated or provided
     if let Some(session_id) = effective_session {


### PR DESCRIPTION
Found while benchmarking Probe against a real corpus (WordPress core, 3,188 PHP files). Four compounding defects made result ordering incorrect and non-deterministic.

## The defects

**1. Exact search skipped ranking entirely.** `let skip_ranking = *exact || ast_all_exact;` meant any exact or quoted query bypassed BM25 and fell back to alphabetical path order. Results looked ranked but were ordered by filename.

**2. `--max-results` changed *which* files were scored.** `effective_batch_size` derived from an estimate that scales with `max_results`, so a results-count safety valve tripped at different file counts per `--max-results`, silently rescoring a different candidate set. A larger limit wasn't "more of the same ranking" — it was a *different* ranking.

**3. Block merging discarded the better rank.** `merge_ranked_blocks` kept whichever sub-block started the merge chain (chosen by start line, not rank), dropping a better rank from an absorbed block. As `--max-results` grew, more blocks entered the merge window, so merging behaved differently per `--max-results`.

**4. Default outline output sorted file groups alphabetically by path**, independent of relevance — enough on its own to make output look unranked even once ranking was correct.

## Measured

Rank of the file that actually *defines* the queried symbol, WordPress core:

| query | `--max-results` 10 / 50 / 200 | |
|---|---|---|
| `human_time_diff` | before **8 / 18 / 51** | after **2 / 2 / 2** |

Exact-mode identifier retrieval improves **4/6 → 6/6**, and those are now genuine relevance ranks rather than alphabetical positions.

## Cost (honest)

**~24% slower at small `--max-results`** (~4.2s → ~5.2s): a small limit can no longer score only ~20 files. At `--max-results 200` the patched build is **faster** (~10.7s vs ~15.9s), because the old batch/threshold interaction did redundant work at larger N. A real but moderate cost, paid for correctness and determinism.

## Also included

`--exact` treats the entire input as one literal string, so a multi-word conceptual query must appear verbatim or returns nothing — measured at 7/7 conceptual queries returning zero under `--exact`. Adds a specific hint for that case; single-word `--exact` output unchanged.

## Verification

- `cargo test --release --lib`: **392 passed, 0 failed** (unchanged from baseline)
- Plus 59 integration tests across CLI, JSON-format, elastic-query, strict-syntax and outline-format suites, run because output ordering changed
- 6/6 exact-mode identifier and 4/4 conceptual queries still match
- Rank stability confirmed via `--format json`, not just default output

## Note for reviewers

Defect 4 is worth a careful look: because the default outline output sorted alphabetically, any benchmark that scrapes `^File:` from default output was partly measuring a formatting sort rather than relevance. That may affect how earlier ranking measurements should be read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)