### PR TITLE
feat(agent): add governed Codex runtime and tool contracts

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -24,7 +24,7 @@ export interface ProbeAgentOptions {
   /** Working directory for resolving relative paths (independent of allowedFolders security) */
   cwd?: string;
   /** Force specific AI provider */
-  provider?: 'anthropic' | 'openai' | 'google';
+  provider?: 'anthropic' | 'openai' | 'google' | 'codex';
   /** Override model name */
   model?: string;
   /** Enable debug mode */
@@ -45,6 +45,11 @@ export interface ProbeAgentOptions {
   hooks?: Record<string, (data: any) => void | Promise<void>>;
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
+  /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
+  governedCodexProfile?: {
+    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
+    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
+  };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Disable automatic mermaid diagram validation and fixing */
@@ -334,6 +339,8 @@ export declare class ProbeAgent {
    * Cancel any ongoing operations
    */
   cancel(): void;
+
+  /** Close engine subprocess and MCP resources. */ close(): Promise<void>;
 
   /**
    * Clear the conversation history

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -46,10 +46,7 @@ export interface ProbeAgentOptions {
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
   /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
-  governedCodexProfile?: {
-    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
-    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
-  };
+  governedCodexProfile?: { version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0; };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Disable automatic mermaid diagram validation and fixing */

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -264,6 +264,10 @@ export interface GovernedAnswerOptions extends AnswerOptions {
   schema: string;
 }
 
+export interface GovernedInvocationAnswerOptions extends GovernedAnswerOptions {
+  invocationDigest: string;
+}
+
 export interface GovernedCodexRuntimeAttestation {
   version: 'probe.governed-codex-attestation/v1';
   profileId: 'luna-xhigh-readonly-v1';
@@ -276,6 +280,22 @@ export interface GovernedCodexRuntimeAttestation {
 export interface GovernedAnswerResult {
   data: unknown;
   runtimeAttestation: GovernedCodexRuntimeAttestation;
+}
+
+export interface GovernedCodexRuntimeAttestationV2 {
+  version: 'probe.governed-codex-attestation/v2';
+  profileId: 'luna-xhigh-readonly-v1';
+  requested: { profileDigest: string; cwdDigest: string; probeToolsDigest: string; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; };
+  observed: { source: 'session_configured'; model: 'gpt-5.6-luna'; modelProviderId: 'openai'; reasoningEffort: 'xhigh'; approvalPolicy: 'never'; cwdDigest: string; permissionProfileDigest: string; filesystem: 'restricted-read-root'; network: 'restricted'; };
+  executionContext: { source: 'caller'; invocationDigest: string; };
+  dispatch: { source: 'probe-host-tools-call'; tool: 'codex'; promptDigest: string; promptBytes: number; };
+  evidence: { eventCount: 1; };
+  usage: { status: 'unavailable'; };
+}
+
+export interface GovernedInvocationAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestationV2;
 }
 
 /**
@@ -344,6 +364,7 @@ export declare class ProbeAgent {
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
 
+  answerGoverned(message: string, options: GovernedInvocationAnswerOptions, images?: any[]): Promise<GovernedInvocationAnswerResult>;
   answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 
   /**

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -95,6 +95,7 @@ export interface ProbeAgentOptions {
  * Tool execution event data
  */
 export interface ToolCallEvent {
+  argumentsDigest?: string;
   /** Unique tool call identifier */
   id: string;
   /** Name of the tool being called */

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -358,6 +358,7 @@ export declare class ProbeAgent {
   
   /** Whether operations have been cancelled */
   cancelled: boolean;
+  readonly abortSignal: AbortSignal;
 
   /**
    * Create a new ProbeAgent instance

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -268,6 +268,17 @@ export interface GovernedInvocationAnswerOptions extends GovernedAnswerOptions {
   invocationDigest: string;
 }
 
+export interface GovernedIdentifiedAnswerOptions extends GovernedInvocationAnswerOptions {
+  resultIdentity: 'probe.governed-result-identity/v1';
+}
+
+export interface GovernedResultIdentity {
+  version: 'probe.governed-result-identity/v1';
+  source: 'probe-host-schema-valid-json';
+  resultDigest: string;
+  canonicalBytes: number;
+}
+
 export interface GovernedCodexRuntimeAttestation {
   version: 'probe.governed-codex-attestation/v1';
   profileId: 'luna-xhigh-readonly-v1';
@@ -296,6 +307,12 @@ export interface GovernedCodexRuntimeAttestationV2 {
 export interface GovernedInvocationAnswerResult {
   data: unknown;
   runtimeAttestation: GovernedCodexRuntimeAttestationV2;
+}
+
+export interface GovernedIdentifiedAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestationV2;
+  resultIdentity: GovernedResultIdentity;
 }
 
 /**
@@ -364,6 +381,7 @@ export declare class ProbeAgent {
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
 
+  answerGoverned(message: string, options: GovernedIdentifiedAnswerOptions, images?: any[]): Promise<GovernedIdentifiedAnswerResult>;
   answerGoverned(message: string, options: GovernedInvocationAnswerOptions, images?: any[]): Promise<GovernedInvocationAnswerResult>;
   answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -260,6 +260,24 @@ export interface AnswerOptions {
   maxIterations?: number;
 }
 
+export interface GovernedAnswerOptions extends AnswerOptions {
+  schema: string;
+}
+
+export interface GovernedCodexRuntimeAttestation {
+  version: 'probe.governed-codex-attestation/v1';
+  profileId: 'luna-xhigh-readonly-v1';
+  requested: { profileDigest: string; cwdDigest: string; probeToolsDigest: string; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; };
+  observed: { source: 'session_configured'; model: 'gpt-5.6-luna'; modelProviderId: 'openai'; reasoningEffort: 'xhigh'; approvalPolicy: 'never'; cwdDigest: string; permissionProfileDigest: string; filesystem: 'restricted-read-root'; network: 'restricted'; };
+  evidence: { eventCount: 1; };
+  usage: { status: 'unavailable'; };
+}
+
+export interface GovernedAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestation;
+}
+
 /**
  * Clone options for creating a new agent with shared history
  */
@@ -325,6 +343,8 @@ export declare class ProbeAgent {
    * @returns Promise resolving to the AI response
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
+
+  answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 
   /**
    * Get token usage statistics

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -63,7 +63,7 @@ export interface ProbeAgentOptions {
   /** Use a delegated code-search subagent for the search tool (default: true) */
   searchDelegate?: boolean;
   /** Force specific AI provider */
-  provider?: 'anthropic' | 'openai' | 'google' | 'bedrock';
+  provider?: 'anthropic' | 'openai' | 'google' | 'bedrock' | 'codex';
   /** Override model name */
   model?: string;
   /** Enable debug mode */
@@ -80,6 +80,11 @@ export interface ProbeAgentOptions {
   mcpServers?: any[];
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
+  /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
+  governedCodexProfile?: {
+    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
+    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
+  };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Retry configuration for handling transient API failures */
@@ -307,6 +312,8 @@ export declare class ProbeAgent {
    * Cancel any ongoing operations
    */
   cancel(): void;
+
+  /** Close engine subprocess and MCP resources. */ close(): Promise<void>;
 
   /**
    * Clear the conversation history

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -325,6 +325,7 @@ export declare class ProbeAgent {
   
   /** Whether operations have been cancelled */
   cancelled: boolean;
+  readonly abortSignal: AbortSignal;
 
   /** AI provider being used */
   readonly clientApiProvider?: string;

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -234,6 +234,10 @@ export interface GovernedAnswerOptions extends AnswerOptions {
   schema: string;
 }
 
+export interface GovernedInvocationAnswerOptions extends GovernedAnswerOptions {
+  invocationDigest: string;
+}
+
 export interface GovernedCodexRuntimeAttestation {
   version: 'probe.governed-codex-attestation/v1';
   profileId: 'luna-xhigh-readonly-v1';
@@ -246,6 +250,22 @@ export interface GovernedCodexRuntimeAttestation {
 export interface GovernedAnswerResult {
   data: unknown;
   runtimeAttestation: GovernedCodexRuntimeAttestation;
+}
+
+export interface GovernedCodexRuntimeAttestationV2 {
+  version: 'probe.governed-codex-attestation/v2';
+  profileId: 'luna-xhigh-readonly-v1';
+  requested: { profileDigest: string; cwdDigest: string; probeToolsDigest: string; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; };
+  observed: { source: 'session_configured'; model: 'gpt-5.6-luna'; modelProviderId: 'openai'; reasoningEffort: 'xhigh'; approvalPolicy: 'never'; cwdDigest: string; permissionProfileDigest: string; filesystem: 'restricted-read-root'; network: 'restricted'; };
+  executionContext: { source: 'caller'; invocationDigest: string; };
+  dispatch: { source: 'probe-host-tools-call'; tool: 'codex'; promptDigest: string; promptBytes: number; };
+  evidence: { eventCount: 1; };
+  usage: { status: 'unavailable'; };
+}
+
+export interface GovernedInvocationAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestationV2;
 }
 
 /**
@@ -317,6 +337,7 @@ export declare class ProbeAgent {
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
 
+  answerGoverned(message: string, options: GovernedInvocationAnswerOptions, images?: any[]): Promise<GovernedInvocationAnswerResult>;
   answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 
   /**

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -156,6 +156,7 @@ export interface TimeoutWindingDownEvent {
  * Tool execution event data
  */
 export interface ToolCallEvent {
+  argumentsDigest?: string;
   /** Unique tool call identifier */
   id: string;
   /** Name of the tool being called */

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -230,6 +230,24 @@ export interface AnswerOptions {
   maxIterations?: number;
 }
 
+export interface GovernedAnswerOptions extends AnswerOptions {
+  schema: string;
+}
+
+export interface GovernedCodexRuntimeAttestation {
+  version: 'probe.governed-codex-attestation/v1';
+  profileId: 'luna-xhigh-readonly-v1';
+  requested: { profileDigest: string; cwdDigest: string; probeToolsDigest: string; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; };
+  observed: { source: 'session_configured'; model: 'gpt-5.6-luna'; modelProviderId: 'openai'; reasoningEffort: 'xhigh'; approvalPolicy: 'never'; cwdDigest: string; permissionProfileDigest: string; filesystem: 'restricted-read-root'; network: 'restricted'; };
+  evidence: { eventCount: 1; };
+  usage: { status: 'unavailable'; };
+}
+
+export interface GovernedAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestation;
+}
+
 /**
  * Clone options for creating a new agent with shared history
  */
@@ -298,6 +316,8 @@ export declare class ProbeAgent {
    * @returns Promise resolving to the AI response
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
+
+  answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 
   /**
    * Get token usage statistics

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -238,6 +238,17 @@ export interface GovernedInvocationAnswerOptions extends GovernedAnswerOptions {
   invocationDigest: string;
 }
 
+export interface GovernedIdentifiedAnswerOptions extends GovernedInvocationAnswerOptions {
+  resultIdentity: 'probe.governed-result-identity/v1';
+}
+
+export interface GovernedResultIdentity {
+  version: 'probe.governed-result-identity/v1';
+  source: 'probe-host-schema-valid-json';
+  resultDigest: string;
+  canonicalBytes: number;
+}
+
 export interface GovernedCodexRuntimeAttestation {
   version: 'probe.governed-codex-attestation/v1';
   profileId: 'luna-xhigh-readonly-v1';
@@ -266,6 +277,12 @@ export interface GovernedCodexRuntimeAttestationV2 {
 export interface GovernedInvocationAnswerResult {
   data: unknown;
   runtimeAttestation: GovernedCodexRuntimeAttestationV2;
+}
+
+export interface GovernedIdentifiedAnswerResult {
+  data: unknown;
+  runtimeAttestation: GovernedCodexRuntimeAttestationV2;
+  resultIdentity: GovernedResultIdentity;
 }
 
 /**
@@ -337,6 +354,7 @@ export declare class ProbeAgent {
    */
   answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;
 
+  answerGoverned(message: string, options: GovernedIdentifiedAnswerOptions, images?: any[]): Promise<GovernedIdentifiedAnswerResult>;
   answerGoverned(message: string, options: GovernedInvocationAnswerOptions, images?: any[]): Promise<GovernedInvocationAnswerResult>;
   answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;
 

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -81,10 +81,7 @@ export interface ProbeAgentOptions {
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
   /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
-  governedCodexProfile?: {
-    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
-    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
-  };
+  governedCodexProfile?: { version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0; };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Retry configuration for handling transient API failures */

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -29,7 +29,7 @@ export const ENGINE_ACTIVITY_TIMEOUT_MAX = 600000;
 
 import { createProviderInstance, DEFAULT_MODELS } from '../utils/provider.js';
 import { streamText, generateText, tool, stepCountIs, jsonSchema, Output } from 'ai';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { EventEmitter } from 'events';
 import { existsSync } from 'fs';
 import { readFile, stat, readdir } from 'fs/promises';
@@ -107,6 +107,40 @@ import {
 } from './tasks/index.js';
 import { z } from 'zod';
 import { validateGovernedCodexProfile } from './engines/governed-codex-profile.js';
+
+const GOVERNED_RESULT_IDENTITY = 'probe.governed-result-identity/v1';
+const GOVERNED_RESULT_DOMAIN = 'probe.governed-result-identity/data/v1';
+
+function normalizeGovernedJson(value) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('answerGoverned validated result is not canonical JSON');
+    return Object.is(value, -0) ? 0 : value;
+  }
+  if (Array.isArray(value)) return value.map(normalizeGovernedJson);
+  if (typeof value === 'object' && (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null)) {
+    return Object.fromEntries(Object.entries(value).sort(([a], [b]) => a < b ? -1 : a > b ? 1 : 0).map(([key, child]) => [key, normalizeGovernedJson(child)]));
+  }
+  throw new TypeError('answerGoverned validated result is not canonical JSON');
+}
+
+function freezeGovernedTree(value) {
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value)) freezeGovernedTree(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function identifyGovernedResult(value) {
+  const data = freezeGovernedTree(normalizeGovernedJson(value));
+  const canonical = Buffer.from(JSON.stringify(data), 'utf8');
+  const byteLength = Buffer.alloc(8);
+  byteLength.writeBigUInt64BE(BigInt(canonical.length));
+  const resultDigest = `sha256:${createHash('sha256').update(GOVERNED_RESULT_DOMAIN, 'utf8').update(Buffer.from([0])).update(byteLength).update(canonical).digest('hex')}`;
+  const resultIdentity = Object.freeze({ version: GOVERNED_RESULT_IDENTITY, source: 'probe-host-schema-valid-json', resultDigest, canonicalBytes: canonical.length });
+  return { data, resultIdentity };
+}
 
 // Maximum tool iterations to prevent infinite loops - configurable via MAX_TOOL_ITERATIONS env var
 const MAX_TOOL_ITERATIONS = (() => {
@@ -3413,7 +3447,9 @@ Follow these instructions carefully:
   async answerGoverned(message, options, images = []) {
     if (!this.governedCodexProfile) throw new Error('answerGoverned requires governedCodexProfile');
     if (!message || typeof message !== 'string' || message.trim().length === 0) throw new Error('Message is required and must be a non-empty string');
-    if (!options || typeof options.schema !== 'string' || !options.schema.trim() || !isJsonSchema(options.schema)) throw new Error('answerGoverned requires a valid JSON schema string');
+    if (!options) throw new Error('answerGoverned requires a valid JSON schema string');
+    const schema = options.schema;
+    if (typeof schema !== 'string' || !schema.trim() || !isJsonSchema(schema)) throw new Error('answerGoverned requires a valid JSON schema string');
     if (!Array.isArray(images) || images.length > 0) throw new Error('answerGoverned does not support images');
 
     const hasInvocationDigest = Object.prototype.hasOwnProperty.call(options,
@@ -3422,8 +3458,17 @@ Follow these instructions carefully:
     if (hasInvocationDigest && (typeof invocationDigest !== 'string' || !/^sha256:[0-9a-f]{64}$/.test(invocationDigest))) {
       throw new TypeError('answerGoverned invocationDigest must match sha256:<64 lowercase hexadecimal digits>');
     }
+    const hasResultIdentity = Object.prototype.hasOwnProperty.call(options,
+      'resultIdentity');
+    const requestedResultIdentity = hasResultIdentity ? options.resultIdentity : undefined;
+    if (hasResultIdentity && requestedResultIdentity !== GOVERNED_RESULT_IDENTITY) {
+      throw new TypeError('answerGoverned resultIdentity must equal probe.governed-result-identity/v1');
+    }
+    if (hasResultIdentity && !hasInvocationDigest) {
+      throw new TypeError('answerGoverned resultIdentity requires an own invocationDigest');
+    }
 
-    const prompt = message.trim() + generateSchemaInstructions(options.schema,{debug:this.debug});
+    const prompt = message.trim()+generateSchemaInstructions(schema,{debug:this.debug});
     let engine;
     try {
       engine = await this.getEngine();
@@ -3446,8 +3491,13 @@ Follow these instructions carefully:
           throw new Error('Expected exactly one matching governed invocation attestation');
         }
       } else if (attestationCount !== 1) throw new Error(`Expected exactly one governed runtime attestation; received ${attestationCount}`);
-      const validation = validateJsonResponse(candidateChunks.join(''), { debug: this.debug, schema: options.schema });
+      const validation = validateJsonResponse(candidateChunks.join(''), {debug:this.debug,schema});
       if (!validation.isValid) throw new Error(validation.errorSummary || validation.error || 'Governed answer failed schema validation');
+      if (hasResultIdentity) {
+        const { data, resultIdentity } = identifyGovernedResult(validation.parsed);
+        freezeGovernedTree(runtimeAttestation);
+        return Object.freeze({ data, runtimeAttestation, resultIdentity });
+      }
       return { data: validation.parsed, runtimeAttestation };
     } finally {
       if (engine) await engine.close();

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -324,11 +324,8 @@ export class ProbeAgent {
     this.thinkingEffort = options.thinkingEffort || null;
 
     if (options.governedCodexProfile !== undefined) {
-      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex');
-      const profile = validateGovernedCodexProfile(options.governedCodexProfile);
-      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) {
-        throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
-      }
+      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex'); const profile = validateGovernedCodexProfile(options.governedCodexProfile);
+      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
       this.governedCodexProfile = profile;
     }
 
@@ -3656,14 +3653,14 @@ Follow these instructions carefully:
         }
 
         // Send the message directly to Codex and collect the response
-        try {
-          const engine = await this.getEngine();
+        let engine; try {
+          engine = await this.getEngine();
           if (engine && engine.query) {
             let assistantResponseContent = '';
             let toolBatch = null;
 
             // Query Codex directly with the message and schema
-            for await (const chunk of engine.query(message, options)) {
+            for await (const chunk of engine.query(message, this.governedCodexProfile ? { ...options, abortSignal: this._abortController.signal } : options)) {
               if (chunk.type === 'text' && chunk.content) {
                 assistantResponseContent += chunk.content;
                 if (options.onStream) {
@@ -3715,7 +3712,7 @@ Follow these instructions carefully:
             console.error('[DEBUG] Codex error:', error);
           }
           throw error;
-        }
+        } finally { if (this.governedCodexProfile && engine) await engine.close(); }
       }
 
       if (this.debug) {
@@ -5671,6 +5668,8 @@ Double-check your response based on the criteria above. If everything looks good
     if (!this._abortController.signal.aborted) {
       this._abortController.abort();
     }
+
+    if (this.governedCodexProfile && this.engine?.close) await this.engine.close();
 
     // Clean up MCP bridge
     if (this.mcpBridge) {

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -106,6 +106,7 @@ import {
   createTaskCompletionBlockedMessage
 } from './tasks/index.js';
 import { z } from 'zod';
+import { validateGovernedCodexProfile } from './engines/governed-codex-profile.js';
 
 // Maximum tool iterations to prevent infinite loops - configurable via MAX_TOOL_ITERATIONS env var
 const MAX_TOOL_ITERATIONS = (() => {
@@ -321,6 +322,15 @@ export class ProbeAgent {
     // Native thinking/reasoning effort for LLM providers
     // Accepted values: 'off' (default), 'low', 'medium', 'high', or a number (budget tokens)
     this.thinkingEffort = options.thinkingEffort || null;
+
+    if (options.governedCodexProfile !== undefined) {
+      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex');
+      const profile = validateGovernedCodexProfile(options.governedCodexProfile);
+      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) {
+        throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
+      }
+      this.governedCodexProfile = profile;
+    }
 
     // Tool filtering configuration
     // Parse allowedTools option: ['*'] = all tools, [] or null = no tools, ['tool1', 'tool2'] = specific tools
@@ -1752,6 +1762,7 @@ export class ProbeAgent {
             result = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, this.debug);
           }
         } catch (error) {
+          if (this.governedCodexProfile) throw error;
           if (this.debug) {
             const engineType = useClaudeCode ? 'Claude Code' : 'Codex';
             console.log(`[DEBUG] Failed to use ${engineType} engine, falling back to Vercel:`, error.message);
@@ -2424,7 +2435,8 @@ export class ProbeAgent {
           sessionId: this.options?.sessionId,
           debug: this.debug,
           allowedTools: this.allowedTools,  // Pass tool filtering configuration
-          model: this.model  // Pass model name (e.g., gpt-5.2, o3, etc.)
+          model: this.model,  // Pass model name (e.g., gpt-5.2, o3, etc.)
+          governedCodexProfile: this.governedCodexProfile
         });
         if (this.debug) {
           console.log('[DEBUG] Using Codex CLI engine with Probe tools');
@@ -2434,6 +2446,7 @@ export class ProbeAgent {
         }
         return this.engine;
       } catch (error) {
+        if (this.governedCodexProfile) throw error;
         console.warn('[WARNING] Failed to load Codex CLI engine:', error.message);
         console.warn('[WARNING] Falling back to Vercel AI SDK');
         this.clientApiProvider = null;

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -3403,6 +3403,44 @@ Follow these instructions carefully:
   }
 
   /**
+   * Return one schema-validated result with its governed Codex attestation.
+   * @param {string} message - The user's question
+   * @param {Object} options - Governed answer options
+   * @param {string} options.schema - Required JSON schema
+   * @param {Array} [images] - Unsupported; must be empty
+   * @returns {Promise<{data: unknown, runtimeAttestation: Object}>}
+   */
+  async answerGoverned(message, options, images = []) {
+    if (!this.governedCodexProfile) throw new Error('answerGoverned requires governedCodexProfile');
+    if (!message || typeof message !== 'string' || message.trim().length === 0) throw new Error('Message is required and must be a non-empty string');
+    if (!options || typeof options.schema !== 'string' || !options.schema.trim() || !isJsonSchema(options.schema)) throw new Error('answerGoverned requires a valid JSON schema string');
+    if (!Array.isArray(images) || images.length > 0) throw new Error('answerGoverned does not support images');
+
+    const prompt = message.trim() + generateSchemaInstructions(options.schema,{debug:this.debug});
+    let engine;
+    try {
+      engine = await this.getEngine();
+      if (!engine?.query) throw new Error('Governed Codex engine is unavailable');
+      const candidateChunks = [];
+      let runtimeAttestation;
+      let attestationCount = 0;
+      for await (const chunk of engine.query(prompt, { abortSignal: this._abortController.signal })) {
+        if (chunk.type === 'text' && chunk.content) candidateChunks.push(chunk.content);
+        else if (chunk.type === 'metadata' && chunk.data?.attestation) {
+          runtimeAttestation = chunk.data.attestation;
+          attestationCount++;
+        } else if (chunk.type === 'error') throw chunk.error || new Error('Governed Codex query failed');
+      }
+      if (attestationCount !== 1) throw new Error(`Expected exactly one governed runtime attestation; received ${attestationCount}`);
+      const validation = validateJsonResponse(candidateChunks.join(''), { debug: this.debug, schema: options.schema });
+      if (!validation.isValid) throw new Error(validation.errorSummary || validation.error || 'Governed answer failed schema validation');
+      return { data: validation.parsed, runtimeAttestation };
+    } finally {
+      if (engine) await engine.close();
+    }
+  }
+
+  /**
    * Answer a question using the agentic flow
    * @param {string} message - The user's question
    * @param {Array} [images] - Optional array of image data (base64 strings or URLs)

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -3416,6 +3416,13 @@ Follow these instructions carefully:
     if (!options || typeof options.schema !== 'string' || !options.schema.trim() || !isJsonSchema(options.schema)) throw new Error('answerGoverned requires a valid JSON schema string');
     if (!Array.isArray(images) || images.length > 0) throw new Error('answerGoverned does not support images');
 
+    const hasInvocationDigest = Object.prototype.hasOwnProperty.call(options,
+      'invocationDigest');
+    const invocationDigest = hasInvocationDigest ? options.invocationDigest : undefined;
+    if (hasInvocationDigest && (typeof invocationDigest !== 'string' || !/^sha256:[0-9a-f]{64}$/.test(invocationDigest))) {
+      throw new TypeError('answerGoverned invocationDigest must match sha256:<64 lowercase hexadecimal digits>');
+    }
+
     const prompt = message.trim() + generateSchemaInstructions(options.schema,{debug:this.debug});
     let engine;
     try {
@@ -3424,14 +3431,21 @@ Follow these instructions carefully:
       const candidateChunks = [];
       let runtimeAttestation;
       let attestationCount = 0;
-      for await (const chunk of engine.query(prompt, { abortSignal: this._abortController.signal })) {
+      const queryOptions = hasInvocationDigest
+        ? { abortSignal: this._abortController.signal, invocationDigest: invocationDigest }
+        : { abortSignal: this._abortController.signal };
+      for await (const chunk of engine.query(prompt, queryOptions)) {
         if (chunk.type === 'text' && chunk.content) candidateChunks.push(chunk.content);
         else if (chunk.type === 'metadata' && chunk.data?.attestation) {
           runtimeAttestation = chunk.data.attestation;
           attestationCount++;
         } else if (chunk.type === 'error') throw chunk.error || new Error('Governed Codex query failed');
       }
-      if (attestationCount !== 1) throw new Error(`Expected exactly one governed runtime attestation; received ${attestationCount}`);
+      if (hasInvocationDigest) {
+        if (attestationCount !== 1 || runtimeAttestation?.version !== 'probe.governed-codex-attestation/v2' || runtimeAttestation?.executionContext?.source !== 'caller' || runtimeAttestation?.executionContext?.invocationDigest !== invocationDigest) {
+          throw new Error('Expected exactly one matching governed invocation attestation');
+        }
+      } else if (attestationCount !== 1) throw new Error(`Expected exactly one governed runtime attestation; received ${attestationCount}`);
       const validation = validateJsonResponse(candidateChunks.join(''), { debug: this.debug, schema: options.schema });
       if (!validation.isValid) throw new Error(validation.errorSummary || validation.error || 'Governed answer failed schema validation');
       return { data: validation.parsed, runtimeAttestation };

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -4,7 +4,7 @@
  */
 
 import { spawn } from 'child_process';
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { createInterface } from 'readline';
 import { BuiltInMCPServer } from '../mcp/built-in-server.js';
 import { Session } from '../shared/Session.js';
@@ -15,6 +15,27 @@ function externalReceipt(attestation) {
     version: attestation.version, profileId: attestation.profileId,
     requested: { profileDigest: attestation.requested.profileDigest, cwdDigest: attestation.requested.cwdDigest, probeToolsDigest: attestation.requested.probeToolsDigest, model: attestation.requested.model, reasoningEffort: attestation.requested.reasoningEffort, sandbox: attestation.requested.sandbox, approvalPolicy: attestation.requested.approvalPolicy },
     observed: { source: attestation.observed.source, model: attestation.observed.model, modelProviderId: attestation.observed.modelProviderId, reasoningEffort: attestation.observed.reasoningEffort, approvalPolicy: attestation.observed.approvalPolicy, cwdDigest: attestation.observed.cwdDigest, permissionProfileDigest: attestation.observed.permissionProfileDigest, filesystem: attestation.observed.filesystem, network: attestation.observed.network },
+    evidence: { eventCount: 1 }, usage: { status: 'unavailable' },
+  };
+}
+
+function governedCodexDispatch(prompt) {
+  const promptBytes = Buffer.byteLength(prompt, 'utf8');
+  const byteLength = Buffer.alloc(8);
+  byteLength.writeBigUInt64BE(BigInt(promptBytes));
+  const promptDigest = `sha256:${createHash('sha256')
+    .update('probe.governed-codex-dispatch/prompt/v1', 'utf8')
+    .update(Buffer.from([0])).update(byteLength).update(prompt, 'utf8').digest('hex')}`;
+  return Object.freeze({ source: 'probe-host-tools-call', tool: 'codex', promptDigest, promptBytes });
+}
+
+function externalBoundReceipt(internal, dispatch, invocationDigest) {
+  return {
+    version: 'probe.governed-codex-attestation/v2', profileId: 'luna-xhigh-readonly-v1',
+    requested: { profileDigest: internal.requested.profileDigest, cwdDigest: internal.requested.cwdDigest, probeToolsDigest: internal.requested.probeToolsDigest, model: internal.requested.model, reasoningEffort: internal.requested.reasoningEffort, sandbox: internal.requested.sandbox, approvalPolicy: internal.requested.approvalPolicy },
+    observed: { source: internal.observed.source, model: internal.observed.model, modelProviderId: internal.observed.modelProviderId, reasoningEffort: internal.observed.reasoningEffort, approvalPolicy: internal.observed.approvalPolicy, cwdDigest: internal.observed.cwdDigest, permissionProfileDigest: internal.observed.permissionProfileDigest, filesystem: internal.observed.filesystem, network: internal.observed.network },
+    executionContext: { source: 'caller', invocationDigest },
+    dispatch: { source: dispatch.source, tool: dispatch.tool, promptDigest: dispatch.promptDigest, promptBytes: dispatch.promptBytes },
     evidence: { eventCount: 1 }, usage: { status: 'unavailable' },
   };
 }
@@ -195,6 +216,13 @@ export async function createCodexEngine(options = {}) {
       let abortHandler;
 
       try {
+        const hasInvocationDigest = Object.prototype.hasOwnProperty.call(opts,
+          'invocationDigest');
+        const invocationDigest = hasInvocationDigest ? opts.invocationDigest : undefined;
+        if (hasInvocationDigest && (typeof invocationDigest !== 'string' || !/^sha256:[0-9a-f]{64}$/.test(invocationDigest))) {
+          throw new TypeError('answerGoverned invocationDigest must match sha256:<64 lowercase hexadecimal digits>');
+        }
+
         // Build arguments
         let toolArgs = { prompt: finalPrompt };
 
@@ -257,6 +285,7 @@ export async function createCodexEngine(options = {}) {
         });
 
         // Call the tool
+        const dispatch = governedProfile ? governedCodexDispatch(toolArgs.prompt) : null;
         const resultPromise = sendRequest('tools/call', {
           name: toolName,
           arguments: toolArgs
@@ -269,7 +298,10 @@ export async function createCodexEngine(options = {}) {
         eventHandlers.delete(reqId);
         let attestation = null;
         if (governedProfile) {
-          attestation = externalReceipt(attestGovernedCodexSession({ profile: governedProfile, events: evidence }));
+          const internal = attestGovernedCodexSession({ profile: governedProfile, events: evidence });
+          attestation = hasInvocationDigest
+            ? externalBoundReceipt(internal, dispatch, invocationDigest)
+            : externalReceipt(internal);
           session.setConversationId(evidence[0].params.msg.session_id);
         }
 

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -8,12 +8,14 @@ import { randomBytes } from 'crypto';
 import { createInterface } from 'readline';
 import { BuiltInMCPServer } from '../mcp/built-in-server.js';
 import { Session } from '../shared/Session.js';
+import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs, validateGovernedCodexProfile } from './governed-codex-profile.js';
 
 /**
  * Codex Engine using MCP Server with event streaming
  */
 export async function createCodexEngine(options = {}) {
   const { agent, systemPrompt, customPrompt, debug, sessionId, allowedTools, model } = options;
+  const governedProfile = options.governedCodexProfile === undefined ? null : validateGovernedCodexProfile(options.governedCodexProfile);
 
   const session = new Session(
     sessionId || randomBytes(8).toString('hex'),
@@ -55,6 +57,8 @@ export async function createCodexEngine(options = {}) {
   let requestId = 0;
   const pendingRequests = new Map();
   const eventHandlers = new Map();
+  let governedEvidenceHandler = null, governedQueryStarted = false, closePromise = null;
+  const processClosed = new Promise((resolve) => codexProcess.once('close', resolve));
 
   // Read stdout line by line
   const stdoutReader = createInterface({
@@ -74,8 +78,9 @@ export async function createCodexEngine(options = {}) {
 
       // Handle responses to our requests
       if (message.id !== undefined && pendingRequests.has(message.id)) {
-        const { resolve, reject } = pendingRequests.get(message.id);
+        const { resolve, reject, timer } = pendingRequests.get(message.id);
         pendingRequests.delete(message.id);
+        clearTimeout(timer);
 
         if (message.error) {
           reject(new Error(message.error.message || JSON.stringify(message.error)));
@@ -86,6 +91,7 @@ export async function createCodexEngine(options = {}) {
 
       // Handle notifications (codex/event)
       if (message.method === 'codex/event' && message.params) {
+        if (governedEvidenceHandler && message.params.msg?.type === 'session_configured') governedEvidenceHandler(message);
         const requestId = message.params._meta?.requestId;
         if (requestId !== undefined && eventHandlers.has(requestId)) {
           eventHandlers.get(requestId)(message.params);
@@ -98,6 +104,8 @@ export async function createCodexEngine(options = {}) {
     }
   });
 
+  codexProcess.once('error', (error) => rejectPending(error)); codexProcess.once('close', () => rejectPending(new Error('Codex process closed')));
+
   // Handle stderr
   if (debug) {
     codexProcess.stderr.on('data', (data) => {
@@ -108,6 +116,7 @@ export async function createCodexEngine(options = {}) {
   // Send JSON-RPC request
   function sendRequest(method, params = {}) {
     return new Promise((resolve, reject) => {
+      if (closePromise) return reject(new Error('Codex engine is closed'));
       const id = ++requestId;
       const request = {
         jsonrpc: '2.0',
@@ -116,29 +125,45 @@ export async function createCodexEngine(options = {}) {
         params
       };
 
-      pendingRequests.set(id, { resolve, reject });
-
       // Timeout after 10 minutes
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (pendingRequests.has(id)) {
           pendingRequests.delete(id);
           reject(new Error(`Request ${method} timed out after 10 minutes`));
         }
       }, 600000);
+      pendingRequests.set(id, { resolve, reject, timer });
 
       codexProcess.stdin.write(JSON.stringify(request) + '\n');
     });
   }
 
+  function rejectPending(error) {
+    for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); }
+    pendingRequests.clear();
+  }
+
+  async function cleanup(reason = new Error('Codex engine closed')) {
+    if (closePromise) return closePromise;
+    closePromise = (async () => {
+      rejectPending(reason);
+      eventHandlers.clear(); governedEvidenceHandler = null;
+      stdoutReader.close();
+      codexProcess.stdin.destroy();
+      if (codexProcess.exitCode === null && !codexProcess.killed) codexProcess.kill();
+      await processClosed;
+      if (mcpServer) await mcpServer.stop();
+    })();
+    return closePromise;
+  }
+
   // Initialize MCP connection
-  await sendRequest('initialize', {
-    protocolVersion: '2024-11-05',
-    capabilities: { tools: {} },
-    clientInfo: {
-      name: 'probe-codex-client',
-      version: '1.0.0'
-    }
-  });
+  try {
+    await sendRequest('initialize', {
+      protocolVersion: '2024-11-05', capabilities: { tools: {} },
+      clientInfo: { name: 'probe-codex-client', version: '1.0.0' }
+    });
+  } catch (error) { await cleanup(error); throw error; }
 
   if (debug) {
     console.log('[DEBUG] Connected to Codex MCP server');
@@ -164,8 +189,9 @@ export async function createCodexEngine(options = {}) {
       const isFollowUp = session.conversationId !== null;
       const toolName = isFollowUp ? 'codex-reply' : 'codex';
 
-      // Build arguments
-      const toolArgs = { prompt: finalPrompt };
+      try {
+        // Build arguments
+        let toolArgs = { prompt: finalPrompt };
 
       if (isFollowUp) {
         toolArgs.conversationId = session.conversationId;
@@ -173,10 +199,16 @@ export async function createCodexEngine(options = {}) {
           console.log(`[DEBUG] Follow-up with conversationId: ${session.conversationId}`);
         }
       } else {
-        if (model) {
+        if (governedProfile) {
+          if (governedQueryStarted) throw new Error('Governed Codex engine permits one initial query');
+          governedQueryStarted = true;
+          toolArgs = buildGovernedCodexInitialToolArgs({
+            profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl }
+          });
+        } else if (model) {
           toolArgs.model = model;
         }
-        if (mcpServerUrl && mcpServerName) {
+        if (!governedProfile && mcpServerUrl && mcpServerName) {
           toolArgs.config = {
             mcp_servers: {
               [mcpServerName]: { url: mcpServerUrl }
@@ -188,40 +220,39 @@ export async function createCodexEngine(options = {}) {
         }
       }
 
-      try {
         const reqId = requestId + 1;
         let fullResponse = '';
         let gotSessionId = false;
+        const evidence = [];
+        if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
+        let abortHandler;
+        if (opts.abortSignal) {
+          if (opts.abortSignal.aborted) throw new Error('Codex query cancelled');
+          abortHandler = () => cleanup(new Error('Codex query cancelled'));
+          opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
+        }
 
         // Register event handler for this request
-        const eventPromise = new Promise((resolve) => {
-          eventHandlers.set(reqId, (eventParams) => {
-            const msg = eventParams.msg;
+        eventHandlers.set(reqId, (eventParams) => {
+          const msg = eventParams.msg;
 
-            // Extract session_id from session_configured event
-            if (msg.type === 'session_configured' && msg.session_id && !gotSessionId) {
-              session.setConversationId(msg.session_id);
-              gotSessionId = true;
-            }
+          // Extract session_id from session_configured event
+          if (!governedProfile && msg.type === 'session_configured' && msg.session_id && !gotSessionId) {
+            session.setConversationId(msg.session_id);
+            gotSessionId = true;
+          }
 
-            // Collect agent messages
-            if (msg.type === 'raw_response_item' && msg.item?.role === 'assistant') {
-              const content = msg.item.content;
-              if (Array.isArray(content)) {
-                for (const part of content) {
-                  if (part.type === 'text' && part.text) {
-                    fullResponse += part.text;
-                  }
+          // Collect agent messages
+          if (msg.type === 'raw_response_item' && msg.item?.role === 'assistant') {
+            const content = msg.item.content;
+            if (Array.isArray(content)) {
+              for (const part of content) {
+                if (part.type === 'text' && part.text) {
+                  fullResponse += part.text;
                 }
               }
             }
-          });
-
-          // Mark as resolved when we're done
-          setTimeout(() => {
-            eventHandlers.delete(reqId);
-            resolve();
-          }, 600000); // 10 min timeout
+          }
         });
 
         // Call the tool
@@ -235,6 +266,12 @@ export async function createCodexEngine(options = {}) {
 
         // Clean up event handler
         eventHandlers.delete(reqId);
+        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
+        let attestation = null;
+        if (governedProfile) {
+          attestation = attestGovernedCodexSession({ profile: governedProfile, events: evidence });
+          session.setConversationId(evidence[0].params.msg.session_id);
+        }
 
         // Parse result
         if (result && result.content && Array.isArray(result.content)) {
@@ -261,7 +298,7 @@ export async function createCodexEngine(options = {}) {
 
         yield {
           type: 'metadata',
-          data: {
+          data: governedProfile ? { attestation } : {
             sessionId: session.id,
             conversationId: session.conversationId,
             messageCount: session.messageCount
@@ -276,6 +313,8 @@ export async function createCodexEngine(options = {}) {
           type: 'error',
           error: error
         };
+      } finally {
+        if (governedProfile) await cleanup();
       }
     },
 
@@ -290,43 +329,7 @@ export async function createCodexEngine(options = {}) {
      * Clean up resources
      */
     async close() {
-      try {
-        // Close readline interface first to remove event listeners
-        if (stdoutReader) {
-          stdoutReader.close();
-          if (debug) {
-            console.log('[DEBUG] Closed stdout reader');
-          }
-        }
-
-        // Clear all pending requests and event handlers
-        pendingRequests.clear();
-        eventHandlers.clear();
-
-        // Kill Codex process
-        if (codexProcess && !codexProcess.killed) {
-          codexProcess.kill();
-          if (debug) {
-            console.log('[DEBUG] Killed Codex MCP server process');
-          }
-        }
-
-        // Stop Probe MCP server
-        if (mcpServer) {
-          await mcpServer.stop();
-          if (debug) {
-            console.log('[DEBUG] Stopped Probe MCP server');
-          }
-        }
-
-        if (debug) {
-          console.log('[DEBUG] Engine closed, session:', session.id);
-        }
-      } catch (error) {
-        if (debug) {
-          console.error('[DEBUG] Error during cleanup:', error.message);
-        }
-      }
+      await cleanup();
     }
   };
 }

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -10,6 +10,15 @@ import { BuiltInMCPServer } from '../mcp/built-in-server.js';
 import { Session } from '../shared/Session.js';
 import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs, validateGovernedCodexProfile } from './governed-codex-profile.js';
 
+function externalReceipt(attestation) {
+  return {
+    version: attestation.version, profileId: attestation.profileId,
+    requested: { profileDigest: attestation.requested.profileDigest, cwdDigest: attestation.requested.cwdDigest, probeToolsDigest: attestation.requested.probeToolsDigest, model: attestation.requested.model, reasoningEffort: attestation.requested.reasoningEffort, sandbox: attestation.requested.sandbox, approvalPolicy: attestation.requested.approvalPolicy },
+    observed: { source: attestation.observed.source, model: attestation.observed.model, modelProviderId: attestation.observed.modelProviderId, reasoningEffort: attestation.observed.reasoningEffort, approvalPolicy: attestation.observed.approvalPolicy, cwdDigest: attestation.observed.cwdDigest, permissionProfileDigest: attestation.observed.permissionProfileDigest, filesystem: attestation.observed.filesystem, network: attestation.observed.network },
+    evidence: { eventCount: 1 }, usage: { status: 'unavailable' },
+  };
+}
+
 /**
  * Codex Engine using MCP Server with event streaming
  */
@@ -138,18 +147,13 @@ export async function createCodexEngine(options = {}) {
     });
   }
 
-  function rejectPending(error) {
-    for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); }
-    pendingRequests.clear();
-  }
+  function rejectPending(error) { for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); } pendingRequests.clear(); }
 
   async function cleanup(reason = new Error('Codex engine closed')) {
     if (closePromise) return closePromise;
     closePromise = (async () => {
-      rejectPending(reason);
-      eventHandlers.clear(); governedEvidenceHandler = null;
-      stdoutReader.close();
-      codexProcess.stdin.destroy();
+      rejectPending(reason); eventHandlers.clear(); governedEvidenceHandler = null;
+      stdoutReader.close(); codexProcess.stdin.destroy();
       if (codexProcess.exitCode === null && !codexProcess.killed) codexProcess.kill();
       await processClosed;
       if (mcpServer) await mcpServer.stop();
@@ -188,6 +192,7 @@ export async function createCodexEngine(options = {}) {
 
       const isFollowUp = session.conversationId !== null;
       const toolName = isFollowUp ? 'codex-reply' : 'codex';
+      let abortHandler;
 
       try {
         // Build arguments
@@ -202,9 +207,7 @@ export async function createCodexEngine(options = {}) {
         if (governedProfile) {
           if (governedQueryStarted) throw new Error('Governed Codex engine permits one initial query');
           governedQueryStarted = true;
-          toolArgs = buildGovernedCodexInitialToolArgs({
-            profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl }
-          });
+          toolArgs = buildGovernedCodexInitialToolArgs({ profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl } });
         } else if (model) {
           toolArgs.model = model;
         }
@@ -223,9 +226,7 @@ export async function createCodexEngine(options = {}) {
         const reqId = requestId + 1;
         let fullResponse = '';
         let gotSessionId = false;
-        const evidence = [];
-        if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
-        let abortHandler;
+        const evidence = []; if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
         if (opts.abortSignal) {
           if (opts.abortSignal.aborted) throw new Error('Codex query cancelled');
           abortHandler = () => cleanup(new Error('Codex query cancelled'));
@@ -266,10 +267,9 @@ export async function createCodexEngine(options = {}) {
 
         // Clean up event handler
         eventHandlers.delete(reqId);
-        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
         let attestation = null;
         if (governedProfile) {
-          attestation = attestGovernedCodexSession({ profile: governedProfile, events: evidence });
+          attestation = externalReceipt(attestGovernedCodexSession({ profile: governedProfile, events: evidence }));
           session.setConversationId(evidence[0].params.msg.session_id);
         }
 
@@ -314,6 +314,7 @@ export async function createCodexEngine(options = {}) {
           error: error
         };
       } finally {
+        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
         if (governedProfile) await cleanup();
       }
     },

--- a/npm/src/agent/engines/governed-codex-profile.js
+++ b/npm/src/agent/engines/governed-codex-profile.js
@@ -1,0 +1,153 @@
+import { createHash } from 'node:crypto';
+import { realpathSync, statSync } from 'node:fs';
+import { isAbsolute, normalize } from 'node:path';
+
+const PROFILE_KEYS = ['version', 'profileId', 'engine', 'model', 'reasoningEffort', 'sandbox', 'approvalPolicy', 'cwd', 'probeTools', 'fallback', 'retries'];
+const PROFILE_VALUES = {
+  version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex',
+  model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never',
+  fallback: false, retries: 0,
+};
+const PROBE_TOOLS = ['search', 'extract', 'listFiles'];
+const ENABLED_TOOLS = ['mcp__probe__search', 'mcp__probe__extract', 'mcp__probe__listFiles'];
+const FEATURE_NAMES = [
+  'shell_tool', 'multi_agent', 'multi_agent_v2', 'enable_fanout', 'apps', 'enable_mcp_apps',
+  'tool_suggest', 'plugins', 'in_app_browser', 'browser_use', 'browser_use_full_cdp_access',
+  'browser_use_external', 'computer_use', 'remote_plugin', 'plugin_sharing', 'image_generation',
+  'skill_mcp_dependency_install', 'hooks', 'request_permissions_tool', 'standalone_web_search',
+];
+const SAFE_ID = /^[A-Za-z0-9._:-]{1,128}$/;
+const ROLLOUT = /\/sessions\/(\d{4})\/(0[1-9]|1[0-2])\/(0[1-9]|[12]\d|3[01])\/rollout-(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3])-([0-5]\d)-([0-5]\d)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/;
+
+function invalid(label) { throw new TypeError(`Invalid ${label}`); }
+function enumerableKeys(value) {
+  return Reflect.ownKeys(value).filter((key) => Object.prototype.propertyIsEnumerable.call(value, key));
+}
+function exactObject(value, keys, label) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) invalid(label);
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) invalid(label);
+  const actual = enumerableKeys(value);
+  if (actual.some((key) => typeof key !== 'string') || actual.length !== keys.length || keys.some((key) => !actual.includes(key))) invalid(label);
+  for (const key of keys) if (!Object.prototype.hasOwnProperty.call(Object.getOwnPropertyDescriptor(value, key), 'value')) invalid(label);
+  return value;
+}
+function exactArray(value, length, label) {
+  if (!Array.isArray(value) || value.length !== length) invalid(label);
+  const keys = enumerableKeys(value);
+  if (keys.length !== length || keys.some((key, index) => key !== String(index))) invalid(label);
+  return value;
+}
+function deepFreeze(value) {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    for (const key of Reflect.ownKeys(value)) deepFreeze(value[key]);
+    Object.freeze(value);
+  }
+  return value;
+}
+function canonicalJson(value) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number' && Number.isFinite(value)) return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`).join(',')}}`;
+  }
+  invalid('canonical JSON value');
+}
+function digest(value) { return createHash('sha256').update(canonicalJson(value), 'utf8').digest('hex'); }
+function canonicalCwd(value) {
+  if (typeof value !== 'string' || !isAbsolute(value) || value.includes('\0')) invalid('cwd');
+  try {
+    const resolved = realpathSync(value);
+    if (!statSync(resolved).isDirectory()) invalid('cwd');
+    return resolved;
+  } catch { invalid('cwd'); }
+}
+function requireValue(actual, expected, label) { if (!Object.is(actual, expected)) invalid(label); }
+
+export function validateGovernedCodexProfile(input) {
+  const profile = exactObject(input, PROFILE_KEYS, 'profile');
+  for (const [key, value] of Object.entries(PROFILE_VALUES)) requireValue(profile[key], value, `profile.${key}`);
+  exactArray(profile.probeTools, PROBE_TOOLS.length, 'profile.probeTools');
+  PROBE_TOOLS.forEach((tool, index) => requireValue(profile.probeTools[index], tool, `profile.probeTools[${index}]`));
+  return deepFreeze({
+    version: PROFILE_VALUES.version, profileId: PROFILE_VALUES.profileId, engine: PROFILE_VALUES.engine,
+    model: PROFILE_VALUES.model, reasoningEffort: PROFILE_VALUES.reasoningEffort, sandbox: PROFILE_VALUES.sandbox,
+    approvalPolicy: PROFILE_VALUES.approvalPolicy, cwd: canonicalCwd(profile.cwd), probeTools: [...PROBE_TOOLS],
+    fallback: false, retries: 0,
+  });
+}
+
+function validateMcp(input) {
+  const mcp = exactObject(input, ['name', 'url'], 'mcp');
+  if (typeof mcp.name !== 'string' || !/^probe_[0-9a-f]{16}$/.test(mcp.name) || typeof mcp.url !== 'string') invalid('mcp');
+  const raw = /^http:\/\/127\.0\.0\.1:([0-9]{1,5})\/mcp$/.exec(mcp.url);
+  let parsed;
+  try { parsed = new URL(mcp.url); } catch { invalid('mcp.url'); }
+  const port = raw && Number(raw[1]);
+  if (!raw || String(port) !== raw[1] || port < 1 || port > 65535 || parsed.protocol !== 'http:' || parsed.hostname !== '127.0.0.1' || (parsed.port !== raw[1] && !(port === 80 && parsed.port === '')) || parsed.pathname !== '/mcp' || parsed.username || parsed.password || parsed.search || parsed.hash) invalid('mcp.url');
+  return mcp;
+}
+
+export function buildGovernedCodexInitialToolArgs(input) {
+  exactObject(input, ['profile', 'prompt', 'mcp'], 'builder input');
+  const profile = validateGovernedCodexProfile(input.profile);
+  if (typeof input.prompt !== 'string' || Buffer.byteLength(input.prompt, 'utf8') < 1 || Buffer.byteLength(input.prompt, 'utf8') > 131072) invalid('prompt');
+  const mcp = validateMcp(input.mcp);
+  const features = Object.fromEntries(FEATURE_NAMES.map((name) => [name, false]));
+  const tools = Object.fromEntries(ENABLED_TOOLS.map((name) => [name, { approval_mode: 'approve' }]));
+  const server = { url: mcp.url, default_tools_approval_mode: 'prompt', enabled_tools: [...ENABLED_TOOLS], tools };
+  return deepFreeze({
+    prompt: input.prompt, model: profile.model,
+    config: { model_reasoning_effort: profile.reasoningEffort, web_search: 'disabled', features, skills: { include_instructions: false }, mcp_servers: { [mcp.name]: server } },
+    cwd: profile.cwd, sandbox: profile.sandbox, 'approval-policy': profile.approvalPolicy,
+  });
+}
+
+function validatePermission(input) {
+  const permission = exactObject(input, ['type', 'file_system', 'network'], 'permission_profile');
+  requireValue(permission.type, 'managed', 'permission_profile.type');
+  requireValue(permission.network, 'restricted', 'permission_profile.network');
+  const fileSystem = exactObject(permission.file_system, ['type', 'entries'], 'file_system');
+  requireValue(fileSystem.type, 'restricted', 'file_system.type');
+  exactArray(fileSystem.entries, 1, 'file_system.entries');
+  const entry = exactObject(fileSystem.entries[0], ['access', 'path'], 'file_system entry');
+  requireValue(entry.access, 'read', 'file_system entry access');
+  const path = exactObject(entry.path, ['type', 'value'], 'permission path');
+  requireValue(path.type, 'special', 'permission path type');
+  const value = exactObject(path.value, ['kind'], 'permission path value');
+  requireValue(value.kind, 'root', 'permission path kind');
+  return { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' };
+}
+
+function validateRollout(value) {
+  if (typeof value !== 'string' || Buffer.byteLength(value, 'utf8') > 4096 || value.includes('\0') || !isAbsolute(value) || normalize(value) !== value) invalid('rollout_path');
+  const match = ROLLOUT.exec(value);
+  if (!match || match.index + match[0].length !== value.length || match[1] !== match[4] || match[2] !== match[5] || match[3] !== match[6]) invalid('rollout_path');
+}
+
+export function attestGovernedCodexSession(input) {
+  exactObject(input, ['profile', 'events'], 'attester input');
+  const profile = validateGovernedCodexProfile(input.profile);
+  exactArray(input.events, 1, 'events');
+  const event = exactObject(input.events[0], ['jsonrpc', 'method', 'params'], 'event');
+  requireValue(event.jsonrpc, '2.0', 'event.jsonrpc'); requireValue(event.method, 'codex/event', 'event.method');
+  const params = exactObject(event.params, ['_meta', 'id', 'msg'], 'event.params'); requireValue(params.id, '', 'event.params.id');
+  const meta = exactObject(params._meta, ['requestId', 'threadId'], 'event._meta'); requireValue(meta.requestId, 2, 'requestId');
+  const msg = exactObject(params.msg, ['type', 'session_id', 'thread_id', 'model', 'model_provider_id', 'approval_policy', 'approvals_reviewer', 'permission_profile', 'reasoning_effort', 'rollout_path', 'cwd'], 'event.msg');
+  for (const id of [meta.threadId, msg.session_id, msg.thread_id]) if (typeof id !== 'string' || !SAFE_ID.test(id)) invalid('session identity');
+  if (meta.threadId !== msg.session_id || msg.session_id !== msg.thread_id) invalid('session identity');
+  requireValue(msg.type, 'session_configured', 'msg.type'); requireValue(msg.model, profile.model, 'msg.model');
+  requireValue(msg.model_provider_id, 'openai', 'msg.model_provider_id'); requireValue(msg.approval_policy, profile.approvalPolicy, 'msg.approval_policy');
+  requireValue(msg.approvals_reviewer, 'user', 'msg.approvals_reviewer'); requireValue(msg.reasoning_effort, profile.reasoningEffort, 'msg.reasoning_effort');
+  validateRollout(msg.rollout_path);
+  if (canonicalCwd(msg.cwd) !== profile.cwd) invalid('msg.cwd');
+  const permission = validatePermission(msg.permission_profile);
+  const cwdDigest = digest(profile.cwd);
+  return deepFreeze({
+    version: 'probe.governed-codex-attestation/v1', profileId: profile.profileId,
+    requested: { profileDigest: digest(profile), cwdDigest, probeToolsDigest: digest(profile.probeTools), model: profile.model, reasoningEffort: profile.reasoningEffort, sandbox: profile.sandbox, approvalPolicy: profile.approvalPolicy },
+    observed: { source: 'session_configured', model: msg.model, modelProviderId: msg.model_provider_id, reasoningEffort: msg.reasoning_effort, approvalPolicy: msg.approval_policy, cwdDigest, permissionProfileDigest: digest(permission), filesystem: 'restricted-read-root', network: permission.network },
+    correlation: { requestId: 2, eventCount: 1 }, usage: { status: 'unavailable' },
+  });
+}

--- a/npm/src/agent/mcp/built-in-server.js
+++ b/npm/src/agent/mcp/built-in-server.js
@@ -5,7 +5,7 @@
 
 import { createServer } from 'http';
 import { EventEmitter } from 'events';
-import { randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -28,14 +28,60 @@ const TOOL_DESCRIPTORS = Object.freeze({
   listFiles: descriptor('List files in a directory', listFilesSchema)
 });
 
+const ARGUMENT_DOMAIN = Buffer.from('reqproof.probe.tool-arguments/v1', 'utf8');
+
+function ownData(value, arrays, stack = new Set()) {
+  if (value === null || typeof value !== 'object') return;
+  if (stack.has(value)) throw new TypeError('cycle');
+  stack.add(value);
+  const proto = Object.getPrototypeOf(value);
+  const isArray = Array.isArray(value);
+  if (isArray ? proto !== Array.prototype : proto !== Object.prototype && proto !== null) throw new TypeError('prototype');
+  const descriptors = Object.getOwnPropertyDescriptors(value);
+  const keys = Reflect.ownKeys(descriptors);
+  if (keys.some(key => typeof key === 'symbol')) throw new TypeError('symbol');
+  if (isArray) {
+    if (!arrays) throw new TypeError('array');
+    if (keys.some(key => key !== 'length' && (!/^(0|[1-9]\d*)$/.test(key) || Number(key) >= value.length))) throw new TypeError('array key');
+    for (let i = 0; i < value.length; i++) if (!Object.prototype.hasOwnProperty.call(descriptors, i)) throw new TypeError('array hole');
+  }
+  for (const key of keys) {
+    if (isArray && key === 'length') continue;
+    const property = descriptors[key];
+    if (!property.enumerable || !Object.prototype.hasOwnProperty.call(property, 'value') || key === 'toJSON') throw new TypeError('property');
+    ownData(property.value, arrays, stack);
+  }
+  stack.delete(value);
+}
+
+function canonicalJSON(value, stack = new Set()) {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') { if (!Number.isFinite(value)) throw new TypeError('number'); return Object.is(value, -0) ? '0' : JSON.stringify(value); }
+  if (typeof value !== 'object' || stack.has(value)) throw new TypeError('value');
+  ownData(value, true); stack.add(value);
+  let encoded;
+  if (Array.isArray(value)) encoded = `[${value.map(item => canonicalJSON(item, stack)).join(',')}]`;
+  else encoded = `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalJSON(value[key], stack)}`).join(',')}}`;
+  stack.delete(value); return encoded;
+}
+
+function argumentDigest(value) {
+  const payload = Buffer.from(canonicalJSON(value), 'utf8');
+  const length = bytes => { const out = Buffer.alloc(8); out.writeBigUInt64BE(BigInt(bytes.length)); return out; };
+  return `sha256:${createHash('sha256').update(length(ARGUMENT_DOMAIN)).update(ARGUMENT_DOMAIN).update(length(payload)).update(payload).digest('hex')}`;
+}
+
 async function validateToolArguments(name, args) {
   const contract = TOOL_DESCRIPTORS[name];
-  if (!contract) return args;
-  if (!args || Array.isArray(args) || typeof args !== 'object') throw new TypeError(`Invalid arguments for ${name}`);
-  for (const key of Object.keys(args)) if (!Object.prototype.hasOwnProperty.call(contract.inputSchema.properties, key)) throw new TypeError(`Unknown argument ${key} for ${name}`);
-  const validated = await contract.validate(args);
-  if (!validated.success) throw new TypeError(`Invalid arguments for ${name}: ${validated.error.message}`);
-  return validated.value;
+  if (!contract) return { value: args };
+  try { if (!args || Array.isArray(args) || typeof args !== 'object') throw new TypeError(); ownData(args, false); }
+  catch { throw new TypeError('TOOL_ARGUMENT_CONTAINER_INVALID'); }
+  try {
+    for (const key of Object.keys(args)) if (!Object.prototype.hasOwnProperty.call(contract.inputSchema.properties, key)) throw new TypeError();
+    const validated = await contract.validate(args);
+    if (!validated.success) throw new TypeError();
+    return { value: validated.value, digest: argumentDigest(validated.value) };
+  } catch { throw new TypeError('TOOL_ARGUMENT_VALIDATION_FAILED'); }
 }
 
 function emitToolCall(agent, event) {
@@ -682,17 +728,18 @@ export class BuiltInMCPServer extends EventEmitter {
       throw new Error(`Tool ${name} not found`);
     }
 
-    let args;
-    try { args = await validateToolArguments(toolName, rawArgs); } catch (error) {
+    let validated;
+    try { validated = await validateToolArguments(toolName, rawArgs); } catch (error) {
       return { content: [{ type: 'text', text: `Error executing ${name}: ${error.message}` }], isError: true };
     }
+    const { value: args, digest: argumentsDigest } = validated;
 
     const id = randomUUID();
     const startTime = Date.now();
-    const baseEvent = { id, name: toolName, sessionId: this.agent.sessionId, startTime };
+    const baseEvent = { id, name: toolName, sessionId: this.agent.sessionId, startTime, ...(argumentsDigest && { argumentsDigest }) };
     const fail = error => {
       const endTime = Date.now();
-      try { emitToolCall(this.agent, { ...baseEvent, status: 'failed', error: error.message, endTime, duration: endTime - startTime }); }
+      try { emitToolCall(this.agent, { ...baseEvent, status: 'failed', error: 'TOOL_EXECUTION_FAILED', endTime, duration: endTime - startTime }); }
       catch (listenerError) { error = listenerError; }
       return { content: [{ type: 'text', text: `Error executing ${name}: ${error.message}` }], isError: true };
     };

--- a/npm/src/agent/mcp/built-in-server.js
+++ b/npm/src/agent/mcp/built-in-server.js
@@ -9,11 +9,48 @@ import { randomUUID } from 'crypto';
 import { Server as MCPServer } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { asSchema } from 'ai';
+import { searchSchema, extractSchema, listFilesSchema } from '../../tools/common.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   isInitializeRequest
 } from '@modelcontextprotocol/sdk/types.js';
+
+function descriptor(description, schema) {
+  const canonical = asSchema(schema);
+  return Object.freeze({ description, inputSchema: canonical.jsonSchema, validate: canonical.validate });
+}
+
+const TOOL_DESCRIPTORS = Object.freeze({
+  search: descriptor('Search for code patterns using semantic search', searchSchema),
+  extract: descriptor('Extract code from files or symbols', extractSchema),
+  listFiles: descriptor('List files in a directory', listFilesSchema)
+});
+
+async function validateToolArguments(name, args) {
+  const contract = TOOL_DESCRIPTORS[name];
+  if (!contract) return args;
+  if (!args || Array.isArray(args) || typeof args !== 'object') throw new TypeError(`Invalid arguments for ${name}`);
+  for (const key of Object.keys(args)) if (!Object.prototype.hasOwnProperty.call(contract.inputSchema.properties, key)) throw new TypeError(`Unknown argument ${key} for ${name}`);
+  const validated = await contract.validate(args);
+  if (!validated.success) throw new TypeError(`Invalid arguments for ${name}: ${validated.error.message}`);
+  return validated.value;
+}
+
+function emitToolCall(agent, event) {
+  agent.events?.emit('toolCall', Object.freeze(event));
+}
+
+function abortable(promise, signal) {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(new Error('Tool execution cancelled'));
+  return new Promise((resolve, reject) => {
+    const aborted = () => reject(new Error('Tool execution cancelled'));
+    signal.addEventListener('abort', aborted, { once: true });
+    promise.then(value => { signal.removeEventListener('abort', aborted); resolve(value); }, error => { signal.removeEventListener('abort', aborted); reject(error); });
+  });
+}
 
 /**
  * Simple in-memory event store for resumability
@@ -586,40 +623,7 @@ export class BuiltInMCPServer extends EventEmitter {
 
     // Get tools from agent
     if (this.agent && this.agent.allowedTools) {
-      const toolDefs = {
-        search: {
-          description: 'Search for code patterns using semantic search',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              query: { type: 'string', description: 'Search query' },
-              path: { type: 'string', description: 'Directory to search', default: '.' },
-              maxResults: { type: 'integer', default: 10 }
-            },
-            required: ['query']
-          }
-        },
-        extract: {
-          description: 'Extract code from specific file location',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              path: { type: 'string', description: 'File path with optional line number' }
-            },
-            required: ['path']
-          }
-        },
-        listFiles: {
-          description: 'List files in a directory',
-          inputSchema: {
-            type: 'object',
-            properties: {
-              path: { type: 'string', description: 'Directory path' },
-              pattern: { type: 'string', description: 'File pattern' }
-            },
-            required: ['path']
-          }
-        },
+      const toolDefs = { ...TOOL_DESCRIPTORS,
         searchFiles: {
           description: 'Search for files by name pattern',
           inputSchema: {
@@ -662,7 +666,7 @@ export class BuiltInMCPServer extends EventEmitter {
    * Handle tool execution
    */
   async handleCallTool(params) {
-    const { name, arguments: args } = params;
+    const { name, arguments: rawArgs } = params;
 
     // Extract tool name from MCP format
     const toolName = name.replace('mcp__probe__', '');
@@ -678,9 +682,33 @@ export class BuiltInMCPServer extends EventEmitter {
       throw new Error(`Tool ${name} not found`);
     }
 
+    let args;
+    try { args = await validateToolArguments(toolName, rawArgs); } catch (error) {
+      return { content: [{ type: 'text', text: `Error executing ${name}: ${error.message}` }], isError: true };
+    }
+
+    const id = randomUUID();
+    const startTime = Date.now();
+    const baseEvent = { id, name: toolName, sessionId: this.agent.sessionId, startTime };
+    const fail = error => {
+      const endTime = Date.now();
+      try { emitToolCall(this.agent, { ...baseEvent, status: 'failed', error: error.message, endTime, duration: endTime - startTime }); }
+      catch (listenerError) { error = listenerError; }
+      return { content: [{ type: 'text', text: `Error executing ${name}: ${error.message}` }], isError: true };
+    };
+
+    try { emitToolCall(this.agent, { ...baseEvent, status: 'in_progress' }); }
+    catch (error) { return fail(error); }
+
     try {
       // Execute tool directly (no spawning!)
-      const result = await tool.execute(args);
+      const signal = this.agent._abortController?.signal;
+      const execution = Promise.resolve().then(() => tool.execute({ ...args, sessionId: this.agent.sessionId, workingDirectory: this.agent.workspaceRoot || this.agent.cwd || process.cwd(), abortSignal: signal }));
+      const result = await abortable(execution, signal);
+
+      const endTime = Date.now();
+      try { emitToolCall(this.agent, { ...baseEvent, status: 'completed', endTime, duration: endTime - startTime }); }
+      catch { /* Execution already succeeded; observer failure is non-authoritative. */ }
 
       return {
         content: [{
@@ -689,13 +717,7 @@ export class BuiltInMCPServer extends EventEmitter {
         }]
       };
     } catch (error) {
-      return {
-        content: [{
-          type: 'text',
-          text: `Error executing ${name}: ${error.message}`
-        }],
-        isError: true
-      };
+      return fail(error);
     }
   }
 

--- a/npm/src/agent/mcp/built-in-server.js
+++ b/npm/src/agent/mcp/built-in-server.js
@@ -702,7 +702,7 @@ export class BuiltInMCPServer extends EventEmitter {
 
     try {
       // Execute tool directly (no spawning!)
-      const signal = this.agent._abortController?.signal;
+      const signal = this.agent.abortSignal;
       const execution = Promise.resolve().then(() => tool.execute({ ...args, sessionId: this.agent.sessionId, workingDirectory: this.agent.workspaceRoot || this.agent.cwd || process.cwd(), abortSignal: signal }));
       const result = await abortable(execution, signal);
 

--- a/npm/src/agent/mcp/index.d.ts
+++ b/npm/src/agent/mcp/index.d.ts
@@ -1,0 +1,62 @@
+import type { ProbeAgent } from '../ProbeAgent.js';
+
+export type MCPRecord = Record<string, unknown>;
+export interface BuiltInMCPServerOptions { port?: number; host?: string; debug?: boolean; }
+export interface MCPToolDefinition { name: string; description: string; inputSchema: MCPRecord; }
+export interface MCPToolResult { content: Array<{ type: string; text: string }>; isError?: boolean; }
+
+export class BuiltInMCPServer {
+  constructor(agent: ProbeAgent, options?: BuiltInMCPServerOptions);
+  start(): Promise<{ host: string; port: number }>;
+  stop(): Promise<void>;
+  handleListTools(): Promise<{ tools: MCPToolDefinition[] }>;
+  handleCallTool(params: { name: string; arguments?: MCPRecord }): Promise<MCPToolResult>;
+  getToolCount(): number;
+  getConfig(): { transport: 'http'; url: string };
+}
+
+export class MCPClientManager {
+  constructor(options?: MCPRecord);
+  initialize(config?: MCPRecord | null): Promise<MCPRecord>;
+  connectToServer(config: MCPRecord): Promise<unknown>;
+  callTool(toolName: string, args?: MCPRecord): Promise<unknown>;
+  callGracefulStopAll(): Promise<unknown[]>;
+  getTools(): Record<string, unknown>;
+  getVercelTools(): Record<string, unknown>;
+  disconnect(): Promise<void>;
+}
+
+export function createMCPManager(options?: MCPRecord): Promise<MCPClientManager>;
+export function createTransport(serverConfig: MCPRecord): unknown;
+export function loadMCPConfiguration(): MCPRecord;
+export function loadMCPConfigurationFromPath(configPath: string): MCPRecord;
+export function parseEnabledServers(config: MCPRecord): MCPRecord[];
+export function createSampleConfig(): MCPRecord;
+export function saveConfig(config: MCPRecord, path: string): void;
+
+export class MCPXmlBridge {
+  constructor(options?: MCPRecord);
+  initialize(config?: MCPRecord | MCPRecord[] | null): Promise<void>;
+  getVercelTools(filterToolNames?: string[] | null): Record<string, unknown>;
+  getToolNames(): string[];
+  isMcpTool(toolName: string): boolean;
+  callGracefulStopAll(): Promise<unknown[]>;
+  cleanup(): Promise<void>;
+}
+
+export function mcpToolToDescription(name: string, tool: MCPRecord): string;
+
+declare const MCP: {
+  MCPClientManager: typeof MCPClientManager;
+  createMCPManager: typeof createMCPManager;
+  createTransport: typeof createTransport;
+  loadMCPConfiguration: typeof loadMCPConfiguration;
+  loadMCPConfigurationFromPath: typeof loadMCPConfigurationFromPath;
+  parseEnabledServers: typeof parseEnabledServers;
+  createSampleConfig: typeof createSampleConfig;
+  saveConfig: typeof saveConfig;
+  MCPXmlBridge: typeof MCPXmlBridge;
+  mcpToolToDescription: typeof mcpToolToDescription;
+  BuiltInMCPServer: typeof BuiltInMCPServer;
+};
+export default MCP;

--- a/npm/src/agent/mcp/index.js
+++ b/npm/src/agent/mcp/index.js
@@ -20,6 +20,7 @@ export {
   MCPXmlBridge,
   mcpToolToDescription
 } from './xmlBridge.js';
+export { BuiltInMCPServer } from './built-in-server.js';
 
 // Import for default export
 import { MCPClientManager, createMCPManager, createTransport } from './client.js';
@@ -34,6 +35,7 @@ import {
   MCPXmlBridge,
   mcpToolToDescription
 } from './xmlBridge.js';
+import { BuiltInMCPServer } from './built-in-server.js';
 
 // Default export for convenience
 export default {
@@ -51,5 +53,8 @@ export default {
 
   // MCP Bridge
   MCPXmlBridge,
-  mcpToolToDescription
+  mcpToolToDescription,
+
+  // Built-in server
+  BuiltInMCPServer
 };

--- a/npm/tests/unit/governed-codex-profile-contract.exp-0133.test.js
+++ b/npm/tests/unit/governed-codex-profile-contract.exp-0133.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync, realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import * as kernel from '../../src/agent/engines/governed-codex-profile.js';
+
+const { validateGovernedCodexProfile, buildGovernedCodexInitialToolArgs, attestGovernedCodexSession } = kernel;
+const cwd = realpathSync(process.cwd());
+const mcp = { name: 'probe_0123456789abcdef', url: 'http://127.0.0.1:43123/mcp' };
+const rollout = '/ENVIRONMENT_SENTINEL/HOME_SENTINEL/sessions/2026/08/25/rollout-2026-08-25T12-34-56-01234567-89ab-cdef-0123-456789abcdef.jsonl';
+const toolNames = ['mcp__probe__search', 'mcp__probe__extract', 'mcp__probe__listFiles'];
+const featureNames = [
+  'shell_tool', 'multi_agent', 'multi_agent_v2', 'enable_fanout', 'apps', 'enable_mcp_apps',
+  'tool_suggest', 'plugins', 'in_app_browser', 'browser_use', 'browser_use_full_cdp_access',
+  'browser_use_external', 'computer_use', 'remote_plugin', 'plugin_sharing', 'image_generation',
+  'skill_mcp_dependency_install', 'hooks', 'request_permissions_tool', 'standalone_web_search',
+];
+
+function profile() {
+  return {
+    version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex',
+    model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never',
+    cwd, probeTools: ['search', 'extract', 'listFiles'], fallback: false, retries: 0,
+  };
+}
+function permission() {
+  return { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' };
+}
+function captured(id = 'thread-1') {
+  return {
+    jsonrpc: '2.0', method: 'codex/event',
+    params: {
+      _meta: { requestId: 2, threadId: id }, id: '',
+      msg: {
+        type: 'session_configured', session_id: id, thread_id: id, model: 'gpt-5.6-luna',
+        model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
+        permission_profile: permission(), reasoning_effort: 'xhigh', rollout_path: rollout, cwd,
+      },
+    },
+  };
+}
+function clone(value) { return JSON.parse(JSON.stringify(value)); }
+function frozen(value) {
+  if (!value || typeof value !== 'object') return;
+  assert.equal(Object.isFrozen(value), true);
+  for (const child of Object.values(value)) frozen(child);
+}
+function canonical(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`).join(',')}}`;
+}
+function digest(value) { return createHash('sha256').update(canonical(value), 'utf8').digest('hex'); }
+function rejected(fn) { assert.throws(fn, { name: 'TypeError' }); }
+
+test('exact profile, request, and captured event produce deterministic frozen values', () => {
+  assert.deepEqual(Object.keys(kernel).sort(), ['attestGovernedCodexSession', 'buildGovernedCodexInitialToolArgs', 'validateGovernedCodexProfile']);
+  const normalized = validateGovernedCodexProfile(profile());
+  assert.deepEqual(normalized, profile());
+  assert.notEqual(normalized, profile());
+  frozen(normalized);
+  const prompt = 'PROMPT_SENTINEL SOURCE_SENTINEL CANDIDATE_SENTINEL';
+  const args = buildGovernedCodexInitialToolArgs({ profile: profile(), prompt, mcp: { ...mcp } });
+  const features = Object.fromEntries(featureNames.map((name) => [name, false]));
+  const tools = Object.fromEntries(toolNames.map((name) => [name, { approval_mode: 'approve' }]));
+  assert.deepEqual(args, {
+    prompt, model: 'gpt-5.6-luna',
+    config: {
+      model_reasoning_effort: 'xhigh', web_search: 'disabled', features, skills: { include_instructions: false },
+      mcp_servers: { [mcp.name]: { url: mcp.url, default_tools_approval_mode: 'prompt', enabled_tools: toolNames, tools } },
+    },
+    cwd, sandbox: 'read-only', 'approval-policy': 'never',
+  });
+  assert.deepEqual(Object.keys(args), ['prompt', 'model', 'config', 'cwd', 'sandbox', 'approval-policy']);
+  frozen(args);
+  const attestation = attestGovernedCodexSession({ profile: profile(), events: [captured()] });
+  assert.deepEqual(attestation, {
+    version: 'probe.governed-codex-attestation/v1', profileId: 'luna-xhigh-readonly-v1',
+    requested: { profileDigest: digest(normalized), cwdDigest: digest(cwd), probeToolsDigest: digest(normalized.probeTools), model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never' },
+    observed: { source: 'session_configured', model: 'gpt-5.6-luna', modelProviderId: 'openai', reasoningEffort: 'xhigh', approvalPolicy: 'never', cwdDigest: digest(cwd), permissionProfileDigest: digest(permission()), filesystem: 'restricted-read-root', network: 'restricted' },
+    correlation: { requestId: 2, eventCount: 1 }, usage: { status: 'unavailable' },
+  });
+  frozen(attestation);
+  const argsAgain = buildGovernedCodexInitialToolArgs({ profile: profile(), prompt, mcp: { ...mcp } });
+  const attestationAgain = attestGovernedCodexSession({ profile: profile(), events: [captured()] });
+  assert.equal(canonical(argsAgain), canonical(args));
+  assert.equal(canonical(attestationAgain), canonical(attestation));
+});
+
+test('profile validation rejects missing, unknown, aliased, typed, widened, tool-order, and cwd defects', () => {
+  const mutations = [
+    (p) => { delete p.model; }, (p) => { p.unknown = true; },
+    (p) => { p.reasoning_effort = p.reasoningEffort; delete p.reasoningEffort; },
+    (p) => { p.retries = '0'; }, (p) => { p.fallback = true; }, (p) => { p.sandbox = 'workspace-write'; },
+    (p) => { p.probeTools.reverse(); }, (p) => { p.probeTools.push('write'); },
+    (p) => { p.cwd = 'relative'; }, (p) => { p.cwd = `${cwd}/.exp-0133-definitely-absent`; },
+    (p) => { p.cwd = fileURLToPath(import.meta.url); }, (p) => { p.cwd = `${cwd}\0bad`; },
+  ];
+  for (const mutate of mutations) { const value = profile(); mutate(value); rejected(() => validateGovernedCodexProfile(value)); }
+  const getter = profile(); Object.defineProperty(getter, 'model', { enumerable: true, get: () => 'gpt-5.6-luna' });
+  rejected(() => validateGovernedCodexProfile(getter));
+});
+
+test('request compiler rejects input, prompt, and loopback MCP widening', () => {
+  rejected(() => buildGovernedCodexInitialToolArgs({ profile: profile(), prompt: 'x' }));
+  rejected(() => buildGovernedCodexInitialToolArgs({ profile: profile(), prompt: 'x', mcp, extra: true }));
+  rejected(() => buildGovernedCodexInitialToolArgs({ profile: profile(), prompt: '', mcp }));
+  rejected(() => buildGovernedCodexInitialToolArgs({ profile: profile(), prompt: 'é'.repeat(65537), mcp }));
+  const badBindings = [
+    { ...mcp, extra: true }, { ...mcp, name: 'probe_search' }, { ...mcp, url: 'not a url' },
+    { ...mcp, url: 'https://127.0.0.1:43123/mcp' }, { ...mcp, url: 'http://localhost:43123/mcp' },
+    { ...mcp, url: 'http://127.0.0.1:0/mcp' }, { ...mcp, url: 'http://127.0.0.1:65536/mcp' },
+    { ...mcp, url: 'http://user@127.0.0.1:43123/mcp' }, { ...mcp, url: 'http://127.0.0.1:43123/other' },
+    { ...mcp, url: 'http://127.0.0.1:43123/mcp?q=1' }, { ...mcp, url: 'http://127.0.0.1:43123/mcp#x' },
+  ];
+  for (const binding of badBindings) rejected(() => buildGovernedCodexInitialToolArgs({ profile: profile(), prompt: 'x', mcp: binding }));
+});
+
+test('attester rejects correlation, identity, rollout, and recursive captured-shape defects', () => {
+  rejected(() => attestGovernedCodexSession({ profile: profile(), events: [] }));
+  rejected(() => attestGovernedCodexSession({ profile: profile(), events: [captured(), captured()] }));
+  rejected(() => attestGovernedCodexSession({ profile: profile(), events: [captured()], extra: true }));
+  const mutations = [
+    (e) => { e.jsonrpc = '1.0'; }, (e) => { e.method = 'other'; }, (e) => { e.params.id = 'x'; },
+    (e) => { e.params._meta.requestId = 3; }, (e) => { e.params.msg.type = 'turn_started'; },
+    (e) => { e.params.msg.thread_id = 'other'; }, (e) => { e.params._meta.threadId = 'unsafe id'; },
+    (e) => { e.extra = true; }, (e) => { e.params._meta.extra = true; }, (e) => { delete e.params.msg.model; },
+    (e) => { e.params.msg.permission_profile.file_system.entries[0].path.value.extra = true; },
+    (e) => { e.params.msg.rollout_path = rollout.replace('/08/25/', '/08/24/'); },
+    (e) => { e.params.msg.rollout_path = `${rollout}/extra`; },
+    (e) => { e.params.msg.rollout_path = `${rollout}\n`; }, (e) => { e.params.msg.rollout_path = `${rollout}\r`; },
+    (e) => { e.params.msg.rollout_path = `${rollout}\u2028`; }, (e) => { e.params.msg.rollout_path = `${rollout}\u2029`; },
+  ];
+  for (const mutate of mutations) { const event = captured(); mutate(event); rejected(() => attestGovernedCodexSession({ profile: profile(), events: [event] })); }
+});
+
+test('attester rejects observed model, effort, approval, cwd, permission, filesystem, and network mismatch', () => {
+  const mutations = [
+    (m) => { m.model = 'other'; }, (m) => { m.model_provider_id = 'other'; },
+    (m) => { m.reasoning_effort = 'high'; }, (m) => { m.approval_policy = 'on-request'; },
+    (m) => { m.approvals_reviewer = 'agent'; }, (m) => { m.cwd = '/'; },
+    (m) => { m.permission_profile.type = 'unmanaged'; }, (m) => { m.permission_profile.network = 'enabled'; },
+    (m) => { m.permission_profile.file_system.type = 'full'; },
+    (m) => { m.permission_profile.file_system.entries.push(clone(m.permission_profile.file_system.entries[0])); },
+    (m) => { m.permission_profile.file_system.entries[0].access = 'write'; },
+    (m) => { m.permission_profile.file_system.entries[0].path.type = 'literal'; },
+    (m) => { m.permission_profile.file_system.entries[0].path.value.kind = 'cwd'; },
+  ];
+  for (const mutate of mutations) { const event = captured(); mutate(event.params.msg); rejected(() => attestGovernedCodexSession({ profile: profile(), events: [event] })); }
+});
+
+test('sanitized attestation leaks no prompt, path, identity, environment, credential, usage zero, or raw event', () => {
+  const prompt = 'PROMPT_SENTINEL SOURCE_SENTINEL CANDIDATE_SENTINEL';
+  buildGovernedCodexInitialToolArgs({ profile: profile(), prompt, mcp });
+  const raw = captured('credential_SENTINEL');
+  const serialized = JSON.stringify(attestGovernedCodexSession({ profile: profile(), events: [raw] }));
+  for (const sentinel of [...prompt.split(' '), mcp.url, cwd, rollout, 'credential_SENTINEL', 'ENVIRONMENT_SENTINEL', 'HOME_SENTINEL']) assert.equal(serialized.includes(sentinel), false, sentinel);
+  for (const forbidden of ['rollout_path', 'session_id', 'thread_id', 'permission_profile', 'prompt', 'mcp', 'credential', 'environment', '"tokens":0', '"cost":0']) assert.equal(serialized.toLowerCase().includes(forbidden), false, forbidden);
+  assert.deepEqual(JSON.parse(serialized).usage, { status: 'unavailable' });
+});
+
+test('module side-effect census is Node built-ins plus read-only filesystem inspection only', () => {
+  const source = readFileSync(new URL('../../src/agent/engines/governed-codex-profile.js', import.meta.url), 'utf8');
+  function assertSideEffectCensus(candidateSource) {
+    const staticImports = candidateSource.split('\n').filter((line) => line.startsWith('import '));
+    assert.deepEqual(staticImports, ["import { createHash } from 'node:crypto';", "import { realpathSync, statSync } from 'node:fs';", "import { isAbsolute, normalize } from 'node:path';"]);
+    assert.equal((candidateSource.match(/\bimport\s+(?!\()/g) || []).length, 3);
+    assert.deepEqual([...new Set(candidateSource.match(/\b(?:Buffer|URL)\b/g) || [])].sort(), ['Buffer', 'URL']);
+    assert.doesNotMatch(candidateSource, /import\s*\(|\b(?:require|eval|Function|process|globalThis)\b/);
+    assert.doesNotMatch(candidateSource, /\b(?:spawn|fork|fetch|createServer|connect|writeFile(?:Sync)?|appendFile(?:Sync)?|createWriteStream|rm(?:Sync)?|unlink(?:Sync)?|rename(?:Sync)?|mkdir(?:Sync)?|copyFile(?:Sync)?|setTimeout|setInterval|setImmediate|ProbeAgent)\b/);
+  }
+  assertSideEffectCensus(source);
+  assert.throws(() => assertSideEffectCensus(`${source}\nimport { exec } from 'node:child_process';`));
+  assert.throws(() => assertSideEffectCensus(`${source}\nvoid import('node:child_process');`));
+  assert.throws(() => assertSideEffectCensus(`${source}\nrequire('node:child_process');`));
+});

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -6,8 +6,11 @@ import { join } from 'node:path';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 import { createCodexEngine } from '../../src/agent/engines/codex.js';
 import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
+import { generateSchemaInstructions } from '../../src/agent/schemaUtils.js';
 
 const TOOLS = ['search', 'extract', 'listFiles'];
+const LINEAGE = { subjectId: 'SYS-REQ-048', subjectFingerprint: '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7', role: 'spec-review', coverageKey: 'SYS-REQ-048::spec-review', findings: [{ type: 'ambiguity', severity: 'medium', message: 'timeout semantics are underspecified' }] };
+const LINEAGE_SCHEMA = JSON.stringify({ type: 'object', required: ['subjectId', 'subjectFingerprint', 'role', 'coverageKey', 'findings'], additionalProperties: false, properties: { subjectId: { type: 'string' }, subjectFingerprint: { type: 'string' }, role: { type: 'string' }, coverageKey: { type: 'string' }, findings: { type: 'array', items: { type: 'object', required: ['type', 'severity', 'message'], additionalProperties: false, properties: { type: { type: 'string' }, severity: { type: 'string' }, message: { type: 'string' } } } } } });
 const fakeCodex = `#!/usr/bin/env node
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline';
@@ -40,6 +43,11 @@ createInterface({ input: process.stdin }).on('line', async line => {
   if (foreign) { const cwd = decodeURIComponent(foreign[2]); events = [configured(request.id, { ...args, cwd }, {}, Number(foreign[1]))]; }
   for (const event of events) send(event);
   let text = 'candidate-' + process.pid;
+  const lineage = { subjectId: 'SYS-REQ-048', subjectFingerprint: '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7', role: 'spec-review', coverageKey: 'SYS-REQ-048::spec-review', findings: [{ type: 'ambiguity', severity: 'medium', message: 'timeout semantics are underspecified' }] };
+  if (prompt.includes('[VALID]')) text = JSON.stringify(lineage);
+  if (prompt.includes('[WRONG]')) text = JSON.stringify({ subjectId: lineage.subjectId });
+  if (prompt.includes('[BADJSON]')) text = '{';
+  if (prompt.includes('[EXTRA]')) text = JSON.stringify({ ...lineage, extra: true });
   if (prompt.includes('[FORBIDDEN]')) {
     const url = Object.values(args.config.mcp_servers)[0].url.replace('/mcp', '/rpc');
     const response = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'mcp__probe__bash', arguments: {} } }) });
@@ -95,6 +103,9 @@ async function closed(url) {
 function host() {
   return { allowedTools: { isEnabled: name => TOOLS.includes(name) }, toolImplementations: Object.fromEntries(TOOLS.map(name => [name, { execute: async () => name }])) };
 }
+function governedAgent(root) {
+  return new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+}
 async function runEngine(root, stateDir, marker, useProbe = false) {
   const before = await stateFiles(stateDir); let engine;
   if (useProbe) {
@@ -107,6 +118,12 @@ async function runEngine(root, stateDir, marker, useProbe = false) {
   const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
   return { engine, output, state, call, url };
 }
+async function runGoverned(root, stateDir, marker) {
+  const before = await stateFiles(stateDir); const agent = governedAgent(root);
+  const settled = await agent.answerGoverned(marker, { schema: LINEAGE_SCHEMA }).then(value => ({ value }), error => ({ error }));
+  const state = await readState(await waitForState(stateDir, before, marker)); const call = state.seen.find(item => item.method === 'tools/call');
+  return { settled, state, call, url: Object.values(call.params.arguments.config.mcp_servers)[0].url };
+}
 
 test('EXP-0148 governed Codex runtime binding', async t => {
   const root = await mkdtemp(join(tmpdir(), 'probe-exp0148-'));
@@ -115,6 +132,7 @@ test('EXP-0148 governed Codex runtime binding', async t => {
   const executable = join(bin, 'codex'); await writeFile(executable, fakeCodex); await chmod(executable, 0o755);
   const originalPath = process.env.PATH; process.env.PATH = `${bin}:${originalPath}`; process.env.PROBE_EXP0148_STATE = stateDir;
   t.after(async () => { process.env.PATH = originalPath; delete process.env.PROBE_EXP0148_STATE; await rm(root, { recursive: true, force: true }); });
+  let governedValid;
 
   await t.test('rejects non-exact public bindings before spawn', () => {
     const count = () => stateFiles(stateDir);
@@ -196,6 +214,70 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     const url = Object.values(state.seen.find(item => item.method === 'tools/call').params.arguments.config.mcp_servers)[0].url;
     await engine.close(); const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
     assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+  });
+
+  await t.test('O1 governed answer returns parsed data and the exact attestation', async () => {
+    governedValid = await runGoverned(root, stateDir, '[VALID]'); assert.ifError(governedValid.settled.error);
+    assert.deepEqual(Object.keys(governedValid.settled.value), ['data', 'runtimeAttestation']);
+    assert.deepEqual(governedValid.settled.value.data, LINEAGE);
+    const receipt = governedValid.settled.value.runtimeAttestation; const internal = attestGovernedCodexSession({ profile: profile(root), events: [configuredEvidence(governedValid.state.pid, 2, root)] });
+    assert.deepEqual(receipt, { version: 'probe.governed-codex-attestation/v1', profileId: 'luna-xhigh-readonly-v1', requested: { profileDigest: internal.requested.profileDigest, cwdDigest: internal.requested.cwdDigest, probeToolsDigest: internal.requested.probeToolsDigest, model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never' }, observed: { source: 'session_configured', model: 'gpt-5.6-luna', modelProviderId: 'openai', reasoningEffort: 'xhigh', approvalPolicy: 'never', cwdDigest: internal.observed.cwdDigest, permissionProfileDigest: internal.observed.permissionProfileDigest, filesystem: 'restricted-read-root', network: 'restricted' }, evidence: { eventCount: 1 }, usage: { status: 'unavailable' } });
+    assert.equal(alive(governedValid.state.pid), false); assert.equal(await closed(governedValid.url), true);
+  });
+
+  await t.test('O2 preflight rejects before acquisition and wrong-shaped JSON fails closed', async () => {
+    const preflight = governedAgent(root); let acquisitions = 0; preflight.getEngine = async () => { acquisitions++; throw new Error('must not acquire'); };
+    for (const call of [() => preflight.answerGoverned('x'), () => preflight.answerGoverned('x', { schema: '' }), () => preflight.answerGoverned('x', { schema: 'plain text' }), () => preflight.answerGoverned('x', { schema: LINEAGE_SCHEMA }, {}), () => preflight.answerGoverned('x', { schema: LINEAGE_SCHEMA }, ['image'])]) await assert.rejects(call());
+    const ungoverned = new ProbeAgent({ provider: 'codex', path: root, allowedTools: [...TOOLS] }); ungoverned.getEngine = preflight.getEngine;
+    await assert.rejects(ungoverned.answerGoverned('x', { schema: LINEAGE_SCHEMA }), /governedCodexProfile/); assert.equal(acquisitions, 0);
+    const run = await runGoverned(root, stateDir, '[WRONG]'); assert.match(run.settled.error.message, /Schema validation failed/);
+    assert.equal(alive(run.state.pid), false); assert.equal(await closed(run.url), true);
+  });
+
+  await t.test('O3 malformed JSON fails closed', async () => {
+    const run = await runGoverned(root, stateDir, '[BADJSON]'); assert.ok(run.settled.error);
+    assert.equal(alive(run.state.pid), false); assert.equal(await closed(run.url), true);
+  });
+
+  await t.test('O4 forbidden extra properties fail closed', async () => {
+    const run = await runGoverned(root, stateDir, '[EXTRA]'); assert.match(run.settled.error.message, /Schema validation failed/);
+    assert.equal(alive(run.state.pid), false); assert.equal(await closed(run.url), true);
+  });
+
+  await t.test('O5 missing or duplicate attestation metadata fails closed', async () => {
+    for (const copies of [0, 2]) {
+      const agent = governedAgent(root); let closeCount = 0; let queryCount = 0;
+      agent.engine = { async *query() { queryCount++; yield { type: 'text', content: JSON.stringify(LINEAGE) }; for (let i = 0; i < copies; i++) yield { type: 'metadata', data: { attestation: governedValid.settled.value.runtimeAttestation } }; }, async close() { closeCount++; } };
+      await assert.rejects(agent.answerGoverned('[INJECTED]', { schema: LINEAGE_SCHEMA }), /exactly one/);
+      assert.equal(queryCount, 1); assert.equal(closeCount, 1);
+    }
+  });
+
+  await t.test('O6 the sole tools/call contains exactly one exact schema suffix', () => {
+    const suffix = generateSchemaInstructions(LINEAGE_SCHEMA, { debug: false }); const prompt = governedValid.call.params.arguments.prompt;
+    assert.equal(prompt.endsWith('[VALID]' + suffix), true); assert.equal(prompt.split(suffix).length - 1, 1);
+    assert.equal(governedValid.state.seen.filter(item => item.method === 'tools/call').length, 1);
+  });
+
+  await t.test('O7 cancellation returns no result and awaits cleanup', async () => {
+    const before = await stateFiles(stateDir); const agent = governedAgent(root);
+    const pending = agent.answerGoverned('[WAIT]', { schema: LINEAGE_SCHEMA }).then(value => ({ value }), error => ({ error }));
+    const state = await readState(await waitForState(stateDir, before, '[WAIT]')); const call = state.seen.find(item => item.method === 'tools/call'); const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+    agent.cancel(); const settled = await pending; assert.ok(settled.error); assert.equal('value' in settled, false);
+    assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+  });
+
+  await t.test('O8 answer keeps its string-returning behavior', async () => {
+    const before = await stateFiles(stateDir); const agent = governedAgent(root); const value = await agent.answer('[STRING]');
+    const state = await readState(await waitForState(stateDir, before, '[STRING]')); const call = state.seen.find(item => item.method === 'tools/call'); const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+    assert.equal(typeof value, 'string'); assert.match(value, /^candidate-/); assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+  });
+
+  await t.test('O9 frozen Proof-admission lineage is preserved without interpretation', () => {
+    const data = governedValid.settled.value.data;
+    assert.equal(data.subjectId, 'SYS-REQ-048'); assert.equal(data.subjectFingerprint, '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7');
+    assert.equal(data.role, 'spec-review'); assert.equal(data.coverageKey, 'SYS-REQ-048::spec-review'); assert.deepEqual(data.findings, LINEAGE.findings);
+    assert.equal('runtimeAttestation' in data, false);
   });
 
   await t.test('omitting the profile preserves the ungoverned result path', async () => {

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 import { createCodexEngine } from '../../src/agent/engines/codex.js';
-import { buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
+import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
 
 const TOOLS = ['search', 'extract', 'listFiles'];
 const fakeCodex = `#!/usr/bin/env node
@@ -14,12 +14,12 @@ import { createInterface } from 'node:readline';
 const file = process.env.PROBE_EXP0148_STATE + '/' + process.pid + '.json';
 const seen = []; const save = () => writeFileSync(file, JSON.stringify({ pid: process.pid, seen }));
 const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
-const configured = (requestId, args, patch = {}) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
-  _meta: { requestId, threadId: 'session-' + process.pid }, id: '', msg: {
-    type: 'session_configured', session_id: 'session-' + process.pid, thread_id: 'session-' + process.pid,
+const configured = (requestId, args, patch = {}, identity = process.pid) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
+  _meta: { requestId, threadId: 'session-' + identity }, id: '', msg: {
+    type: 'session_configured', session_id: 'session-' + identity, thread_id: 'session-' + identity,
     model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
     permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' },
-    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(process.pid).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
+    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(identity).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
   }
 }});
 createInterface({ input: process.stdin }).on('line', async line => {
@@ -29,12 +29,15 @@ createInterface({ input: process.stdin }).on('line', async line => {
   if (prompt.includes('[WAIT]')) return;
   if (prompt.includes('[EVENT]')) send({ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, msg: { type: 'raw_response_item', item: { role: 'assistant', content: [{ type: 'text', text: 'event-candidate' }] } } } });
   if (prompt.includes('[DELAY]')) await new Promise(resolve => setTimeout(resolve, 80));
+  if (prompt.includes('[HOLD]')) await new Promise(resolve => setTimeout(resolve, 200));
   let events = [configured(request.id, args)];
   if (prompt.includes('[MISSING]')) events = [];
   if (prompt.includes('[DUPLICATE]')) events.push(events[0]);
   if (prompt.includes('[MALFORMED]')) events = [{ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, id: '', msg: { type: 'session_configured' } } }];
   if (prompt.includes('[UNCORRELATED]')) events = [configured(999, args)];
   if (prompt.includes('[MISMATCHED]')) events = [configured(request.id, args, { model: 'wrong' })];
+  const foreign = /\\[FOREIGN:(\\d+):([^\\]]+)\\]/.exec(prompt);
+  if (foreign) { const cwd = decodeURIComponent(foreign[2]); events = [configured(request.id, { ...args, cwd }, {}, Number(foreign[1]))]; }
   for (const event of events) send(event);
   let text = 'candidate-' + process.pid;
   if (prompt.includes('[FORBIDDEN]')) {
@@ -48,6 +51,17 @@ createInterface({ input: process.stdin }).on('line', async line => {
 
 function profile(cwd) {
   return { version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex', model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never', cwd, probeTools: [...TOOLS], fallback: false, retries: 0 };
+}
+function configuredEvidence(pid, requestId, cwd) {
+  const identity = `session-${pid}`;
+  return { jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId, threadId: identity }, id: '', msg: {
+    type: 'session_configured', session_id: identity, thread_id: identity, model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
+    permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' }, reasoning_effort: 'xhigh',
+    rollout_path: `${cwd}/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-${String(pid).padStart(12, '0')}.jsonl`, cwd
+  } } };
+}
+function recursiveKeys(value, found = []) {
+  if (value && typeof value === 'object') for (const [key, child] of Object.entries(value)) { found.push(key); recursiveKeys(child, found); } return found;
 }
 async function stateFiles(dir) {
   return (await readdir(dir)).filter(name => name.endsWith('.json'));
@@ -124,6 +138,17 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     assert.deepEqual(call.params.arguments, buildGovernedCodexInitialToolArgs({ profile: profile(root), prompt: call.params.arguments.prompt, mcp: { name: server[0], url: server[1].url } }));
     assert.equal(output.filter(item => item.type === 'text').length, 1); assert.match(output[0].content, /^candidate-/);
     const receipt = output.find(item => item.type === 'metadata').data.attestation; const serialized = JSON.stringify(receipt);
+    const internal = attestGovernedCodexSession({ profile: profile(root), events: [configuredEvidence(state.pid, 2, root)] });
+    assert.deepEqual(receipt, {
+      version: 'probe.governed-codex-attestation/v1', profileId: 'luna-xhigh-readonly-v1',
+      requested: { profileDigest: internal.requested.profileDigest, cwdDigest: internal.requested.cwdDigest, probeToolsDigest: internal.requested.probeToolsDigest, model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never' },
+      observed: { source: 'session_configured', model: 'gpt-5.6-luna', modelProviderId: 'openai', reasoningEffort: 'xhigh', approvalPolicy: 'never', cwdDigest: internal.observed.cwdDigest, permissionProfileDigest: internal.observed.permissionProfileDigest, filesystem: 'restricted-read-root', network: 'restricted' },
+      evidence: { eventCount: 1 }, usage: { status: 'unavailable' }
+    });
+    assert.deepEqual(Object.keys(receipt), ['version', 'profileId', 'requested', 'observed', 'evidence', 'usage']);
+    assert.deepEqual(Object.keys(receipt.requested), ['profileDigest', 'cwdDigest', 'probeToolsDigest', 'model', 'reasoningEffort', 'sandbox', 'approvalPolicy']);
+    assert.deepEqual(Object.keys(receipt.observed), ['source', 'model', 'modelProviderId', 'reasoningEffort', 'approvalPolicy', 'cwdDigest', 'permissionProfileDigest', 'filesystem', 'network']);
+    for (const forbidden of ['correlation', 'requestId', 'sessionId', 'threadId', 'conversationId', 'rolloutPath', 'cwd', 'prompt', 'candidate', 'environment']) assert.equal(recursiveKeys(receipt).includes(forbidden), false);
     for (const secret of [root, call.params.arguments.prompt, String(state.pid), 'event-candidate', process.env.PATH]) assert.equal(serialized.includes(secret), false);
     assert.equal(receipt.observed.network, 'restricted'); assert.equal(alive(state.pid), false); assert.equal(await closed(server[1].url), true);
   });
@@ -144,26 +169,33 @@ test('EXP-0148 governed Codex runtime binding', async t => {
   });
 
   await t.test('simultaneous agents keep child, session, and MCP state isolated', async () => {
-    const [a, b] = await Promise.all([runEngine(root, stateDir, '[A]', true), runEngine(root, stateDir, '[B]', true)]);
+    const cwdA = join(root, 'cwd-a'); const cwdB = join(root, 'cwd-b'); await mkdir(cwdA); await mkdir(cwdB);
+    const before = await stateFiles(stateDir); const pendingA = runEngine(cwdA, stateDir, '[A][HOLD]', true);
+    const liveA = await readState(await waitForState(stateDir, before, '[A]'));
+    const [a, b] = await Promise.all([pendingA, runEngine(cwdB, stateDir, `[FOREIGN:${liveA.pid}:${encodeURIComponent(cwdA)}]`, true)]);
     assert.notEqual(a.state.pid, b.state.pid); assert.notEqual(a.url, b.url);
     assert.notEqual(Object.keys(a.call.params.arguments.config.mcp_servers)[0], Object.keys(b.call.params.arguments.config.mcp_servers)[0]);
-    const ra = a.output.find(item => item.type === 'metadata').data.attestation;
-    const rb = b.output.find(item => item.type === 'metadata').data.attestation;
-    assert.deepEqual(ra.requested, rb.requested); assert.equal(alive(a.state.pid) || alive(b.state.pid), false);
+    assert.equal(a.output.filter(item => item.type === 'text').length, 1); assert.equal(a.output.some(item => item.type === 'error'), false);
+    assert.equal(b.output.some(item => item.type === 'text'), false); assert.equal(b.output.filter(item => item.type === 'error').length, 1);
+    assert.equal(alive(a.state.pid) || alive(b.state.pid), false); assert.equal(await closed(a.url), true); assert.equal(await closed(b.url), true);
   });
 
-  await t.test('cancellation and explicit close await child and listener cleanup', async () => {
-    for (const action of ['abort', 'close']) {
-      const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
-      try {
-        const controller = new AbortController(); const iterator = engine.query('[WAIT]', { abortSignal: controller.signal }); const pending = collect(iterator);
-        const file = await waitForState(stateDir, before, '[WAIT]'); const state = await readState(file); const call = state.seen.find(item => item.method === 'tools/call');
-        const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
-        if (action === 'abort') controller.abort(); else await engine.close();
-        const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
-        assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
-      } finally { await engine.close(); }
+  await t.test('public cancel, cleanup, and explicit close await child and listener cleanup', async () => {
+    for (const action of ['cancel', 'cleanup']) {
+      const before = await stateFiles(stateDir); const released = [];
+      const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+      const pending = agent.answer('[WAIT]', [], { onStream: text => released.push(text) }).then(value => ({ value }), error => ({ error }));
+      const state = await readState(await waitForState(stateDir, before, '[WAIT]')); const call = state.seen.find(item => item.method === 'tools/call');
+      const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+      if (action === 'cancel') assert.equal(agent.cancel(), undefined); else { await agent.cleanup(); assert.equal(alive(state.pid), false); assert.equal(await closed(url), true); }
+      const settled = await pending; assert.ok(settled.error); assert.deepEqual(released, []);
+      assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
     }
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+    const pending = collect(engine.query('[WAIT]')); const state = await readState(await waitForState(stateDir, before, '[WAIT]'));
+    const url = Object.values(state.seen.find(item => item.method === 'tools/call').params.arguments.config.mcp_servers)[0].url;
+    await engine.close(); const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
+    assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
   });
 
   await t.test('omitting the profile preserves the ungoverned result path', async () => {

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,6 +10,8 @@ import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs } from '.
 import { generateSchemaInstructions } from '../../src/agent/schemaUtils.js';
 
 const TOOLS = ['search', 'extract', 'listFiles'];
+const DIGEST_A = `sha256:${'a'.repeat(64)}`;
+const DIGEST_B = `sha256:${'b'.repeat(64)}`;
 const LINEAGE = { subjectId: 'SYS-REQ-048', subjectFingerprint: '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7', role: 'spec-review', coverageKey: 'SYS-REQ-048::spec-review', findings: [{ type: 'ambiguity', severity: 'medium', message: 'timeout semantics are underspecified' }] };
 const LINEAGE_SCHEMA = JSON.stringify({ type: 'object', required: ['subjectId', 'subjectFingerprint', 'role', 'coverageKey', 'findings'], additionalProperties: false, properties: { subjectId: { type: 'string' }, subjectFingerprint: { type: 'string' }, role: { type: 'string' }, coverageKey: { type: 'string' }, findings: { type: 'array', items: { type: 'object', required: ['type', 'severity', 'message'], additionalProperties: false, properties: { type: { type: 'string' }, severity: { type: 'string' }, message: { type: 'string' } } } } } });
 const fakeCodex = `#!/usr/bin/env node
@@ -71,6 +74,12 @@ function configuredEvidence(pid, requestId, cwd) {
 function recursiveKeys(value, found = []) {
   if (value && typeof value === 'object') for (const [key, child] of Object.entries(value)) { found.push(key); recursiveKeys(child, found); } return found;
 }
+function dispatchFor(prompt) {
+  const promptBytes = Buffer.byteLength(prompt, 'utf8'); const byteLength = Buffer.alloc(8);
+  byteLength.writeBigUInt64BE(BigInt(promptBytes));
+  const promptDigest = `sha256:${createHash('sha256').update('probe.governed-codex-dispatch/prompt/v1', 'utf8').update(Buffer.from([0])).update(byteLength).update(prompt, 'utf8').digest('hex')}`;
+  return { source: 'probe-host-tools-call', tool: 'codex', promptDigest, promptBytes };
+}
 async function stateFiles(dir) {
   return (await readdir(dir)).filter(name => name.endsWith('.json'));
 }
@@ -118,9 +127,9 @@ async function runEngine(root, stateDir, marker, useProbe = false) {
   const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
   return { engine, output, state, call, url };
 }
-async function runGoverned(root, stateDir, marker) {
+async function runGoverned(root, stateDir, marker, options = { schema: LINEAGE_SCHEMA }) {
   const before = await stateFiles(stateDir); const agent = governedAgent(root);
-  const settled = await agent.answerGoverned(marker, { schema: LINEAGE_SCHEMA }).then(value => ({ value }), error => ({ error }));
+  const settled = await agent.answerGoverned(marker, options).then(value => ({ value }), error => ({ error }));
   const state = await readState(await waitForState(stateDir, before, marker)); const call = state.seen.find(item => item.method === 'tools/call');
   return { settled, state, call, url: Object.values(call.params.arguments.config.mcp_servers)[0].url };
 }
@@ -132,7 +141,7 @@ test('EXP-0148 governed Codex runtime binding', async t => {
   const executable = join(bin, 'codex'); await writeFile(executable, fakeCodex); await chmod(executable, 0o755);
   const originalPath = process.env.PATH; process.env.PATH = `${bin}:${originalPath}`; process.env.PROBE_EXP0148_STATE = stateDir;
   t.after(async () => { process.env.PATH = originalPath; delete process.env.PROBE_EXP0148_STATE; await rm(root, { recursive: true, force: true }); });
-  let governedValid;
+  let governedValid; let boundValid;
 
   await t.test('rejects non-exact public bindings before spawn', () => {
     const count = () => stateFiles(stateDir);
@@ -278,6 +287,138 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     assert.equal(data.subjectId, 'SYS-REQ-048'); assert.equal(data.subjectFingerprint, '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7');
     assert.equal(data.role, 'spec-review'); assert.equal(data.coverageKey, 'SYS-REQ-048::spec-review'); assert.deepEqual(data.findings, LINEAGE.findings);
     assert.equal('runtimeAttestation' in data, false);
+  });
+
+  await t.test('EXP-0151 O01 omitted digest preserves exact v1 receipt and result', async () => {
+    const run = await runGoverned(root, stateDir, '[VALID][UNBOUND-V1]'); assert.ifError(run.settled.error);
+    assert.deepEqual(run.settled.value.runtimeAttestation, governedValid.settled.value.runtimeAttestation);
+    assert.deepEqual(Object.keys(run.settled.value), ['data', 'runtimeAttestation']);
+    const inherited = Object.assign(Object.create({ invocationDigest: DIGEST_A }), { schema: LINEAGE_SCHEMA });
+    const inheritedRun = await runGoverned(root, stateDir, '[VALID][INHERITED-V1]', inherited); assert.ifError(inheritedRun.settled.error);
+    assert.equal(inheritedRun.settled.value.runtimeAttestation.version, 'probe.governed-codex-attestation/v1');
+  });
+
+  await t.test('EXP-0151 O02 bound digest returns the exact distinct v2 projection', async () => {
+    boundValid = await runGoverned(root, stateDir, '[VALID][BOUND]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }); assert.ifError(boundValid.settled.error);
+    const receipt = boundValid.settled.value.runtimeAttestation;
+    assert.deepEqual(Object.keys(boundValid.settled.value), ['data', 'runtimeAttestation']); assert.deepEqual(boundValid.settled.value.data, LINEAGE);
+    const server = Object.entries(boundValid.call.params.arguments.config.mcp_servers)[0]; assert.deepEqual(boundValid.call.params.arguments, buildGovernedCodexInitialToolArgs({ profile: profile(root), prompt: boundValid.call.params.arguments.prompt, mcp: { name: server[0], url: server[1].url } }));
+    assert.deepEqual(Object.keys(receipt), ['version', 'profileId', 'requested', 'observed', 'executionContext', 'dispatch', 'evidence', 'usage']);
+    assert.equal(receipt.version, 'probe.governed-codex-attestation/v2'); assert.equal(receipt.profileId, 'luna-xhigh-readonly-v1');
+    assert.deepEqual(receipt.requested, governedValid.settled.value.runtimeAttestation.requested); assert.deepEqual(receipt.observed, governedValid.settled.value.runtimeAttestation.observed);
+    assert.deepEqual(receipt.executionContext, { source: 'caller', invocationDigest: DIGEST_A });
+    assert.deepEqual(Object.keys(receipt.dispatch), ['source', 'tool', 'promptDigest', 'promptBytes']);
+    assert.deepEqual(receipt.evidence, { eventCount: 1 }); assert.deepEqual(receipt.usage, { status: 'unavailable' });
+  });
+
+  await t.test('EXP-0151 O03 independently recomputes prompt digest and byte length', () => {
+    assert.deepEqual(boundValid.settled.value.runtimeAttestation.dispatch, dispatchFor(boundValid.call.params.arguments.prompt));
+  });
+
+  await t.test('EXP-0151 O04 digest is host-only and absent from prompt, tool args, and candidate', () => {
+    assert.equal(JSON.stringify(boundValid.call.params.arguments).includes(DIGEST_A), false);
+    assert.equal(boundValid.call.params.arguments.prompt.includes(DIGEST_A), false);
+    assert.equal(JSON.stringify(boundValid.settled.value.data).includes(DIGEST_A), false);
+  });
+
+  await t.test('EXP-0151 O05 changing only caller digest changes only execution context', async () => {
+    const run = await runGoverned(root, stateDir, '[VALID][BOUND]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_B }); assert.ifError(run.settled.error);
+    const a = structuredClone(boundValid.settled.value.runtimeAttestation); const b = structuredClone(run.settled.value.runtimeAttestation);
+    assert.equal(a.executionContext.invocationDigest, DIGEST_A); assert.equal(b.executionContext.invocationDigest, DIGEST_B);
+    delete a.executionContext; delete b.executionContext; assert.deepEqual(a, b);
+    assert.equal(boundValid.call.params.arguments.prompt, run.call.params.arguments.prompt);
+  });
+
+  await t.test('EXP-0151 O06 changing prompt bytes changes dispatch under the same digest', async () => {
+    const run = await runGoverned(root, stateDir, '[VALID][BOUND-CHANGED]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }); assert.ifError(run.settled.error);
+    assert.notEqual(run.call.params.arguments.prompt, boundValid.call.params.arguments.prompt);
+    assert.notEqual(run.settled.value.runtimeAttestation.dispatch.promptDigest, boundValid.settled.value.runtimeAttestation.dispatch.promptDigest);
+    assert.equal(run.settled.value.runtimeAttestation.executionContext.invocationDigest, DIGEST_A);
+  });
+
+  await t.test('EXP-0151 O07 invalid digests fail before acquisition and direct tools call', async () => {
+    const invalid = ['a'.repeat(64), `sha256:${'A'.repeat(64)}`, ` ${DIGEST_A}`, `${DIGEST_A}\n`, 'sha256:ab', 7, null];
+    const agent = governedAgent(root); let acquisitions = 0; agent.getEngine = async () => { acquisitions++; throw new Error('must not acquire'); };
+    for (const invocationDigest of invalid) await assert.rejects(agent.answerGoverned('x', { schema: LINEAGE_SCHEMA, invocationDigest }), { name: 'TypeError', message: 'answerGoverned invocationDigest must match sha256:<64 lowercase hexadecimal digits>' });
+    assert.equal(acquisitions, 0);
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+    const output = await collect(engine.query('[DIRECT-INVALID]', { invocationDigest: 'bad' })); const state = await readState(await waitForState(stateDir, before));
+    assert.equal(output.filter(item => item.type === 'error').length, 1); assert.equal(state.seen.some(item => item.method === 'tools/call'), false); assert.equal(alive(state.pid), false);
+  });
+
+  await t.test('EXP-0151 O08 unmatched v2 metadata fails closed', async () => {
+    const receipt = boundValid.settled.value.runtimeAttestation;
+    const cases = [[], [receipt, receipt], [{ ...receipt, version: 'probe.governed-codex-attestation/v1' }], [{ ...receipt, executionContext: { source: 'caller', invocationDigest: DIGEST_B } }]];
+    for (const receipts of cases) {
+      const agent = governedAgent(root); let closeCount = 0;
+      agent.engine = { async *query() { yield { type: 'text', content: JSON.stringify(LINEAGE) }; for (const attestation of receipts) yield { type: 'metadata', data: { attestation } }; }, async close() { closeCount++; } };
+      await assert.rejects(agent.answerGoverned('[INJECTED-V2]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }), { message: 'Expected exactly one matching governed invocation attestation' }); assert.equal(closeCount, 1);
+    }
+  });
+
+  await t.test('EXP-0151 O09 simultaneous siblings retain their own binding', async () => {
+    const [a, b] = await Promise.all([
+      runGoverned(root, stateDir, '[VALID][HOLD][BOUND-SIBLING-A]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }),
+      runGoverned(root, stateDir, '[VALID][BOUND-SIBLING-B]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_B })
+    ]);
+    assert.ifError(a.settled.error); assert.ifError(b.settled.error); assert.notEqual(a.state.pid, b.state.pid);
+    assert.equal(a.settled.value.runtimeAttestation.executionContext.invocationDigest, DIGEST_A); assert.equal(b.settled.value.runtimeAttestation.executionContext.invocationDigest, DIGEST_B);
+    assert.notEqual(a.url, b.url); assert.equal(alive(a.state.pid) || alive(b.state.pid), false);
+  });
+
+  await t.test('EXP-0151 O10 bound call has one schema suffix, query, and tools call', () => {
+    const suffix = generateSchemaInstructions(LINEAGE_SCHEMA, { debug: false }); const prompt = boundValid.call.params.arguments.prompt;
+    assert.equal(prompt.split(suffix).length - 1, 1); assert.equal(boundValid.state.seen.filter(item => item.method === 'tools/call').length, 1);
+    const agent = governedAgent(root); let queryCount = 0;
+    agent.engine = { async *query() { queryCount++; yield { type: 'text', content: JSON.stringify(LINEAGE) }; yield { type: 'metadata', data: { attestation: boundValid.settled.value.runtimeAttestation } }; }, async close() {} };
+    return agent.answerGoverned('[QUERY-COUNT]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }).then(() => assert.equal(queryCount, 1));
+  });
+
+  await t.test('EXP-0151 O11 bound projection recursively redacts host and model bytes', () => {
+    const receipt = boundValid.settled.value.runtimeAttestation; const serialized = JSON.stringify(receipt);
+    for (const forbidden of ['prompt', 'schema', 'candidate', 'environment', 'credentials', 'correlation', 'requestId', 'sessionId', 'threadId', 'conversationId', 'cwd', 'path']) assert.equal(recursiveKeys(receipt).includes(forbidden), false, forbidden);
+    for (const secret of [root, boundValid.call.params.arguments.prompt, LINEAGE_SCHEMA, JSON.stringify(LINEAGE), process.env.PATH]) assert.equal(serialized.includes(secret), false);
+  });
+
+  await t.test('EXP-0151 O12 inherited governed contracts remain live', () => {
+    assert.equal(governedValid.settled.value.runtimeAttestation.version, 'probe.governed-codex-attestation/v1');
+    assert.deepEqual(boundValid.settled.value.data, LINEAGE); assert.equal(alive(boundValid.state.pid), false);
+  });
+
+  await t.test('EXP-0151 O13 bound cancellation emits no admissible result and cleans up', async () => {
+    const before = await stateFiles(stateDir); const agent = governedAgent(root);
+    const pending = agent.answerGoverned('[WAIT][BOUND-CANCEL]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }).then(value => ({ value }), error => ({ error }));
+    const state = await readState(await waitForState(stateDir, before, '[BOUND-CANCEL]')); const call = state.seen.find(item => item.method === 'tools/call'); const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+    agent.cancel(); const settled = await pending; assert.ok(settled.error); assert.equal('value' in settled, false); assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+  });
+
+  await t.test('EXP-0151 O14 mirrors match and regular answer bytes remain frozen', async () => {
+    const sourceDeclaration = await readFile(new URL('../../src/agent/ProbeAgent.d.ts', import.meta.url), 'utf8'); const packageDeclaration = await readFile(new URL('../../index.d.ts', import.meta.url), 'utf8');
+    const contract = value => value.slice(value.indexOf('export interface GovernedAnswerOptions'), value.indexOf('/**\n * Clone options', value.indexOf('export interface GovernedAnswerOptions')));
+    assert.equal(contract(sourceDeclaration), contract(packageDeclaration));
+    for (const declaration of [sourceDeclaration, packageDeclaration]) assert.equal(declaration.includes('answer(message: string, images?: any[], options?: AnswerOptions): Promise<string>;'), true);
+    const source = await readFile(new URL('../../src/agent/ProbeAgent.js', import.meta.url), 'utf8'); const answer = source.slice(source.indexOf('  async answer(message'), source.indexOf('  /**\n   * Get token usage information', source.indexOf('  async answer(message')));
+    assert.equal(createHash('sha256').update(answer).digest('hex'), '53ee9f207963f5b991aaf89e143211039ad632d9cc7535d91af66bcae95b135f');
+  });
+
+  await t.test('EXP-0151 O15 changing own getters are read once at each boundary', async () => {
+    let agentReads = 0; const options = { schema: LINEAGE_SCHEMA };
+    Object.defineProperty(options, 'invocationDigest', { enumerable: true, get() { agentReads++; return agentReads === 1 ? DIGEST_A : DIGEST_B; } });
+    const agent = governedAgent(root); let transported;
+    agent.engine = { async *query(_prompt, opts) { transported = opts.invocationDigest; yield { type: 'text', content: JSON.stringify(LINEAGE) }; yield { type: 'metadata', data: { attestation: boundValid.settled.value.runtimeAttestation } }; }, async close() {} };
+    const answer = await agent.answerGoverned('[GETTER-AGENT]', options); assert.equal(agentReads, 1); assert.equal(transported, DIGEST_A); assert.equal(answer.runtimeAttestation.executionContext.invocationDigest, DIGEST_A);
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) }); let engineReads = 0; const engineOptions = {};
+    Object.defineProperty(engineOptions, 'invocationDigest', { enumerable: true, get() { engineReads++; return engineReads === 1 ? DIGEST_A : DIGEST_B; } });
+    const output = await collect(engine.query('[VALID][GETTER-ENGINE]', engineOptions)); const state = await readState(await waitForState(stateDir, before, '[GETTER-ENGINE]'));
+    assert.equal(engineReads, 1); assert.equal(output.find(item => item.type === 'metadata').data.attestation.executionContext.invocationDigest, DIGEST_A); assert.equal(alive(state.pid), false);
+  });
+
+  await t.test('EXP-0151 O16 caller mutation after start cannot alter snapshot', async () => {
+    const before = await stateFiles(stateDir); const agent = governedAgent(root); const options = { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A };
+    const pending = agent.answerGoverned('[VALID][DELAY][MUTATION]', options).then(value => ({ value }), error => ({ error })); options.invocationDigest = DIGEST_B;
+    const settled = await pending; assert.ifError(settled.error); const state = await readState(await waitForState(stateDir, before, '[MUTATION]')); const call = state.seen.find(item => item.method === 'tools/call');
+    assert.equal(settled.value.runtimeAttestation.executionContext.invocationDigest, DIGEST_A);
+    assert.equal(JSON.stringify(call.params.arguments).includes(DIGEST_A) || JSON.stringify(call.params.arguments).includes(DIGEST_B), false);
   });
 
   await t.test('omitting the profile preserves the ungoverned result path', async () => {

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -1,9 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 import { createCodexEngine } from '../../src/agent/engines/codex.js';
 import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
@@ -12,6 +15,8 @@ import { generateSchemaInstructions } from '../../src/agent/schemaUtils.js';
 const TOOLS = ['search', 'extract', 'listFiles'];
 const DIGEST_A = `sha256:${'a'.repeat(64)}`;
 const DIGEST_B = `sha256:${'b'.repeat(64)}`;
+const RESULT_IDENTITY = 'probe.governed-result-identity/v1';
+const execFileAsync = promisify(execFile);
 const LINEAGE = { subjectId: 'SYS-REQ-048', subjectFingerprint: '636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7', role: 'spec-review', coverageKey: 'SYS-REQ-048::spec-review', findings: [{ type: 'ambiguity', severity: 'medium', message: 'timeout semantics are underspecified' }] };
 const LINEAGE_SCHEMA = JSON.stringify({ type: 'object', required: ['subjectId', 'subjectFingerprint', 'role', 'coverageKey', 'findings'], additionalProperties: false, properties: { subjectId: { type: 'string' }, subjectFingerprint: { type: 'string' }, role: { type: 'string' }, coverageKey: { type: 'string' }, findings: { type: 'array', items: { type: 'object', required: ['type', 'severity', 'message'], additionalProperties: false, properties: { type: { type: 'string' }, severity: { type: 'string' }, message: { type: 'string' } } } } } });
 const fakeCodex = `#!/usr/bin/env node
@@ -132,6 +137,18 @@ async function runGoverned(root, stateDir, marker, options = { schema: LINEAGE_S
   const settled = await agent.answerGoverned(marker, options).then(value => ({ value }), error => ({ error }));
   const state = await readState(await waitForState(stateDir, before, marker)); const call = state.seen.find(item => item.method === 'tools/call');
   return { settled, state, call, url: Object.values(call.params.arguments.config.mcp_servers)[0].url };
+}
+function installIdentifiedEngine(agent, receipt, candidate) {
+  const state = { queries: 0, closes: 0, prompts: [], options: [] };
+  agent.engine = { async *query(prompt, options) { state.queries++; state.prompts.push(prompt); state.options.push(options); yield { type: 'text', content: candidate }; yield { type: 'metadata', data: { attestation: structuredClone(receipt) } }; }, async close() { state.closes++; } };
+  return state;
+}
+function expectedResultIdentity(canonical) {
+  const bytes = Buffer.from(canonical, 'utf8'); const byteLength = Buffer.alloc(8); byteLength.writeBigUInt64BE(BigInt(bytes.length));
+  return { version: RESULT_IDENTITY, source: 'probe-host-schema-valid-json', resultDigest: `sha256:${createHash('sha256').update('probe.governed-result-identity/data/v1', 'utf8').update(Buffer.from([0])).update(byteLength).update(bytes).digest('hex')}`, canonicalBytes: bytes.length };
+}
+function assertDeepFrozen(value) {
+  if (!value || typeof value !== 'object') return; assert.equal(Object.isFrozen(value), true); for (const child of Object.values(value)) assertDeepFrozen(child);
 }
 
 test('EXP-0148 governed Codex runtime binding', async t => {
@@ -426,5 +443,129 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     const output = await collect(engine.query('[MISSING]')); const state = await readState(await waitForState(stateDir, before, '[MISSING]'));
     assert.match(output.find(item => item.type === 'text').content, /^candidate-/); assert.equal(alive(state.pid), true);
     await engine.close(); assert.equal(alive(state.pid), false);
+  });
+
+  let identifiedValid;
+  await t.test('EXP-0152 T01 omitted and inherited selector preserve v1 and v2 lanes', async () => {
+    const v1 = await runGoverned(root, stateDir, '[VALID][EXP0152-V1]'); const v2 = await runGoverned(root, stateDir, '[VALID][EXP0152-V2]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A });
+    assert.deepEqual(Object.keys(v1.settled.value), ['data', 'runtimeAttestation']); assert.deepEqual(Object.keys(v2.settled.value), ['data', 'runtimeAttestation']); assert.equal(Object.isFrozen(v1.settled.value), false); assert.equal(Object.isFrozen(v2.settled.value), false);
+    const inherited = Object.assign(Object.create({ resultIdentity: RESULT_IDENTITY }), { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }); const inheritedRun = await runGoverned(root, stateDir, '[VALID][EXP0152-INHERITED]', inherited);
+    assert.ifError(inheritedRun.settled.error); assert.deepEqual(Object.keys(inheritedRun.settled.value), ['data', 'runtimeAttestation']); assert.equal(inheritedRun.settled.value.runtimeAttestation.version, 'probe.governed-codex-attestation/v2');
+  });
+
+  await t.test('EXP-0152 T02 public types and overload returns compile with expected errors', async () => {
+    const npmRoot = fileURLToPath(new URL('../..', import.meta.url));
+    const typescriptBin = join(npmRoot, 'node_modules', 'typescript', 'bin', 'tsc');
+    const fixtureDir = await mkdtemp(join(npmRoot, '.exp-0152-types-'));
+    const fixturePath = join(fixtureDir, 'overloads.mts');
+    const fixtureSource = `import type ProbeAgent from '../index.js';
+import type { GovernedAnswerResult, GovernedIdentifiedAnswerResult, GovernedInvocationAnswerResult } from '../index.js';
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Expect<T extends true> = T;
+declare const agent: ProbeAgent;
+declare const schema: string;
+declare const invocationDigest: string;
+const identified = agent.answerGoverned('x', { schema, invocationDigest, resultIdentity: 'probe.governed-result-identity/v1' });
+const bound = agent.answerGoverned('x', { schema, invocationDigest });
+const unbound = agent.answerGoverned('x', { schema });
+type Identified = Expect<Equal<typeof identified, Promise<GovernedIdentifiedAnswerResult>>>;
+type Bound = Expect<Equal<typeof bound, Promise<GovernedInvocationAnswerResult>>>;
+type Unbound = Expect<Equal<typeof unbound, Promise<GovernedAnswerResult>>>;
+// @ts-expect-error wrong resultIdentity literal
+agent.answerGoverned('x', { schema, invocationDigest, resultIdentity: 'wrong' });
+// @ts-expect-error resultIdentity requires invocationDigest
+agent.answerGoverned('x', { schema, resultIdentity: 'probe.governed-result-identity/v1' });`;
+    try {
+      await writeFile(fixturePath, fixtureSource, 'utf8');
+      await execFileAsync(process.execPath,[typescriptBin,'--noEmit','--strict','--skipLibCheck','--target','ES2022','--module','NodeNext','--moduleResolution','NodeNext','--types','node',fixturePath],{cwd:npmRoot});
+    } finally {
+      await rm(fixtureDir, { recursive: true, force: true });
+    }
+  });
+
+  await t.test('EXP-0152 T03 selector errors are exact, ordered, and pre-acquisition', async () => {
+    const agent = governedAgent(root); let acquisitions = 0; agent.getEngine = async () => { acquisitions++; throw new Error('must not acquire'); };
+    await assert.rejects(agent.answerGoverned('x', { schema: LINEAGE_SCHEMA, invocationDigest: 'bad', resultIdentity: 'wrong' }), { name: 'TypeError', message: 'answerGoverned invocationDigest must match sha256:<64 lowercase hexadecimal digits>' });
+    await assert.rejects(agent.answerGoverned('x', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: 'wrong' }), { name: 'TypeError', message: 'answerGoverned resultIdentity must equal probe.governed-result-identity/v1' });
+    await assert.rejects(agent.answerGoverned('x', { schema: LINEAGE_SCHEMA, resultIdentity: RESULT_IDENTITY }), { name: 'TypeError', message: 'answerGoverned resultIdentity requires an own invocationDigest' }); assert.equal(acquisitions, 0);
+  });
+
+  await t.test('EXP-0152 T04 schema and optional selectors are one-read snapshots before await', async () => {
+    const trace = []; let schemaReads = 0; let invocationReads = 0; let resultReads = 0; const options = {};
+    Object.defineProperty(options, 'schema', { enumerable: true, get() { trace.push('schema'); schemaReads++; return schemaReads === 1 ? LINEAGE_SCHEMA : JSON.stringify({ type: 'string' }); } });
+    Object.defineProperty(options, 'invocationDigest', { enumerable: true, get() { trace.push('invocation'); invocationReads++; return invocationReads === 1 ? DIGEST_A : DIGEST_B; } });
+    Object.defineProperty(options, 'resultIdentity', { enumerable: true, get() { trace.push('result'); resultReads++; return resultReads === 1 ? RESULT_IDENTITY : 'wrong'; } });
+    const agent = governedAgent(root); const state = installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, JSON.stringify(LINEAGE)); const value = await agent.answerGoverned('[EXP0152-GETTERS]', options);
+    assert.deepEqual(trace, ['schema', 'invocation', 'result']); assert.deepEqual([schemaReads, invocationReads, resultReads], [1, 1, 1]); assert.equal(state.prompts[0].endsWith(generateSchemaInstructions(LINEAGE_SCHEMA, { debug: false })), true); assert.deepEqual(value.data, LINEAGE);
+    const mutable = { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }; const delayed = governedAgent(root); installIdentifiedEngine(delayed, boundValid.settled.value.runtimeAttestation, JSON.stringify(LINEAGE)); const pending = delayed.answerGoverned('[EXP0152-MUTATE]', mutable); mutable.schema = JSON.stringify({ type: 'string' }); assert.deepEqual((await pending).data, LINEAGE);
+  });
+
+  await t.test('EXP-0152 T05 independently recomputes canonical bytes and framed digest', async () => {
+    const agent = governedAgent(root); const candidate = '{"findings":[{"message":"timeout semantics are underspecified","severity":"medium","type":"ambiguity"}],"coverageKey":"SYS-REQ-048::spec-review","role":"spec-review","subjectFingerprint":"636e9230b39a705f4dc1488038718281791f82f31e917296af090e9c0638fef7","subjectId":"SYS-REQ-048"}';
+    installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, candidate); identifiedValid = await agent.answerGoverned('[EXP0152-IDENTIFIED]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY });
+    const canonical = JSON.stringify({ coverageKey: LINEAGE.coverageKey, findings: [{ message: LINEAGE.findings[0].message, severity: 'medium', type: 'ambiguity' }], role: 'spec-review', subjectFingerprint: LINEAGE.subjectFingerprint, subjectId: 'SYS-REQ-048' });
+    assert.deepEqual(identifiedValid.resultIdentity, expectedResultIdentity(canonical)); assert.deepEqual(Object.keys(identifiedValid), ['data', 'runtimeAttestation', 'resultIdentity']);
+  });
+
+  await t.test('EXP-0152 T06 equivalence and honest mixed-key ordering include own __proto__', async () => {
+    const mixedKeys=['10','2','01','4294967294','4294967295','é','😀','__proto__'];
+    const schema=JSON.stringify({type:'object',required:mixedKeys,additionalProperties:false,properties:Object.fromEntries(mixedKeys.map(key=>[key,{type:'string'}])),patternProperties:{'^__proto__$':{type:'string'}}}); const raw = '{"10":"ten","2":"two","01":"leading","4294967294":"max","4294967295":"overflow","é":"accent","😀":"emoji","__proto__":"proto"}';
+    const agent = governedAgent(root); installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, raw); const mixed = await agent.answerGoverned('mixed', { schema, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY });
+    const expected = '{"2":"two","10":"ten","4294967294":"max","01":"leading","4294967295":"overflow","__proto__":"proto","é":"accent","😀":"emoji"}';
+    assert.deepEqual(Object.keys(mixed.data), ['2', '10', '4294967294', '01', '4294967295', '__proto__', 'é', '😀']); assert.equal(Object.prototype.hasOwnProperty.call(mixed.data, '__proto__'), true); assert.deepEqual(mixed.resultIdentity, expectedResultIdentity(expected));
+    const equivalent = governedAgent(root); installIdentifiedEngine(equivalent, boundValid.settled.value.runtimeAttestation, '{"😀":"emoji","é":"accent","__proto__":"proto","4294967295":"overflow","4294967294":"max","01":"leading","2":"two","10":"ten"}'); const reordered = await equivalent.answerGoverned('mixed-2', { schema, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }); assert.equal(reordered.resultIdentity.resultDigest, mixed.resultIdentity.resultDigest);
+    for (const candidate of ['-0', '0']) { const numberAgent = governedAgent(root); installIdentifiedEngine(numberAgent, boundValid.settled.value.runtimeAttestation, candidate); const result = await numberAgent.answerGoverned('number', { schema: JSON.stringify({ type: 'number' }), invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }); assert.equal(result.resultIdentity.resultDigest, expectedResultIdentity('0').resultDigest); }
+  });
+
+  await t.test('EXP-0152 T07 semantic content and array order change identity', async () => {
+    const answer = async candidate => { const agent = governedAgent(root); installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, candidate); return agent.answerGoverned('array', { schema: '{}', invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }); };
+    const [a, b, c] = await Promise.all([answer('[1,2]'), answer('[2,1]'), answer('[1,3]')]); assert.notEqual(a.resultIdentity.resultDigest, b.resultIdentity.resultDigest); assert.notEqual(a.resultIdentity.resultDigest, c.resultIdentity.resultDigest);
+  });
+
+  await t.test('EXP-0152 T08 identity is content-only across invocation bindings', async () => {
+    const receiptB = structuredClone(boundValid.settled.value.runtimeAttestation); receiptB.executionContext.invocationDigest = DIGEST_B;
+    const run = async (digest, receipt) => { const agent = governedAgent(root); installIdentifiedEngine(agent, receipt, JSON.stringify(LINEAGE)); return agent.answerGoverned('same', { schema: LINEAGE_SCHEMA, invocationDigest: digest, resultIdentity: RESULT_IDENTITY }); };
+    const [a, b] = await Promise.all([run(DIGEST_A, boundValid.settled.value.runtimeAttestation), run(DIGEST_B, receiptB)]); assert.equal(a.resultIdentity.resultDigest, b.resultIdentity.resultDigest); assert.notEqual(a.runtimeAttestation.executionContext.invocationDigest, b.runtimeAttestation.executionContext.invocationDigest);
+  });
+
+  await t.test('EXP-0152 T09 complete identified graph is deeply frozen', () => {
+    assertDeepFrozen(identifiedValid); assertDeepFrozen(identifiedValid.data); assertDeepFrozen(identifiedValid.resultIdentity); assertDeepFrozen(identifiedValid.runtimeAttestation);
+  });
+
+  await t.test('EXP-0152 T10 normalized data is a new host snapshot', async () => {
+    const source = { z: [{ b: 2, a: 1 }] }; const agent = governedAgent(root); installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, JSON.stringify(source)); const result = await agent.answerGoverned('copy', { schema: '{}', invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY });
+    assert.notEqual(result.data, source); assert.notEqual(result.data.z, source.z); assert.deepEqual(result.data, { z: [{ a: 1, b: 2 }] }); source.z[0].a = 9; assert.equal(result.data.z[0].a, 1);
+  });
+
+  await t.test('EXP-0152 T11 receipt and schema failures emit no identity and clean once', async () => {
+    const mismatch = governedAgent(root); const wrong = structuredClone(boundValid.settled.value.runtimeAttestation); wrong.executionContext.invocationDigest = DIGEST_B; const mismatchState = installIdentifiedEngine(mismatch, wrong, '{');
+    const mismatchSettled = await mismatch.answerGoverned('mismatch', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }).then(value => ({ value }), error => ({ error })); assert.equal('value' in mismatchSettled, false); assert.match(mismatchSettled.error.message, /matching governed invocation/); assert.deepEqual([mismatchState.queries, mismatchState.closes], [1, 1]);
+    const invalid = governedAgent(root); const invalidState = installIdentifiedEngine(invalid, boundValid.settled.value.runtimeAttestation, '{'); const invalidSettled = await invalid.answerGoverned('invalid', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }).then(value => ({ value }), error => ({ error })); assert.equal('value' in invalidSettled, false); assert.doesNotMatch(invalidSettled.error.message, /matching governed invocation/); assert.deepEqual([invalidState.queries, invalidState.closes], [1, 1]);
+  });
+
+  await t.test('EXP-0152 T12 public identity and receipt recursively exclude operational bytes', () => {
+    const projection = { runtimeAttestation: identifiedValid.runtimeAttestation, resultIdentity: identifiedValid.resultIdentity }; const serialized = JSON.stringify(projection);
+    for (const forbidden of ['prompt', 'schema', 'candidate', 'canonical', 'environment', 'credentials', 'correlation', 'requestId', 'sessionId', 'threadId', 'conversationId', 'cwd', 'path']) assert.equal(recursiveKeys(projection).includes(forbidden), false, forbidden);
+    for (const secret of [root, LINEAGE_SCHEMA, JSON.stringify(LINEAGE), process.env.PATH]) assert.equal(serialized.includes(secret), false);
+  });
+
+  await t.test('EXP-0152 T13 complete EXP-0151 oracle set remains present', async () => {
+    const source = await readFile(new URL(import.meta.url), 'utf8'); for (let i = 1; i <= 16; i++) assert.match(source, new RegExp(`EXP-0151 O${String(i).padStart(2, '0')}`));
+  });
+
+  await t.test('EXP-0152 T14 declaration mirrors and overload order are exact', async () => {
+    const sourceDeclaration = await readFile(new URL('../../src/agent/ProbeAgent.d.ts', import.meta.url), 'utf8'); const packageDeclaration = await readFile(new URL('../../index.d.ts', import.meta.url), 'utf8');
+    const contract = value => value.slice(value.indexOf('export interface GovernedAnswerOptions'), value.indexOf('/**\n * Clone options', value.indexOf('export interface GovernedAnswerOptions'))); assert.equal(contract(sourceDeclaration), contract(packageDeclaration));
+    const overloads = value => value.slice(value.indexOf('  answerGoverned(message: string, options: GovernedIdentifiedAnswerOptions'), value.indexOf('\n\n  /**\n   * Get token usage', value.indexOf('  answerGoverned(message: string, options: GovernedIdentifiedAnswerOptions'))); assert.equal(overloads(sourceDeclaration), overloads(packageDeclaration));
+    assert.equal(overloads(sourceDeclaration), `  answerGoverned(message: string, options: GovernedIdentifiedAnswerOptions, images?: any[]): Promise<GovernedIdentifiedAnswerResult>;\n  answerGoverned(message: string, options: GovernedInvocationAnswerOptions, images?: any[]): Promise<GovernedInvocationAnswerResult>;\n  answerGoverned(message: string, options: GovernedAnswerOptions, images?: any[]): Promise<GovernedAnswerResult>;`);
+  });
+
+  await t.test('EXP-0152 T15 frozen files and legacy function/declaration regions remain exact', async () => {
+    const sha = value => createHash('sha256').update(value).digest('hex'); const read = path => readFile(new URL(path, import.meta.url), 'utf8');
+    assert.equal(sha(await read('../../src/agent/engines/codex.js')), '98e688326ecaabf384559f882e0bffea70460f5667b9f47f183763cf2a3f8912'); assert.equal(sha(await read('../../src/agent/schemaUtils.js')), '24332877e019ef29311f03ce9b63e61925c25fd7f83f5dd442b22dc68c60f6e9'); assert.equal(sha(await read('../../src/agent/engines/governed-codex-profile.js')), 'de56ab543afb61224bdba860bbad0a6734d48bbb5393d3da7807cfb5baf54936');
+    const source = await read('../../src/agent/ProbeAgent.js'); const answer = source.slice(source.indexOf('  async answer(message'), source.indexOf('  /**\n   * Get token usage information', source.indexOf('  async answer(message'))); assert.equal(sha(answer), '53ee9f207963f5b991aaf89e143211039ad632d9cc7535d91af66bcae95b135f');
+    const governed = source.slice(source.indexOf('  async answerGoverned(message'), source.indexOf('\n  /**\n   * Answer a question', source.indexOf('  async answerGoverned(message'))); assert.equal((governed.match(/options\.schema/g) || []).length, 1); assert.equal((governed.match(/options\.resultIdentity/g) || []).length, 1); assert.equal((governed.match(/validateJsonResponse\(/g) || []).length, 1); assert.match(governed, /return \{ data: validation\.parsed, runtimeAttestation \};/);
+    const identityHelper = source.slice(source.indexOf('function identifyGovernedResult'), source.indexOf('// Maximum tool iterations')); assert.equal((identityHelper.match(/JSON\.stringify\(/g) || []).length, 1);
   });
 });

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -534,8 +534,23 @@ agent.answerGoverned('x', { schema, resultIdentity: 'probe.governed-result-ident
   });
 
   await t.test('EXP-0152 T10 normalized data is a new host snapshot', async () => {
-    const source = { z: [{ b: 2, a: 1 }] }; const agent = governedAgent(root); installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, JSON.stringify(source)); const result = await agent.answerGoverned('copy', { schema: '{}', invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY });
-    assert.notEqual(result.data, source); assert.notEqual(result.data.z, source.z); assert.deepEqual(result.data, { z: [{ a: 1, b: 2 }] }); source.z[0].a = 9; assert.equal(result.data.z[0].a, 1);
+    const candidate='{"z":[{"b":2,"a":1}]}';
+    const originalJSONParse=JSON.parse;
+    const captures=[];
+    JSON.parse=function (...args) {
+      const parsed=Reflect.apply(originalJSONParse,this,args);
+      if (args[0]===candidate && parsed!==null && typeof parsed==='object') captures.push(parsed);
+      return parsed;
+    };
+    let result;
+    try {
+      const agent = governedAgent(root); installIdentifiedEngine(agent, boundValid.settled.value.runtimeAttestation, candidate); result = await agent.answerGoverned('copy', { schema: '{}', invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY });
+    } finally {
+      JSON.parse=originalJSONParse;
+    }
+    assert.equal(captures.length, 2); const validationParsed=captures.at(-1);
+    assert.notEqual(result.data, validationParsed); assert.notEqual(result.data.z, validationParsed.z); assert.notEqual(result.data.z[0], validationParsed.z[0]);
+    assert.deepEqual(result.data, { z: [{ a: 1, b: 2 }] }); assert.equal(result.data.z[0].a, 1); assert.equal(result.data.z[0].b, 2); assertDeepFrozen(result.data);
   });
 
   await t.test('EXP-0152 T11 receipt and schema failures emit no identity and clean once', async () => {

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
+import { createCodexEngine } from '../../src/agent/engines/codex.js';
+import { buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
+
+const TOOLS = ['search', 'extract', 'listFiles'];
+const fakeCodex = `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+const file = process.env.PROBE_EXP0148_STATE + '/' + process.pid + '.json';
+const seen = []; const save = () => writeFileSync(file, JSON.stringify({ pid: process.pid, seen }));
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const configured = (requestId, args, patch = {}) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
+  _meta: { requestId, threadId: 'session-' + process.pid }, id: '', msg: {
+    type: 'session_configured', session_id: 'session-' + process.pid, thread_id: 'session-' + process.pid,
+    model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
+    permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' },
+    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(process.pid).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
+  }
+}});
+createInterface({ input: process.stdin }).on('line', async line => {
+  const request = JSON.parse(line); seen.push(request); save();
+  if (request.method === 'initialize') return send({ jsonrpc: '2.0', id: request.id, result: {} });
+  const args = request.params.arguments; const prompt = args.prompt;
+  if (prompt.includes('[WAIT]')) return;
+  if (prompt.includes('[EVENT]')) send({ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, msg: { type: 'raw_response_item', item: { role: 'assistant', content: [{ type: 'text', text: 'event-candidate' }] } } } });
+  if (prompt.includes('[DELAY]')) await new Promise(resolve => setTimeout(resolve, 80));
+  let events = [configured(request.id, args)];
+  if (prompt.includes('[MISSING]')) events = [];
+  if (prompt.includes('[DUPLICATE]')) events.push(events[0]);
+  if (prompt.includes('[MALFORMED]')) events = [{ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, id: '', msg: { type: 'session_configured' } } }];
+  if (prompt.includes('[UNCORRELATED]')) events = [configured(999, args)];
+  if (prompt.includes('[MISMATCHED]')) events = [configured(request.id, args, { model: 'wrong' })];
+  for (const event of events) send(event);
+  let text = 'candidate-' + process.pid;
+  if (prompt.includes('[FORBIDDEN]')) {
+    const url = Object.values(args.config.mcp_servers)[0].url.replace('/mcp', '/rpc');
+    const response = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'mcp__probe__bash', arguments: {} } }) });
+    text = (await response.json()).error ? 'host-denied' : 'host-allowed';
+  }
+  send({ jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text }] } });
+});
+`;
+
+function profile(cwd) {
+  return { version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex', model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never', cwd, probeTools: [...TOOLS], fallback: false, retries: 0 };
+}
+async function stateFiles(dir) {
+  return (await readdir(dir)).filter(name => name.endsWith('.json'));
+}
+async function waitForState(dir, before = [], marker = null) {
+  for (let i = 0; i < 100; i++) {
+    const files = (await stateFiles(dir)).filter(name => !before.includes(name));
+    for (const name of files) {
+      const file = join(dir, name);
+      try {
+        const state = await readState(file);
+        if (!marker || state.seen.some(item => item.params?.arguments?.prompt?.includes(marker))) return file;
+      } catch { /* Child may be replacing its state snapshot. */ }
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('fake Codex state timeout');
+}
+async function readState(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+async function collect(iterator) {
+  const output = []; for await (const item of iterator) output.push(item); return output;
+}
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+async function closed(url) {
+  try { await fetch(url.replace('/mcp', '/health'), { signal: AbortSignal.timeout(250) }); return false; } catch { return true; }
+}
+function host() {
+  return { allowedTools: { isEnabled: name => TOOLS.includes(name) }, toolImplementations: Object.fromEntries(TOOLS.map(name => [name, { execute: async () => name }])) };
+}
+async function runEngine(root, stateDir, marker, useProbe = false) {
+  const before = await stateFiles(stateDir); let engine;
+  if (useProbe) {
+    const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+    engine = await agent.getEngine();
+  } else engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+  const output = await collect(engine.query(marker));
+  const state = await readState(await waitForState(stateDir, before, marker));
+  const call = state.seen.find(item => item.method === 'tools/call');
+  const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+  return { engine, output, state, call, url };
+}
+
+test('EXP-0148 governed Codex runtime binding', async t => {
+  const root = await mkdtemp(join(tmpdir(), 'probe-exp0148-'));
+  const bin = join(root, 'bin'); const stateDir = join(root, 'state');
+  await mkdir(bin); await mkdir(stateDir);
+  const executable = join(bin, 'codex'); await writeFile(executable, fakeCodex); await chmod(executable, 0o755);
+  const originalPath = process.env.PATH; process.env.PATH = `${bin}:${originalPath}`; process.env.PROBE_EXP0148_STATE = stateDir;
+  t.after(async () => { process.env.PATH = originalPath; delete process.env.PROBE_EXP0148_STATE; await rm(root, { recursive: true, force: true }); });
+
+  await t.test('rejects non-exact public bindings before spawn', () => {
+    const count = () => stateFiles(stateDir);
+    assert.throws(() => new ProbeAgent({ provider: 'openai', allowedTools: [...TOOLS], governedCodexProfile: profile(root) }), /provider codex/);
+    for (const allowedTools of [undefined, ['*'], ['search', 'listFiles', 'extract'], ['search', 'extract', 'listFiles', 'bash'], ['search', 'extract', 'extract']]) {
+      assert.throws(() => new ProbeAgent({ provider: 'codex', allowedTools, governedCodexProfile: profile(root) }), /exactly match/);
+    }
+    return count().then(files => assert.equal(files.length, 0));
+  });
+
+  await t.test('uses exact C5a request, buffers output, sanitizes receipt, and closes', async () => {
+    const before = await stateFiles(stateDir);
+    const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+    const engine = await agent.getEngine(); const iterator = engine.query('[EVENT][DELAY]');
+    const first = iterator.next(); assert.equal(await Promise.race([first.then(() => 'released'), new Promise(resolve => setTimeout(() => resolve('buffered'), 30))]), 'buffered');
+    const output = [(await first).value]; for await (const item of iterator) output.push(item);
+    const state = await readState(await waitForState(stateDir, before, '[EVENT]')); const call = state.seen.find(item => item.method === 'tools/call');
+    assert.deepEqual(state.seen[0], { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, clientInfo: { name: 'probe-codex-client', version: '1.0.0' } } });
+    assert.equal(call.id, 2); assert.equal(call.params.name, 'codex');
+    const server = Object.entries(call.params.arguments.config.mcp_servers)[0];
+    assert.deepEqual(call.params.arguments, buildGovernedCodexInitialToolArgs({ profile: profile(root), prompt: call.params.arguments.prompt, mcp: { name: server[0], url: server[1].url } }));
+    assert.equal(output.filter(item => item.type === 'text').length, 1); assert.match(output[0].content, /^candidate-/);
+    const receipt = output.find(item => item.type === 'metadata').data.attestation; const serialized = JSON.stringify(receipt);
+    for (const secret of [root, call.params.arguments.prompt, String(state.pid), 'event-candidate', process.env.PATH]) assert.equal(serialized.includes(secret), false);
+    assert.equal(receipt.observed.network, 'restricted'); assert.equal(alive(state.pid), false); assert.equal(await closed(server[1].url), true);
+  });
+
+  await t.test('host rejects a non-allowlisted tool', async () => {
+    const run = await runEngine(root, stateDir, '[FORBIDDEN]');
+    assert.equal(run.output.find(item => item.type === 'text').content, 'host-denied');
+    assert.equal(alive(run.state.pid), false); assert.equal(await closed(run.url), true);
+  });
+
+  await t.test('all bad evidence fails closed with zero candidate bytes', async () => {
+    for (const marker of ['[MISSING]', '[DUPLICATE]', '[MALFORMED]', '[UNCORRELATED]', '[MISMATCHED]']) {
+      const run = await runEngine(root, stateDir, marker);
+      assert.equal(run.output.some(item => item.type === 'text'), false, marker);
+      assert.equal(run.output.filter(item => item.type === 'error').length, 1, marker);
+      assert.equal(alive(run.state.pid), false, marker); assert.equal(await closed(run.url), true, marker);
+    }
+  });
+
+  await t.test('simultaneous agents keep child, session, and MCP state isolated', async () => {
+    const [a, b] = await Promise.all([runEngine(root, stateDir, '[A]', true), runEngine(root, stateDir, '[B]', true)]);
+    assert.notEqual(a.state.pid, b.state.pid); assert.notEqual(a.url, b.url);
+    assert.notEqual(Object.keys(a.call.params.arguments.config.mcp_servers)[0], Object.keys(b.call.params.arguments.config.mcp_servers)[0]);
+    const ra = a.output.find(item => item.type === 'metadata').data.attestation;
+    const rb = b.output.find(item => item.type === 'metadata').data.attestation;
+    assert.deepEqual(ra.requested, rb.requested); assert.equal(alive(a.state.pid) || alive(b.state.pid), false);
+  });
+
+  await t.test('cancellation and explicit close await child and listener cleanup', async () => {
+    for (const action of ['abort', 'close']) {
+      const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+      try {
+        const controller = new AbortController(); const iterator = engine.query('[WAIT]', { abortSignal: controller.signal }); const pending = collect(iterator);
+        const file = await waitForState(stateDir, before, '[WAIT]'); const state = await readState(file); const call = state.seen.find(item => item.method === 'tools/call');
+        const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+        if (action === 'abort') controller.abort(); else await engine.close();
+        const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
+        assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+      } finally { await engine.close(); }
+    }
+  });
+
+  await t.test('omitting the profile preserves the ungoverned result path', async () => {
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), model: 'legacy' });
+    const output = await collect(engine.query('[MISSING]')); const state = await readState(await waitForState(stateDir, before, '[MISSING]'));
+    assert.match(output.find(item => item.type === 'text').content, /^candidate-/); assert.equal(alive(state.pid), true);
+    await engine.close(); assert.equal(alive(state.pid), false);
+  });
+});

--- a/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
+++ b/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
-import { BuiltInMCPServer } from '../../src/agent/mcp/built-in-server.js';
+import MCP, { BuiltInMCPServer } from '@probelabs/probe/agent/mcp';
 
 const call = (server, name, args) => server.handleCallTool({ name: `mcp__probe__${name}`, arguments: args });
 
@@ -18,6 +23,37 @@ function fixture() {
 }
 
 test('EXP-0159 canonical governed tool contracts and progress', async t => {
+  await t.test('public package export is stable for JavaScript and NodeNext TypeScript consumers', () => {
+    assert.equal(BuiltInMCPServer, MCP.BuiltInMCPServer);
+    const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
+    const temp = mkdtempSync(join(tmpdir(), 'probe-exp-0159-types-'));
+    try {
+      const packageLink = join(temp, 'node_modules', '@probelabs', 'probe');
+      mkdirSync(dirname(packageLink), { recursive: true });
+      symlinkSync(packageRoot, packageLink, 'dir');
+      writeFileSync(join(temp, 'package.json'), JSON.stringify({ type: 'module' }));
+      writeFileSync(join(temp, 'consumer.ts'), `
+        import MCP, { BuiltInMCPServer, MCPClientManager, MCPXmlBridge } from '@probelabs/probe/agent/mcp';
+        import type { ProbeAgent } from '@probelabs/probe/agent';
+        declare const agent: ProbeAgent;
+        const server = new BuiltInMCPServer(agent, { port: 0, debug: false });
+        const same: typeof BuiltInMCPServer = MCP.BuiltInMCPServer;
+        void same; void server.start(); void server.stop(); void server.handleListTools();
+        void server.handleCallTool({ name: 'mcp__probe__search', arguments: { query: 'x' } });
+        const count: number = server.getToolCount(); const url: string = server.getConfig().url;
+        void count; void url; new MCPClientManager(); new MCPXmlBridge();
+      `);
+      writeFileSync(join(temp, 'tsconfig.json'), JSON.stringify({ compilerOptions: {
+        target: 'ES2022', module: 'NodeNext', moduleResolution: 'NodeNext', strict: true,
+        noEmit: true, skipLibCheck: true
+      }, files: ['consumer.ts'] }));
+      const compile = spawnSync(process.execPath, [join(packageRoot, 'node_modules', 'typescript', 'bin', 'tsc'), '-p', join(temp, 'tsconfig.json')], { encoding: 'utf8' });
+      assert.equal(compile.status, 0, `${compile.stdout}${compile.stderr}`);
+    } finally {
+      rmSync(temp, { recursive: true, force: true });
+    }
+  });
+
   await t.test('tools/list describes the inputs direct implementations accept', async () => {
     const { server } = fixture();
     const listed = await server.handleListTools();
@@ -93,10 +129,11 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
     let entered;
     const started = new Promise(resolve => { entered = resolve; });
     // This is cooperative AbortSignal handling; arbitrary binary termination requires external containment.
-    agent.toolImplementations.search.execute = () => new Promise((resolve, reject) => {
+    agent.toolImplementations.search.execute = ({ abortSignal }) => new Promise((resolve, reject) => {
       active = true;
       entered();
-      agent._abortController.signal.addEventListener('abort', () => { active = false; reject(new Error('controlled child cancelled')); }, { once: true });
+      assert.equal(abortSignal, agent.abortSignal);
+      abortSignal.addEventListener('abort', () => { active = false; reject(new Error('controlled child cancelled')); }, { once: true });
     });
     const events = [];
     agent.events.on('toolCall', event => events.push(event));

--- a/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
+++ b/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -34,8 +35,11 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
       writeFileSync(join(temp, 'package.json'), JSON.stringify({ type: 'module' }));
       writeFileSync(join(temp, 'consumer.ts'), `
         import MCP, { BuiltInMCPServer, MCPClientManager, MCPXmlBridge } from '@probelabs/probe/agent/mcp';
+        import type RootProbeAgent from '@probelabs/probe';
+        import type AgentProbeAgent from '@probelabs/probe/agent';
         import type { ProbeAgent } from '@probelabs/probe/agent';
-        declare const agent: ProbeAgent;
+        declare const agent: ProbeAgent; declare const rootAgent: RootProbeAgent; declare const subpathAgent: AgentProbeAgent;
+        const signals: AbortSignal[] = [agent.abortSignal, rootAgent.abortSignal, subpathAgent.abortSignal]; void signals;
         const server = new BuiltInMCPServer(agent, { port: 0, debug: false });
         const same: typeof BuiltInMCPServer = MCP.BuiltInMCPServer;
         void same; void server.start(); void server.stop(); void server.handleListTools();
@@ -124,27 +128,24 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
   });
 
   await t.test('cooperative cancellation settles the call and close bookkeeping', async () => {
-    const { agent, server, lifecycle } = fixture();
-    let active = false;
-    let entered;
-    const started = new Promise(resolve => { entered = resolve; });
+    const controller = new AbortController(), events = new EventEmitter();
+    let entered = 0, observedSignal, closes = 0, markEntered;
+    const started = new Promise(resolve => { markEntered = resolve; });
+    const agent = { allowedTools: { isEnabled: name => name === 'search' }, toolImplementations: { search: {} }, events, sessionId: 'public-facade', cwd: process.cwd(),
+      get abortSignal() { return controller.signal; }, cancel() { controller.abort(); }, async close() { closes++; await server.stop(); } };
+    const server = new BuiltInMCPServer(agent);
+    assert.equal('_abortController' in agent, false);
     // This is cooperative AbortSignal handling; arbitrary binary termination requires external containment.
     agent.toolImplementations.search.execute = ({ abortSignal }) => new Promise((resolve, reject) => {
-      active = true;
-      entered();
-      assert.equal(abortSignal, agent.abortSignal);
-      abortSignal.addEventListener('abort', () => { active = false; reject(new Error('controlled child cancelled')); }, { once: true });
+      entered++; observedSignal = abortSignal; markEntered();
+      abortSignal.addEventListener('abort', () => reject(new Error('controlled child cancelled')), { once: true });
     });
-    const events = [];
-    agent.events.on('toolCall', event => events.push(event));
+    const progress = []; agent.events.on('toolCall', event => progress.push(event));
     const pending = call(server, 'search', { query: 'wait' });
-    await started;
-    agent.cancel();
-    const result = await pending;
-    await agent.close();
+    await started; assert.equal(entered, 1); assert.equal(observedSignal, agent.abortSignal); agent.cancel();
+    const result = await pending; await agent.close();
     assert.equal(result.isError, true);
-    assert.equal(active, false);
-    assert.equal(lifecycle.closes, 1);
-    assert.deepEqual(events.map(event => event.status), ['in_progress', 'failed']);
+    assert.equal(closes, 1);
+    assert.deepEqual(progress.map(event => event.status), ['in_progress', 'failed']);
   });
 });

--- a/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
+++ b/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
@@ -1,0 +1,113 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
+import { BuiltInMCPServer } from '../../src/agent/mcp/built-in-server.js';
+
+const call = (server, name, args) => server.handleCallTool({ name: `mcp__probe__${name}`, arguments: args });
+
+function fixture() {
+  const agent = new ProbeAgent({ allowedTools: ['search', 'extract', 'listFiles'], sessionId: 'exp-0159-session', cwd: process.cwd() });
+  const server = new BuiltInMCPServer(agent);
+  const calls = [];
+  const lifecycle = { closes: 0 };
+  for (const name of ['search', 'extract', 'listFiles']) {
+    agent.toolImplementations[name] = { execute: async params => { calls.push({ name, params }); return `${name}-ok`; } };
+  }
+  agent.engine = { close: async () => { lifecycle.closes++; await server.stop(); } };
+  return { agent, server, calls, lifecycle };
+}
+
+test('EXP-0159 canonical governed tool contracts and progress', async t => {
+  await t.test('tools/list describes the inputs direct implementations accept', async () => {
+    const { server } = fixture();
+    const listed = await server.handleListTools();
+    const schemas = Object.fromEntries(listed.tools.map(tool => [tool.name, tool.inputSchema]));
+    assert.deepEqual(Object.keys(schemas.mcp__probe__search.properties), ['query', 'path', 'exact', 'maxTokens', 'session', 'nextPage']);
+    assert.deepEqual(schemas.mcp__probe__search.required, ['query']);
+    assert.deepEqual(Object.keys(schemas.mcp__probe__extract.properties), ['targets', 'input_content', 'allow_tests']);
+    assert.deepEqual(Object.keys(schemas.mcp__probe__listFiles.properties), ['directory']);
+    assert.equal(schemas.mcp__probe__listFiles.required, undefined);
+  });
+
+  await t.test('canonical calls emit paired public lifecycle without result bodies', async () => {
+    const { agent, server, calls } = fixture();
+    const events = [];
+    agent.events.on('toolCall', event => events.push(event));
+    for (const [name, args] of [['search', { query: 'governed', maxTokens: 50 }], ['extract', { targets: 'src/main.rs' }], ['listFiles', { directory: '.' }]]) {
+      const result = await call(server, name, args);
+      assert.equal(result.isError, undefined);
+    }
+    assert.equal(calls.length, 3);
+    assert.deepEqual(events.map(({ name, status }) => [name, status]), [
+      ['search', 'in_progress'], ['search', 'completed'],
+      ['extract', 'in_progress'], ['extract', 'completed'],
+      ['listFiles', 'in_progress'], ['listFiles', 'completed']
+    ]);
+    for (let i = 0; i < events.length; i += 2) {
+      assert.equal(events[i].id, events[i + 1].id);
+      assert.equal(events[i].sessionId, 'exp-0159-session');
+      assert.equal(events[i + 1].sessionId, 'exp-0159-session');
+      assert.equal(typeof events[i + 1].duration, 'number');
+      for (const key of ['params', 'args', 'result', 'resultPreview', 'preview', 'body']) {
+        assert.equal(Object.prototype.hasOwnProperty.call(events[i], key), false);
+        assert.equal(Object.prototype.hasOwnProperty.call(events[i + 1], key), false);
+      }
+    }
+  });
+
+  await t.test('malformed and unknown shapes fail before execution', async () => {
+    const { server, calls } = fixture();
+    assert.equal((await call(server, 'search', { query: 7 })).isError, true);
+    assert.equal((await call(server, 'extract', { path: 'wrong-shape' })).isError, true);
+    assert.equal((await call(server, 'listFiles', { directory: '.', surprise: true })).isError, true);
+    assert.equal((await call(server, 'search', { query: 'x', constructor: 'owned' })).isError, true);
+    assert.equal((await call(server, 'search', { query: 'x', toString: 'owned' })).isError, true);
+    await assert.rejects(call(server, 'unknown', {}), /not enabled|not found/);
+    assert.equal(calls.length, 0);
+  });
+
+  await t.test('listener errors fail closed before tool execution', async () => {
+    const { agent, server, calls } = fixture();
+    const observed = [];
+    agent.events.on('toolCall', event => { if (event.status === 'in_progress') throw new Error('observer refused call'); });
+    agent.events.on('toolCall', event => observed.push(event.status));
+    const result = await call(server, 'search', { query: 'blocked' });
+    assert.equal(result.isError, true);
+    assert.match(result.content[0].text, /observer refused call/);
+    assert.deepEqual(observed, ['failed']);
+    assert.equal(calls.length, 0);
+  });
+
+  await t.test('completion observer failure cannot reclassify successful execution', async () => {
+    const { agent, server, calls } = fixture();
+    agent.events.on('toolCall', event => { if (event.status === 'completed') throw new Error('late observer failure'); });
+    const result = await call(server, 'search', { query: 'done' });
+    assert.equal(result.isError, undefined);
+    assert.equal(result.content[0].text, 'search-ok');
+    assert.equal(calls.length, 1);
+  });
+
+  await t.test('cooperative cancellation settles the call and close bookkeeping', async () => {
+    const { agent, server, lifecycle } = fixture();
+    let active = false;
+    let entered;
+    const started = new Promise(resolve => { entered = resolve; });
+    // This is cooperative AbortSignal handling; arbitrary binary termination requires external containment.
+    agent.toolImplementations.search.execute = () => new Promise((resolve, reject) => {
+      active = true;
+      entered();
+      agent._abortController.signal.addEventListener('abort', () => { active = false; reject(new Error('controlled child cancelled')); }, { once: true });
+    });
+    const events = [];
+    agent.events.on('toolCall', event => events.push(event));
+    const pending = call(server, 'search', { query: 'wait' });
+    await started;
+    agent.cancel();
+    const result = await pending;
+    await agent.close();
+    assert.equal(result.isError, true);
+    assert.equal(active, false);
+    assert.equal(lifecycle.closes, 1);
+    assert.deepEqual(events.map(event => event.status), ['in_progress', 'failed']);
+  });
+});

--- a/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
+++ b/npm/tests/unit/governed-tool-contract-progress.exp-0159.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -10,6 +11,11 @@ import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 import MCP, { BuiltInMCPServer } from '@probelabs/probe/agent/mcp';
 
 const call = (server, name, args) => server.handleCallTool({ name: `mcp__probe__${name}`, arguments: args });
+const framedDigest = payload => {
+  const domain = Buffer.from('reqproof.probe.tool-arguments/v1'), body = Buffer.from(payload);
+  const length = value => { const bytes = Buffer.alloc(8); bytes.writeBigUInt64BE(BigInt(value.length)); return bytes; };
+  return `sha256:${createHash('sha256').update(length(domain)).update(domain).update(length(body)).update(body).digest('hex')}`;
+};
 
 function fixture() {
   const agent = new ProbeAgent({ allowedTools: ['search', 'extract', 'listFiles'], sessionId: 'exp-0159-session', cwd: process.cwd() });
@@ -40,6 +46,7 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
         import type { ProbeAgent } from '@probelabs/probe/agent';
         declare const agent: ProbeAgent; declare const rootAgent: RootProbeAgent; declare const subpathAgent: AgentProbeAgent;
         const signals: AbortSignal[] = [agent.abortSignal, rootAgent.abortSignal, subpathAgent.abortSignal]; void signals;
+        declare const event: import('@probelabs/probe').ToolCallEvent; const digest: string | undefined = event.argumentsDigest; void digest;
         const server = new BuiltInMCPServer(agent, { port: 0, debug: false });
         const same: typeof BuiltInMCPServer = MCP.BuiltInMCPServer;
         void same; void server.start(); void server.stop(); void server.handleListTools();
@@ -88,11 +95,75 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
       assert.equal(events[i].sessionId, 'exp-0159-session');
       assert.equal(events[i + 1].sessionId, 'exp-0159-session');
       assert.equal(typeof events[i + 1].duration, 'number');
-      for (const key of ['params', 'args', 'result', 'resultPreview', 'preview', 'body']) {
+      assert.match(events[i].argumentsDigest, /^sha256:[0-9a-f]{64}$/);
+      assert.equal(events[i].argumentsDigest, events[i + 1].argumentsDigest);
+      for (const key of ['params', 'args', 'arguments', 'result', 'resultPreview', 'preview', 'body', 'source']) {
         assert.equal(Object.prototype.hasOwnProperty.call(events[i], key), false);
         assert.equal(Object.prototype.hasOwnProperty.call(events[i + 1], key), false);
       }
     }
+  });
+
+  await t.test('digest binds canonical validated arguments, defaults, framing, and number rules', async () => {
+    const { agent, server } = fixture();
+    const events = []; agent.events.on('toolCall', event => events.push(event));
+    await call(server, 'extract', { targets: 'http.go http_test.go' });
+    await call(server, 'extract', { allow_tests: true, targets: 'http.go http_test.go' });
+    await call(server, 'extract', { targets: 'http.go http_test.go', allow_tests: false });
+    await call(server, 'search', { maxTokens: -0, query: 'ordered' });
+    await call(server, 'search', { query: 'ordered', maxTokens: 0 });
+    const digests = events.filter(event => event.status === 'in_progress').map(event => event.argumentsDigest);
+    const payload = '{"allow_tests":true,"targets":"http.go http_test.go"}';
+    assert.equal(digests[0], framedDigest(payload));
+    assert.equal(digests[0], digests[1]);
+    assert.notEqual(digests[1], digests[2]);
+    assert.equal(digests[3], digests[4]);
+    assert.notEqual(digests[0], `sha256:${createHash('sha256').update(Buffer.from(payload)).digest('hex')}`);
+    const nullRecord = Object.assign(Object.create(null), { targets: 'http.go http_test.go' });
+    await call(server, 'extract', nullRecord);
+    assert.equal(events.at(-2).argumentsDigest, digests[0]);
+  });
+
+  await t.test('invalid values and containers fail before lifecycle without leaking details', async () => {
+    const { agent, server, calls } = fixture();
+    const events = []; agent.events.on('toolCall', event => events.push(event));
+    const accessor = {}; Object.defineProperty(accessor, 'query', { enumerable: true, get() { throw new Error('ACCESSOR_SECRET'); } });
+    const hidden = { query: 'safe' }; Object.defineProperty(hidden, 'HIDDEN_SECRET', { value: true });
+    const symbolKey = { query: 'safe', [Symbol('SYMBOL_SECRET')]: true };
+    const exotic = Object.assign(Object.create({ EXOTIC_SECRET: true }), { query: 'safe' });
+    const hook = { query: 'safe', toJSON() { return 'HOOK_SECRET'; } };
+    const trapped = new Proxy({ query: 'safe' }, { ownKeys() { throw new Error('PROXY_SECRET'); } });
+    const cycle = { query: 'safe' }; cycle.self = cycle;
+    const hole = []; hole.length = 1;
+    const extra = ['safe']; extra.extra = true;
+    const containerCases = [null, [], accessor, hidden, symbolKey, exotic, hook, trapped, cycle, { query: hole }, { query: extra }];
+    for (const args of containerCases) {
+      const result = await call(server, 'search', args);
+      assert.equal(result.isError, true);
+      assert.equal(result.content[0].text, 'Error executing mcp__probe__search: TOOL_ARGUMENT_CONTAINER_INVALID');
+    }
+    const invalidCases = [undefined, 1n, () => {}, Symbol('VALUE_SECRET'), NaN, Infinity];
+    for (const query of invalidCases) {
+      const result = await call(server, 'search', { query });
+      assert.equal(result.isError, true);
+      assert.equal(result.content[0].text, 'Error executing mcp__probe__search: TOOL_ARGUMENT_VALIDATION_FAILED');
+    }
+    assert.equal(calls.length, 0); assert.deepEqual(events, []);
+    const diagnostics = containerCases.length + invalidCases.length;
+    assert.equal(diagnostics, 17);
+  });
+
+  await t.test('failed lifecycle exposes one stable code and retains its digest', async () => {
+    const { agent, server, calls } = fixture();
+    agent.toolImplementations.search.execute = async () => { throw new Error('EXECUTION_SECRET'); };
+    const events = []; agent.events.on('toolCall', event => events.push(event));
+    const result = await call(server, 'search', { query: 'ARGUMENT_SECRET' });
+    assert.equal(result.isError, true); assert.equal(calls.length, 0);
+    assert.deepEqual(events.map(event => event.status), ['in_progress', 'failed']);
+    assert.equal(events[0].argumentsDigest, events[1].argumentsDigest);
+    assert.equal(events[1].error, 'TOOL_EXECUTION_FAILED');
+    const publicTrace = JSON.stringify(events);
+    for (const secret of ['ARGUMENT_SECRET', 'EXECUTION_SECRET']) assert.equal(publicTrace.includes(secret), false);
   });
 
   await t.test('malformed and unknown shapes fail before execution', async () => {
@@ -147,5 +218,7 @@ test('EXP-0159 canonical governed tool contracts and progress', async t => {
     assert.equal(result.isError, true);
     assert.equal(closes, 1);
     assert.deepEqual(progress.map(event => event.status), ['in_progress', 'failed']);
+    assert.equal(progress[0].argumentsDigest, progress[1].argumentsDigest);
+    assert.equal(progress[1].error, 'TOOL_EXECUTION_FAILED');
   });
 });


### PR DESCRIPTION
Consolidates the governed Codex/Luna execution chain on the canonical Probe product branch.

Scope:
- governed Luna profile and Codex runtime lifecycle
- typed answer contract
- dispatch binding and requested/observed result identity
- canonical governed MCP tool schemas shared by discovery and execution
- privacy-bounded typed tool start/terminal progress events
- public `@probelabs/probe/agent/mcp` `BuiltInMCPServer` export with adjacent NodeNext declarations
- public readonly `ProbeAgent.abortSignal` used by governed MCP tools with no private-controller fallback
- privacy-safe SHA-256 digests of schema-validated governed tool arguments across lifecycle events, without raw argument or result exposure

Evidence:
- constituent zero-model focused tests passed for the governed profile, runtime/answer, MCP, and P0 tool-contract/progress slices
- P0 recorded 7/7 focused progress, 7/7 profile, 48/48 governed answer, and 22/22 governed MCP tests
- the public MCP export slice passed its focused native 8/8 test, including package self-reference and NodeNext consumer compilation
- the public-only facade cancellation contract passed focused native 8/8, including root and agent NodeNext consumers, exact signal injection, failed progress, and awaited close
- the validated-argument digest slice passed focused native 11/11, including canonical framing/default behavior, lifecycle privacy, failure containment, cancellation, public package use, and NodeNext consumer compilation
- this evidence remains provisional at the consolidated head; full consolidated tests are still pending

This PR remains a draft and does not claim production admission.

North-star program: https://github.com/probelabs/reqproof/pull/1035