### PR TITLE
EXP-0148: bind governed Codex runtime

### DIFF
--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -24,7 +24,7 @@ export interface ProbeAgentOptions {
   /** Working directory for resolving relative paths (independent of allowedFolders security) */
   cwd?: string;
   /** Force specific AI provider */
-  provider?: 'anthropic' | 'openai' | 'google';
+  provider?: 'anthropic' | 'openai' | 'google' | 'codex';
   /** Override model name */
   model?: string;
   /** Enable debug mode */
@@ -45,6 +45,11 @@ export interface ProbeAgentOptions {
   hooks?: Record<string, (data: any) => void | Promise<void>>;
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
+  /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
+  governedCodexProfile?: {
+    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
+    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
+  };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Disable automatic mermaid diagram validation and fixing */
@@ -334,6 +339,8 @@ export declare class ProbeAgent {
    * Cancel any ongoing operations
    */
   cancel(): void;
+
+  /** Close engine subprocess and MCP resources. */ close(): Promise<void>;
 
   /**
    * Clear the conversation history

--- a/npm/index.d.ts
+++ b/npm/index.d.ts
@@ -46,10 +46,7 @@ export interface ProbeAgentOptions {
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
   /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
-  governedCodexProfile?: {
-    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
-    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
-  };
+  governedCodexProfile?: { version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0; };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Disable automatic mermaid diagram validation and fixing */

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -63,7 +63,7 @@ export interface ProbeAgentOptions {
   /** Use a delegated code-search subagent for the search tool (default: true) */
   searchDelegate?: boolean;
   /** Force specific AI provider */
-  provider?: 'anthropic' | 'openai' | 'google' | 'bedrock';
+  provider?: 'anthropic' | 'openai' | 'google' | 'bedrock' | 'codex';
   /** Override model name */
   model?: string;
   /** Enable debug mode */
@@ -80,6 +80,11 @@ export interface ProbeAgentOptions {
   mcpServers?: any[];
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
+  /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
+  governedCodexProfile?: {
+    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
+    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
+  };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Retry configuration for handling transient API failures */
@@ -307,6 +312,8 @@ export declare class ProbeAgent {
    * Cancel any ongoing operations
    */
   cancel(): void;
+
+  /** Close engine subprocess and MCP resources. */ close(): Promise<void>;
 
   /**
    * Clear the conversation history

--- a/npm/src/agent/ProbeAgent.d.ts
+++ b/npm/src/agent/ProbeAgent.d.ts
@@ -81,10 +81,7 @@ export interface ProbeAgentOptions {
   /** List of allowed tool names. Use ['*'] for all tools (default), [] or null for no tools (raw AI mode), or specific tool names like ['search', 'query', 'extract']. Supports exclusion with '!' prefix (e.g., ['*', '!bash']). */
   allowedTools?: string[] | null;
   /** Attested, fail-closed Codex runtime profile. Requires provider codex and an exact allowedTools match. */
-  governedCodexProfile?: {
-    version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna';
-    reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0;
-  };
+  governedCodexProfile?: { version: 'probe.governed-codex-profile/v1'; profileId: 'luna-xhigh-readonly-v1'; engine: 'codex'; model: 'gpt-5.6-luna'; reasoningEffort: 'xhigh'; sandbox: 'read-only'; approvalPolicy: 'never'; cwd: string; probeTools: ['search', 'extract', 'listFiles']; fallback: false; retries: 0; };
   /** Convenience flag to disable all tools (equivalent to allowedTools: []). Takes precedence over allowedTools if set. */
   disableTools?: boolean;
   /** Retry configuration for handling transient API failures */

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -324,11 +324,8 @@ export class ProbeAgent {
     this.thinkingEffort = options.thinkingEffort || null;
 
     if (options.governedCodexProfile !== undefined) {
-      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex');
-      const profile = validateGovernedCodexProfile(options.governedCodexProfile);
-      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) {
-        throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
-      }
+      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex'); const profile = validateGovernedCodexProfile(options.governedCodexProfile);
+      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
       this.governedCodexProfile = profile;
     }
 
@@ -3656,14 +3653,14 @@ Follow these instructions carefully:
         }
 
         // Send the message directly to Codex and collect the response
-        try {
-          const engine = await this.getEngine();
+        let engine; try {
+          engine = await this.getEngine();
           if (engine && engine.query) {
             let assistantResponseContent = '';
             let toolBatch = null;
 
             // Query Codex directly with the message and schema
-            for await (const chunk of engine.query(message, options)) {
+            for await (const chunk of engine.query(message, this.governedCodexProfile ? { ...options, abortSignal: this._abortController.signal } : options)) {
               if (chunk.type === 'text' && chunk.content) {
                 assistantResponseContent += chunk.content;
                 if (options.onStream) {
@@ -3715,7 +3712,7 @@ Follow these instructions carefully:
             console.error('[DEBUG] Codex error:', error);
           }
           throw error;
-        }
+        } finally { if (this.governedCodexProfile && engine) await engine.close(); }
       }
 
       if (this.debug) {
@@ -5671,6 +5668,8 @@ Double-check your response based on the criteria above. If everything looks good
     if (!this._abortController.signal.aborted) {
       this._abortController.abort();
     }
+
+    if (this.governedCodexProfile && this.engine?.close) await this.engine.close();
 
     // Clean up MCP bridge
     if (this.mcpBridge) {

--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -106,6 +106,7 @@ import {
   createTaskCompletionBlockedMessage
 } from './tasks/index.js';
 import { z } from 'zod';
+import { validateGovernedCodexProfile } from './engines/governed-codex-profile.js';
 
 // Maximum tool iterations to prevent infinite loops - configurable via MAX_TOOL_ITERATIONS env var
 const MAX_TOOL_ITERATIONS = (() => {
@@ -321,6 +322,15 @@ export class ProbeAgent {
     // Native thinking/reasoning effort for LLM providers
     // Accepted values: 'off' (default), 'low', 'medium', 'high', or a number (budget tokens)
     this.thinkingEffort = options.thinkingEffort || null;
+
+    if (options.governedCodexProfile !== undefined) {
+      if (options.provider !== 'codex') throw new TypeError('governedCodexProfile requires provider codex');
+      const profile = validateGovernedCodexProfile(options.governedCodexProfile);
+      if (options.disableTools || !Array.isArray(options.allowedTools) || options.allowedTools.length !== profile.probeTools.length || options.allowedTools.some((tool, index) => tool !== profile.probeTools[index])) {
+        throw new TypeError('allowedTools must exactly match governedCodexProfile.probeTools');
+      }
+      this.governedCodexProfile = profile;
+    }
 
     // Tool filtering configuration
     // Parse allowedTools option: ['*'] = all tools, [] or null = no tools, ['tool1', 'tool2'] = specific tools
@@ -1752,6 +1762,7 @@ export class ProbeAgent {
             result = ProbeAgent._wrapEngineStreamWithLimiter(result, limiter, this.debug);
           }
         } catch (error) {
+          if (this.governedCodexProfile) throw error;
           if (this.debug) {
             const engineType = useClaudeCode ? 'Claude Code' : 'Codex';
             console.log(`[DEBUG] Failed to use ${engineType} engine, falling back to Vercel:`, error.message);
@@ -2424,7 +2435,8 @@ export class ProbeAgent {
           sessionId: this.options?.sessionId,
           debug: this.debug,
           allowedTools: this.allowedTools,  // Pass tool filtering configuration
-          model: this.model  // Pass model name (e.g., gpt-5.2, o3, etc.)
+          model: this.model,  // Pass model name (e.g., gpt-5.2, o3, etc.)
+          governedCodexProfile: this.governedCodexProfile
         });
         if (this.debug) {
           console.log('[DEBUG] Using Codex CLI engine with Probe tools');
@@ -2434,6 +2446,7 @@ export class ProbeAgent {
         }
         return this.engine;
       } catch (error) {
+        if (this.governedCodexProfile) throw error;
         console.warn('[WARNING] Failed to load Codex CLI engine:', error.message);
         console.warn('[WARNING] Falling back to Vercel AI SDK');
         this.clientApiProvider = null;

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -8,12 +8,14 @@ import { randomBytes } from 'crypto';
 import { createInterface } from 'readline';
 import { BuiltInMCPServer } from '../mcp/built-in-server.js';
 import { Session } from '../shared/Session.js';
+import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs, validateGovernedCodexProfile } from './governed-codex-profile.js';
 
 /**
  * Codex Engine using MCP Server with event streaming
  */
 export async function createCodexEngine(options = {}) {
   const { agent, systemPrompt, customPrompt, debug, sessionId, allowedTools, model } = options;
+  const governedProfile = options.governedCodexProfile === undefined ? null : validateGovernedCodexProfile(options.governedCodexProfile);
 
   const session = new Session(
     sessionId || randomBytes(8).toString('hex'),
@@ -55,6 +57,8 @@ export async function createCodexEngine(options = {}) {
   let requestId = 0;
   const pendingRequests = new Map();
   const eventHandlers = new Map();
+  let governedEvidenceHandler = null, governedQueryStarted = false, closePromise = null;
+  const processClosed = new Promise((resolve) => codexProcess.once('close', resolve));
 
   // Read stdout line by line
   const stdoutReader = createInterface({
@@ -74,8 +78,9 @@ export async function createCodexEngine(options = {}) {
 
       // Handle responses to our requests
       if (message.id !== undefined && pendingRequests.has(message.id)) {
-        const { resolve, reject } = pendingRequests.get(message.id);
+        const { resolve, reject, timer } = pendingRequests.get(message.id);
         pendingRequests.delete(message.id);
+        clearTimeout(timer);
 
         if (message.error) {
           reject(new Error(message.error.message || JSON.stringify(message.error)));
@@ -86,6 +91,7 @@ export async function createCodexEngine(options = {}) {
 
       // Handle notifications (codex/event)
       if (message.method === 'codex/event' && message.params) {
+        if (governedEvidenceHandler && message.params.msg?.type === 'session_configured') governedEvidenceHandler(message);
         const requestId = message.params._meta?.requestId;
         if (requestId !== undefined && eventHandlers.has(requestId)) {
           eventHandlers.get(requestId)(message.params);
@@ -98,6 +104,8 @@ export async function createCodexEngine(options = {}) {
     }
   });
 
+  codexProcess.once('error', (error) => rejectPending(error)); codexProcess.once('close', () => rejectPending(new Error('Codex process closed')));
+
   // Handle stderr
   if (debug) {
     codexProcess.stderr.on('data', (data) => {
@@ -108,6 +116,7 @@ export async function createCodexEngine(options = {}) {
   // Send JSON-RPC request
   function sendRequest(method, params = {}) {
     return new Promise((resolve, reject) => {
+      if (closePromise) return reject(new Error('Codex engine is closed'));
       const id = ++requestId;
       const request = {
         jsonrpc: '2.0',
@@ -116,29 +125,45 @@ export async function createCodexEngine(options = {}) {
         params
       };
 
-      pendingRequests.set(id, { resolve, reject });
-
       // Timeout after 10 minutes
-      setTimeout(() => {
+      const timer = setTimeout(() => {
         if (pendingRequests.has(id)) {
           pendingRequests.delete(id);
           reject(new Error(`Request ${method} timed out after 10 minutes`));
         }
       }, 600000);
+      pendingRequests.set(id, { resolve, reject, timer });
 
       codexProcess.stdin.write(JSON.stringify(request) + '\n');
     });
   }
 
+  function rejectPending(error) {
+    for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); }
+    pendingRequests.clear();
+  }
+
+  async function cleanup(reason = new Error('Codex engine closed')) {
+    if (closePromise) return closePromise;
+    closePromise = (async () => {
+      rejectPending(reason);
+      eventHandlers.clear(); governedEvidenceHandler = null;
+      stdoutReader.close();
+      codexProcess.stdin.destroy();
+      if (codexProcess.exitCode === null && !codexProcess.killed) codexProcess.kill();
+      await processClosed;
+      if (mcpServer) await mcpServer.stop();
+    })();
+    return closePromise;
+  }
+
   // Initialize MCP connection
-  await sendRequest('initialize', {
-    protocolVersion: '2024-11-05',
-    capabilities: { tools: {} },
-    clientInfo: {
-      name: 'probe-codex-client',
-      version: '1.0.0'
-    }
-  });
+  try {
+    await sendRequest('initialize', {
+      protocolVersion: '2024-11-05', capabilities: { tools: {} },
+      clientInfo: { name: 'probe-codex-client', version: '1.0.0' }
+    });
+  } catch (error) { await cleanup(error); throw error; }
 
   if (debug) {
     console.log('[DEBUG] Connected to Codex MCP server');
@@ -164,8 +189,9 @@ export async function createCodexEngine(options = {}) {
       const isFollowUp = session.conversationId !== null;
       const toolName = isFollowUp ? 'codex-reply' : 'codex';
 
-      // Build arguments
-      const toolArgs = { prompt: finalPrompt };
+      try {
+        // Build arguments
+        let toolArgs = { prompt: finalPrompt };
 
       if (isFollowUp) {
         toolArgs.conversationId = session.conversationId;
@@ -173,10 +199,16 @@ export async function createCodexEngine(options = {}) {
           console.log(`[DEBUG] Follow-up with conversationId: ${session.conversationId}`);
         }
       } else {
-        if (model) {
+        if (governedProfile) {
+          if (governedQueryStarted) throw new Error('Governed Codex engine permits one initial query');
+          governedQueryStarted = true;
+          toolArgs = buildGovernedCodexInitialToolArgs({
+            profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl }
+          });
+        } else if (model) {
           toolArgs.model = model;
         }
-        if (mcpServerUrl && mcpServerName) {
+        if (!governedProfile && mcpServerUrl && mcpServerName) {
           toolArgs.config = {
             mcp_servers: {
               [mcpServerName]: { url: mcpServerUrl }
@@ -188,40 +220,39 @@ export async function createCodexEngine(options = {}) {
         }
       }
 
-      try {
         const reqId = requestId + 1;
         let fullResponse = '';
         let gotSessionId = false;
+        const evidence = [];
+        if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
+        let abortHandler;
+        if (opts.abortSignal) {
+          if (opts.abortSignal.aborted) throw new Error('Codex query cancelled');
+          abortHandler = () => cleanup(new Error('Codex query cancelled'));
+          opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
+        }
 
         // Register event handler for this request
-        const eventPromise = new Promise((resolve) => {
-          eventHandlers.set(reqId, (eventParams) => {
-            const msg = eventParams.msg;
+        eventHandlers.set(reqId, (eventParams) => {
+          const msg = eventParams.msg;
 
-            // Extract session_id from session_configured event
-            if (msg.type === 'session_configured' && msg.session_id && !gotSessionId) {
-              session.setConversationId(msg.session_id);
-              gotSessionId = true;
-            }
+          // Extract session_id from session_configured event
+          if (!governedProfile && msg.type === 'session_configured' && msg.session_id && !gotSessionId) {
+            session.setConversationId(msg.session_id);
+            gotSessionId = true;
+          }
 
-            // Collect agent messages
-            if (msg.type === 'raw_response_item' && msg.item?.role === 'assistant') {
-              const content = msg.item.content;
-              if (Array.isArray(content)) {
-                for (const part of content) {
-                  if (part.type === 'text' && part.text) {
-                    fullResponse += part.text;
-                  }
+          // Collect agent messages
+          if (msg.type === 'raw_response_item' && msg.item?.role === 'assistant') {
+            const content = msg.item.content;
+            if (Array.isArray(content)) {
+              for (const part of content) {
+                if (part.type === 'text' && part.text) {
+                  fullResponse += part.text;
                 }
               }
             }
-          });
-
-          // Mark as resolved when we're done
-          setTimeout(() => {
-            eventHandlers.delete(reqId);
-            resolve();
-          }, 600000); // 10 min timeout
+          }
         });
 
         // Call the tool
@@ -235,6 +266,12 @@ export async function createCodexEngine(options = {}) {
 
         // Clean up event handler
         eventHandlers.delete(reqId);
+        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
+        let attestation = null;
+        if (governedProfile) {
+          attestation = attestGovernedCodexSession({ profile: governedProfile, events: evidence });
+          session.setConversationId(evidence[0].params.msg.session_id);
+        }
 
         // Parse result
         if (result && result.content && Array.isArray(result.content)) {
@@ -261,7 +298,7 @@ export async function createCodexEngine(options = {}) {
 
         yield {
           type: 'metadata',
-          data: {
+          data: governedProfile ? { attestation } : {
             sessionId: session.id,
             conversationId: session.conversationId,
             messageCount: session.messageCount
@@ -276,6 +313,8 @@ export async function createCodexEngine(options = {}) {
           type: 'error',
           error: error
         };
+      } finally {
+        if (governedProfile) await cleanup();
       }
     },
 
@@ -290,43 +329,7 @@ export async function createCodexEngine(options = {}) {
      * Clean up resources
      */
     async close() {
-      try {
-        // Close readline interface first to remove event listeners
-        if (stdoutReader) {
-          stdoutReader.close();
-          if (debug) {
-            console.log('[DEBUG] Closed stdout reader');
-          }
-        }
-
-        // Clear all pending requests and event handlers
-        pendingRequests.clear();
-        eventHandlers.clear();
-
-        // Kill Codex process
-        if (codexProcess && !codexProcess.killed) {
-          codexProcess.kill();
-          if (debug) {
-            console.log('[DEBUG] Killed Codex MCP server process');
-          }
-        }
-
-        // Stop Probe MCP server
-        if (mcpServer) {
-          await mcpServer.stop();
-          if (debug) {
-            console.log('[DEBUG] Stopped Probe MCP server');
-          }
-        }
-
-        if (debug) {
-          console.log('[DEBUG] Engine closed, session:', session.id);
-        }
-      } catch (error) {
-        if (debug) {
-          console.error('[DEBUG] Error during cleanup:', error.message);
-        }
-      }
+      await cleanup();
     }
   };
 }

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -10,6 +10,15 @@ import { BuiltInMCPServer } from '../mcp/built-in-server.js';
 import { Session } from '../shared/Session.js';
 import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs, validateGovernedCodexProfile } from './governed-codex-profile.js';
 
+function externalReceipt(attestation) {
+  return {
+    version: attestation.version, profileId: attestation.profileId,
+    requested: { profileDigest: attestation.requested.profileDigest, cwdDigest: attestation.requested.cwdDigest, probeToolsDigest: attestation.requested.probeToolsDigest, model: attestation.requested.model, reasoningEffort: attestation.requested.reasoningEffort, sandbox: attestation.requested.sandbox, approvalPolicy: attestation.requested.approvalPolicy },
+    observed: { source: attestation.observed.source, model: attestation.observed.model, modelProviderId: attestation.observed.modelProviderId, reasoningEffort: attestation.observed.reasoningEffort, approvalPolicy: attestation.observed.approvalPolicy, cwdDigest: attestation.observed.cwdDigest, permissionProfileDigest: attestation.observed.permissionProfileDigest, filesystem: attestation.observed.filesystem, network: attestation.observed.network },
+    evidence: { eventCount: 1 }, usage: { status: 'unavailable' },
+  };
+}
+
 /**
  * Codex Engine using MCP Server with event streaming
  */
@@ -138,18 +147,13 @@ export async function createCodexEngine(options = {}) {
     });
   }
 
-  function rejectPending(error) {
-    for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); }
-    pendingRequests.clear();
-  }
+  function rejectPending(error) { for (const { reject, timer } of pendingRequests.values()) { clearTimeout(timer); reject(error); } pendingRequests.clear(); }
 
   async function cleanup(reason = new Error('Codex engine closed')) {
     if (closePromise) return closePromise;
     closePromise = (async () => {
-      rejectPending(reason);
-      eventHandlers.clear(); governedEvidenceHandler = null;
-      stdoutReader.close();
-      codexProcess.stdin.destroy();
+      rejectPending(reason); eventHandlers.clear(); governedEvidenceHandler = null;
+      stdoutReader.close(); codexProcess.stdin.destroy();
       if (codexProcess.exitCode === null && !codexProcess.killed) codexProcess.kill();
       await processClosed;
       if (mcpServer) await mcpServer.stop();
@@ -188,6 +192,7 @@ export async function createCodexEngine(options = {}) {
 
       const isFollowUp = session.conversationId !== null;
       const toolName = isFollowUp ? 'codex-reply' : 'codex';
+      let abortHandler;
 
       try {
         // Build arguments
@@ -202,9 +207,7 @@ export async function createCodexEngine(options = {}) {
         if (governedProfile) {
           if (governedQueryStarted) throw new Error('Governed Codex engine permits one initial query');
           governedQueryStarted = true;
-          toolArgs = buildGovernedCodexInitialToolArgs({
-            profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl }
-          });
+          toolArgs = buildGovernedCodexInitialToolArgs({ profile: governedProfile, prompt: finalPrompt, mcp: { name: mcpServerName, url: mcpServerUrl } });
         } else if (model) {
           toolArgs.model = model;
         }
@@ -223,9 +226,7 @@ export async function createCodexEngine(options = {}) {
         const reqId = requestId + 1;
         let fullResponse = '';
         let gotSessionId = false;
-        const evidence = [];
-        if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
-        let abortHandler;
+        const evidence = []; if (governedProfile) governedEvidenceHandler = (event) => evidence.push(event);
         if (opts.abortSignal) {
           if (opts.abortSignal.aborted) throw new Error('Codex query cancelled');
           abortHandler = () => cleanup(new Error('Codex query cancelled'));
@@ -266,10 +267,9 @@ export async function createCodexEngine(options = {}) {
 
         // Clean up event handler
         eventHandlers.delete(reqId);
-        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
         let attestation = null;
         if (governedProfile) {
-          attestation = attestGovernedCodexSession({ profile: governedProfile, events: evidence });
+          attestation = externalReceipt(attestGovernedCodexSession({ profile: governedProfile, events: evidence }));
           session.setConversationId(evidence[0].params.msg.session_id);
         }
 
@@ -314,6 +314,7 @@ export async function createCodexEngine(options = {}) {
           error: error
         };
       } finally {
+        if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
         if (governedProfile) await cleanup();
       }
     },

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
 import { createCodexEngine } from '../../src/agent/engines/codex.js';
-import { buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
+import { attestGovernedCodexSession, buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
 
 const TOOLS = ['search', 'extract', 'listFiles'];
 const fakeCodex = `#!/usr/bin/env node
@@ -14,12 +14,12 @@ import { createInterface } from 'node:readline';
 const file = process.env.PROBE_EXP0148_STATE + '/' + process.pid + '.json';
 const seen = []; const save = () => writeFileSync(file, JSON.stringify({ pid: process.pid, seen }));
 const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
-const configured = (requestId, args, patch = {}) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
-  _meta: { requestId, threadId: 'session-' + process.pid }, id: '', msg: {
-    type: 'session_configured', session_id: 'session-' + process.pid, thread_id: 'session-' + process.pid,
+const configured = (requestId, args, patch = {}, identity = process.pid) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
+  _meta: { requestId, threadId: 'session-' + identity }, id: '', msg: {
+    type: 'session_configured', session_id: 'session-' + identity, thread_id: 'session-' + identity,
     model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
     permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' },
-    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(process.pid).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
+    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(identity).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
   }
 }});
 createInterface({ input: process.stdin }).on('line', async line => {
@@ -29,12 +29,15 @@ createInterface({ input: process.stdin }).on('line', async line => {
   if (prompt.includes('[WAIT]')) return;
   if (prompt.includes('[EVENT]')) send({ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, msg: { type: 'raw_response_item', item: { role: 'assistant', content: [{ type: 'text', text: 'event-candidate' }] } } } });
   if (prompt.includes('[DELAY]')) await new Promise(resolve => setTimeout(resolve, 80));
+  if (prompt.includes('[HOLD]')) await new Promise(resolve => setTimeout(resolve, 200));
   let events = [configured(request.id, args)];
   if (prompt.includes('[MISSING]')) events = [];
   if (prompt.includes('[DUPLICATE]')) events.push(events[0]);
   if (prompt.includes('[MALFORMED]')) events = [{ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, id: '', msg: { type: 'session_configured' } } }];
   if (prompt.includes('[UNCORRELATED]')) events = [configured(999, args)];
   if (prompt.includes('[MISMATCHED]')) events = [configured(request.id, args, { model: 'wrong' })];
+  const foreign = /\\[FOREIGN:(\\d+):([^\\]]+)\\]/.exec(prompt);
+  if (foreign) { const cwd = decodeURIComponent(foreign[2]); events = [configured(request.id, { ...args, cwd }, {}, Number(foreign[1]))]; }
   for (const event of events) send(event);
   let text = 'candidate-' + process.pid;
   if (prompt.includes('[FORBIDDEN]')) {
@@ -48,6 +51,17 @@ createInterface({ input: process.stdin }).on('line', async line => {
 
 function profile(cwd) {
   return { version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex', model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never', cwd, probeTools: [...TOOLS], fallback: false, retries: 0 };
+}
+function configuredEvidence(pid, requestId, cwd) {
+  const identity = `session-${pid}`;
+  return { jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId, threadId: identity }, id: '', msg: {
+    type: 'session_configured', session_id: identity, thread_id: identity, model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
+    permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' }, reasoning_effort: 'xhigh',
+    rollout_path: `${cwd}/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-${String(pid).padStart(12, '0')}.jsonl`, cwd
+  } } };
+}
+function recursiveKeys(value, found = []) {
+  if (value && typeof value === 'object') for (const [key, child] of Object.entries(value)) { found.push(key); recursiveKeys(child, found); } return found;
 }
 async function stateFiles(dir) {
   return (await readdir(dir)).filter(name => name.endsWith('.json'));
@@ -124,6 +138,17 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     assert.deepEqual(call.params.arguments, buildGovernedCodexInitialToolArgs({ profile: profile(root), prompt: call.params.arguments.prompt, mcp: { name: server[0], url: server[1].url } }));
     assert.equal(output.filter(item => item.type === 'text').length, 1); assert.match(output[0].content, /^candidate-/);
     const receipt = output.find(item => item.type === 'metadata').data.attestation; const serialized = JSON.stringify(receipt);
+    const internal = attestGovernedCodexSession({ profile: profile(root), events: [configuredEvidence(state.pid, 2, root)] });
+    assert.deepEqual(receipt, {
+      version: 'probe.governed-codex-attestation/v1', profileId: 'luna-xhigh-readonly-v1',
+      requested: { profileDigest: internal.requested.profileDigest, cwdDigest: internal.requested.cwdDigest, probeToolsDigest: internal.requested.probeToolsDigest, model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never' },
+      observed: { source: 'session_configured', model: 'gpt-5.6-luna', modelProviderId: 'openai', reasoningEffort: 'xhigh', approvalPolicy: 'never', cwdDigest: internal.observed.cwdDigest, permissionProfileDigest: internal.observed.permissionProfileDigest, filesystem: 'restricted-read-root', network: 'restricted' },
+      evidence: { eventCount: 1 }, usage: { status: 'unavailable' }
+    });
+    assert.deepEqual(Object.keys(receipt), ['version', 'profileId', 'requested', 'observed', 'evidence', 'usage']);
+    assert.deepEqual(Object.keys(receipt.requested), ['profileDigest', 'cwdDigest', 'probeToolsDigest', 'model', 'reasoningEffort', 'sandbox', 'approvalPolicy']);
+    assert.deepEqual(Object.keys(receipt.observed), ['source', 'model', 'modelProviderId', 'reasoningEffort', 'approvalPolicy', 'cwdDigest', 'permissionProfileDigest', 'filesystem', 'network']);
+    for (const forbidden of ['correlation', 'requestId', 'sessionId', 'threadId', 'conversationId', 'rolloutPath', 'cwd', 'prompt', 'candidate', 'environment']) assert.equal(recursiveKeys(receipt).includes(forbidden), false);
     for (const secret of [root, call.params.arguments.prompt, String(state.pid), 'event-candidate', process.env.PATH]) assert.equal(serialized.includes(secret), false);
     assert.equal(receipt.observed.network, 'restricted'); assert.equal(alive(state.pid), false); assert.equal(await closed(server[1].url), true);
   });
@@ -144,26 +169,33 @@ test('EXP-0148 governed Codex runtime binding', async t => {
   });
 
   await t.test('simultaneous agents keep child, session, and MCP state isolated', async () => {
-    const [a, b] = await Promise.all([runEngine(root, stateDir, '[A]', true), runEngine(root, stateDir, '[B]', true)]);
+    const cwdA = join(root, 'cwd-a'); const cwdB = join(root, 'cwd-b'); await mkdir(cwdA); await mkdir(cwdB);
+    const before = await stateFiles(stateDir); const pendingA = runEngine(cwdA, stateDir, '[A][HOLD]', true);
+    const liveA = await readState(await waitForState(stateDir, before, '[A]'));
+    const [a, b] = await Promise.all([pendingA, runEngine(cwdB, stateDir, `[FOREIGN:${liveA.pid}:${encodeURIComponent(cwdA)}]`, true)]);
     assert.notEqual(a.state.pid, b.state.pid); assert.notEqual(a.url, b.url);
     assert.notEqual(Object.keys(a.call.params.arguments.config.mcp_servers)[0], Object.keys(b.call.params.arguments.config.mcp_servers)[0]);
-    const ra = a.output.find(item => item.type === 'metadata').data.attestation;
-    const rb = b.output.find(item => item.type === 'metadata').data.attestation;
-    assert.deepEqual(ra.requested, rb.requested); assert.equal(alive(a.state.pid) || alive(b.state.pid), false);
+    assert.equal(a.output.filter(item => item.type === 'text').length, 1); assert.equal(a.output.some(item => item.type === 'error'), false);
+    assert.equal(b.output.some(item => item.type === 'text'), false); assert.equal(b.output.filter(item => item.type === 'error').length, 1);
+    assert.equal(alive(a.state.pid) || alive(b.state.pid), false); assert.equal(await closed(a.url), true); assert.equal(await closed(b.url), true);
   });
 
-  await t.test('cancellation and explicit close await child and listener cleanup', async () => {
-    for (const action of ['abort', 'close']) {
-      const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
-      try {
-        const controller = new AbortController(); const iterator = engine.query('[WAIT]', { abortSignal: controller.signal }); const pending = collect(iterator);
-        const file = await waitForState(stateDir, before, '[WAIT]'); const state = await readState(file); const call = state.seen.find(item => item.method === 'tools/call');
-        const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
-        if (action === 'abort') controller.abort(); else await engine.close();
-        const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
-        assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
-      } finally { await engine.close(); }
+  await t.test('public cancel, cleanup, and explicit close await child and listener cleanup', async () => {
+    for (const action of ['cancel', 'cleanup']) {
+      const before = await stateFiles(stateDir); const released = [];
+      const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+      const pending = agent.answer('[WAIT]', [], { onStream: text => released.push(text) }).then(value => ({ value }), error => ({ error }));
+      const state = await readState(await waitForState(stateDir, before, '[WAIT]')); const call = state.seen.find(item => item.method === 'tools/call');
+      const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+      if (action === 'cancel') assert.equal(agent.cancel(), undefined); else { await agent.cleanup(); assert.equal(alive(state.pid), false); assert.equal(await closed(url), true); }
+      const settled = await pending; assert.ok(settled.error); assert.deepEqual(released, []);
+      assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
     }
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+    const pending = collect(engine.query('[WAIT]')); const state = await readState(await waitForState(stateDir, before, '[WAIT]'));
+    const url = Object.values(state.seen.find(item => item.method === 'tools/call').params.arguments.config.mcp_servers)[0].url;
+    await engine.close(); const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
+    assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
   });
 
   await t.test('omitting the profile preserves the ungoverned result path', async () => {

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ProbeAgent } from '../../src/agent/ProbeAgent.js';
+import { createCodexEngine } from '../../src/agent/engines/codex.js';
+import { buildGovernedCodexInitialToolArgs } from '../../src/agent/engines/governed-codex-profile.js';
+
+const TOOLS = ['search', 'extract', 'listFiles'];
+const fakeCodex = `#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline';
+const file = process.env.PROBE_EXP0148_STATE + '/' + process.pid + '.json';
+const seen = []; const save = () => writeFileSync(file, JSON.stringify({ pid: process.pid, seen }));
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const configured = (requestId, args, patch = {}) => ({ jsonrpc: '2.0', method: 'codex/event', params: {
+  _meta: { requestId, threadId: 'session-' + process.pid }, id: '', msg: {
+    type: 'session_configured', session_id: 'session-' + process.pid, thread_id: 'session-' + process.pid,
+    model: 'gpt-5.6-luna', model_provider_id: 'openai', approval_policy: 'never', approvals_reviewer: 'user',
+    permission_profile: { type: 'managed', file_system: { type: 'restricted', entries: [{ access: 'read', path: { type: 'special', value: { kind: 'root' } } }] }, network: 'restricted' },
+    reasoning_effort: 'xhigh', rollout_path: args.cwd + '/sessions/2026/08/26/rollout-2026-08-26T12-00-00-00000000-0000-4000-8000-' + String(process.pid).padStart(12, '0') + '.jsonl', cwd: args.cwd, ...patch
+  }
+}});
+createInterface({ input: process.stdin }).on('line', async line => {
+  const request = JSON.parse(line); seen.push(request); save();
+  if (request.method === 'initialize') return send({ jsonrpc: '2.0', id: request.id, result: {} });
+  const args = request.params.arguments; const prompt = args.prompt;
+  if (prompt.includes('[WAIT]')) return;
+  if (prompt.includes('[EVENT]')) send({ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, msg: { type: 'raw_response_item', item: { role: 'assistant', content: [{ type: 'text', text: 'event-candidate' }] } } } });
+  if (prompt.includes('[DELAY]')) await new Promise(resolve => setTimeout(resolve, 80));
+  let events = [configured(request.id, args)];
+  if (prompt.includes('[MISSING]')) events = [];
+  if (prompt.includes('[DUPLICATE]')) events.push(events[0]);
+  if (prompt.includes('[MALFORMED]')) events = [{ jsonrpc: '2.0', method: 'codex/event', params: { _meta: { requestId: request.id }, id: '', msg: { type: 'session_configured' } } }];
+  if (prompt.includes('[UNCORRELATED]')) events = [configured(999, args)];
+  if (prompt.includes('[MISMATCHED]')) events = [configured(request.id, args, { model: 'wrong' })];
+  for (const event of events) send(event);
+  let text = 'candidate-' + process.pid;
+  if (prompt.includes('[FORBIDDEN]')) {
+    const url = Object.values(args.config.mcp_servers)[0].url.replace('/mcp', '/rpc');
+    const response = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'mcp__probe__bash', arguments: {} } }) });
+    text = (await response.json()).error ? 'host-denied' : 'host-allowed';
+  }
+  send({ jsonrpc: '2.0', id: request.id, result: { content: [{ type: 'text', text }] } });
+});
+`;
+
+function profile(cwd) {
+  return { version: 'probe.governed-codex-profile/v1', profileId: 'luna-xhigh-readonly-v1', engine: 'codex', model: 'gpt-5.6-luna', reasoningEffort: 'xhigh', sandbox: 'read-only', approvalPolicy: 'never', cwd, probeTools: [...TOOLS], fallback: false, retries: 0 };
+}
+async function stateFiles(dir) {
+  return (await readdir(dir)).filter(name => name.endsWith('.json'));
+}
+async function waitForState(dir, before = [], marker = null) {
+  for (let i = 0; i < 100; i++) {
+    const files = (await stateFiles(dir)).filter(name => !before.includes(name));
+    for (const name of files) {
+      const file = join(dir, name);
+      try {
+        const state = await readState(file);
+        if (!marker || state.seen.some(item => item.params?.arguments?.prompt?.includes(marker))) return file;
+      } catch { /* Child may be replacing its state snapshot. */ }
+    }
+    await new Promise(resolve => setTimeout(resolve, 10));
+  }
+  throw new Error('fake Codex state timeout');
+}
+async function readState(file) {
+  return JSON.parse(await readFile(file, 'utf8'));
+}
+async function collect(iterator) {
+  const output = []; for await (const item of iterator) output.push(item); return output;
+}
+function alive(pid) {
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+async function closed(url) {
+  try { await fetch(url.replace('/mcp', '/health'), { signal: AbortSignal.timeout(250) }); return false; } catch { return true; }
+}
+function host() {
+  return { allowedTools: { isEnabled: name => TOOLS.includes(name) }, toolImplementations: Object.fromEntries(TOOLS.map(name => [name, { execute: async () => name }])) };
+}
+async function runEngine(root, stateDir, marker, useProbe = false) {
+  const before = await stateFiles(stateDir); let engine;
+  if (useProbe) {
+    const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+    engine = await agent.getEngine();
+  } else engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+  const output = await collect(engine.query(marker));
+  const state = await readState(await waitForState(stateDir, before, marker));
+  const call = state.seen.find(item => item.method === 'tools/call');
+  const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+  return { engine, output, state, call, url };
+}
+
+test('EXP-0148 governed Codex runtime binding', async t => {
+  const root = await mkdtemp(join(tmpdir(), 'probe-exp0148-'));
+  const bin = join(root, 'bin'); const stateDir = join(root, 'state');
+  await mkdir(bin); await mkdir(stateDir);
+  const executable = join(bin, 'codex'); await writeFile(executable, fakeCodex); await chmod(executable, 0o755);
+  const originalPath = process.env.PATH; process.env.PATH = `${bin}:${originalPath}`; process.env.PROBE_EXP0148_STATE = stateDir;
+  t.after(async () => { process.env.PATH = originalPath; delete process.env.PROBE_EXP0148_STATE; await rm(root, { recursive: true, force: true }); });
+
+  await t.test('rejects non-exact public bindings before spawn', () => {
+    const count = () => stateFiles(stateDir);
+    assert.throws(() => new ProbeAgent({ provider: 'openai', allowedTools: [...TOOLS], governedCodexProfile: profile(root) }), /provider codex/);
+    for (const allowedTools of [undefined, ['*'], ['search', 'listFiles', 'extract'], ['search', 'extract', 'listFiles', 'bash'], ['search', 'extract', 'extract']]) {
+      assert.throws(() => new ProbeAgent({ provider: 'codex', allowedTools, governedCodexProfile: profile(root) }), /exactly match/);
+    }
+    return count().then(files => assert.equal(files.length, 0));
+  });
+
+  await t.test('uses exact C5a request, buffers output, sanitizes receipt, and closes', async () => {
+    const before = await stateFiles(stateDir);
+    const agent = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: profile(root), disableMermaidValidation: true });
+    const engine = await agent.getEngine(); const iterator = engine.query('[EVENT][DELAY]');
+    const first = iterator.next(); assert.equal(await Promise.race([first.then(() => 'released'), new Promise(resolve => setTimeout(() => resolve('buffered'), 30))]), 'buffered');
+    const output = [(await first).value]; for await (const item of iterator) output.push(item);
+    const state = await readState(await waitForState(stateDir, before, '[EVENT]')); const call = state.seen.find(item => item.method === 'tools/call');
+    assert.deepEqual(state.seen[0], { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2024-11-05', capabilities: { tools: {} }, clientInfo: { name: 'probe-codex-client', version: '1.0.0' } } });
+    assert.equal(call.id, 2); assert.equal(call.params.name, 'codex');
+    const server = Object.entries(call.params.arguments.config.mcp_servers)[0];
+    assert.deepEqual(call.params.arguments, buildGovernedCodexInitialToolArgs({ profile: profile(root), prompt: call.params.arguments.prompt, mcp: { name: server[0], url: server[1].url } }));
+    assert.equal(output.filter(item => item.type === 'text').length, 1); assert.match(output[0].content, /^candidate-/);
+    const receipt = output.find(item => item.type === 'metadata').data.attestation; const serialized = JSON.stringify(receipt);
+    for (const secret of [root, call.params.arguments.prompt, String(state.pid), 'event-candidate', process.env.PATH]) assert.equal(serialized.includes(secret), false);
+    assert.equal(receipt.observed.network, 'restricted'); assert.equal(alive(state.pid), false); assert.equal(await closed(server[1].url), true);
+  });
+
+  await t.test('host rejects a non-allowlisted tool', async () => {
+    const run = await runEngine(root, stateDir, '[FORBIDDEN]');
+    assert.equal(run.output.find(item => item.type === 'text').content, 'host-denied');
+    assert.equal(alive(run.state.pid), false); assert.equal(await closed(run.url), true);
+  });
+
+  await t.test('all bad evidence fails closed with zero candidate bytes', async () => {
+    for (const marker of ['[MISSING]', '[DUPLICATE]', '[MALFORMED]', '[UNCORRELATED]', '[MISMATCHED]']) {
+      const run = await runEngine(root, stateDir, marker);
+      assert.equal(run.output.some(item => item.type === 'text'), false, marker);
+      assert.equal(run.output.filter(item => item.type === 'error').length, 1, marker);
+      assert.equal(alive(run.state.pid), false, marker); assert.equal(await closed(run.url), true, marker);
+    }
+  });
+
+  await t.test('simultaneous agents keep child, session, and MCP state isolated', async () => {
+    const [a, b] = await Promise.all([runEngine(root, stateDir, '[A]', true), runEngine(root, stateDir, '[B]', true)]);
+    assert.notEqual(a.state.pid, b.state.pid); assert.notEqual(a.url, b.url);
+    assert.notEqual(Object.keys(a.call.params.arguments.config.mcp_servers)[0], Object.keys(b.call.params.arguments.config.mcp_servers)[0]);
+    const ra = a.output.find(item => item.type === 'metadata').data.attestation;
+    const rb = b.output.find(item => item.type === 'metadata').data.attestation;
+    assert.deepEqual(ra.requested, rb.requested); assert.equal(alive(a.state.pid) || alive(b.state.pid), false);
+  });
+
+  await t.test('cancellation and explicit close await child and listener cleanup', async () => {
+    for (const action of ['abort', 'close']) {
+      const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), governedCodexProfile: profile(root) });
+      try {
+        const controller = new AbortController(); const iterator = engine.query('[WAIT]', { abortSignal: controller.signal }); const pending = collect(iterator);
+        const file = await waitForState(stateDir, before, '[WAIT]'); const state = await readState(file); const call = state.seen.find(item => item.method === 'tools/call');
+        const url = Object.values(call.params.arguments.config.mcp_servers)[0].url;
+        if (action === 'abort') controller.abort(); else await engine.close();
+        const output = await pending; assert.equal(output.some(item => item.type === 'text'), false);
+        assert.equal(alive(state.pid), false); assert.equal(await closed(url), true);
+      } finally { await engine.close(); }
+    }
+  });
+
+  await t.test('omitting the profile preserves the ungoverned result path', async () => {
+    const before = await stateFiles(stateDir); const engine = await createCodexEngine({ agent: host(), model: 'legacy' });
+    const output = await collect(engine.query('[MISSING]')); const state = await readState(await waitForState(stateDir, before, '[MISSING]'));
+    assert.match(output.find(item => item.type === 'text').content, /^candidate-/); assert.equal(alive(state.pid), true);
+    await engine.close(); assert.equal(alive(state.pid), false);
+  });
+});


### PR DESCRIPTION
Stacked PoC on #587. Binds the accepted C5a profile to Probe's existing Codex child JSON-RPC path with exact host-tool enforcement, a fail-closed session attestation barrier, sanitized receipt metadata, and awaited child/MCP cleanup. Offline fake-child tests only; no model, external provider, or external network calls. This does not claim Proof-role execution, Visor orchestration, evidence admission, panel quality, security, or production readiness.