### PR TITLE
fix(agent): classify governed answer failures

### DIFF
--- a/npm/src/agent/ProbeAgent.js
+++ b/npm/src/agent/ProbeAgent.js
@@ -2503,7 +2503,10 @@ export class ProbeAgent {
         }
         return this.engine;
       } catch (error) {
-        if (this.governedCodexProfile) throw error;
+        if (this.governedCodexProfile) {
+          throw normalizeGovernedAnswerFailure(error, 'provider_engine', null, null, null,
+            null, null, 'acquire');
+        }
         console.warn('[WARNING] Failed to load Codex CLI engine:', error.message);
         console.warn('[WARNING] Falling back to Vercel AI SDK');
         this.clientApiProvider = null;
@@ -3530,8 +3533,11 @@ Follow these instructions carefully:
     let engine, answerFailure = null;
     try {
       try { engine = await this.getEngine(); }
-      catch { throw governedAnswerFailure('provider_engine'); }
-      if (!engine?.query) throw governedAnswerFailure('provider_engine');
+      catch (error) {
+        throw normalizeGovernedAnswerFailure(error, 'provider_engine', null, null, null,
+          null, null, 'acquire');
+      }
+      if (!engine?.query) throw governedAnswerFailure('internal_contract');
       const candidateChunks = [];
       let runtimeAttestation;
       let attestationCount = 0;
@@ -3540,31 +3546,47 @@ Follow these instructions carefully:
       const queryOptions = hasInvocationDigest
         ? { abortSignal: this._abortController.signal, invocationDigest: invocationDigest }
         : { abortSignal: this._abortController.signal };
-      for await (const chunk of engine.query(prompt, queryOptions)) {
-        if (chunk.type === 'text' && chunk.content) candidateChunks.push(chunk.content);
-        else if (chunk.type === 'metadata' && chunk.data?.attestation) {
-          runtimeAttestation = chunk.data.attestation;
-          attestationCount++;
-        } else if (chunk.type === 'toolBatch') {
-          nativeToolBatch = chunk;
-          nativeToolBatchCount++;
-        } else if (chunk.type === 'error') throw normalizeGovernedAnswerFailure(chunk.error, 'unknown');
+      try {
+        for await (const chunk of engine.query(prompt, queryOptions)) {
+          if (chunk.type === 'text' && chunk.content) candidateChunks.push(chunk.content);
+          else if (chunk.type === 'metadata' && chunk.data?.attestation) {
+            runtimeAttestation = chunk.data.attestation;
+            attestationCount++;
+          } else if (chunk.type === 'toolBatch') {
+            nativeToolBatch = chunk;
+            nativeToolBatchCount++;
+          } else if (chunk.type === 'error') {
+            throw normalizeGovernedAnswerFailure(chunk.error, 'provider_engine', null, null, null,
+              null, null, 'query');
+          }
+        }
+      } catch (error) {
+        throw normalizeGovernedAnswerFailure(error, 'provider_engine', null, null, null,
+          null, null, 'query');
       }
       if (hasInvocationDigest) {
         const expectedAttestation = this.governedCodexProfile?.version === 'probe.governed-codex-profile/v2'
           ? 'probe.governed-codex-attestation/v3' : 'probe.governed-codex-attestation/v2';
         if (attestationCount !== 1 || runtimeAttestation?.version !== expectedAttestation || runtimeAttestation?.executionContext?.source !== 'caller' || runtimeAttestation?.executionContext?.invocationDigest !== invocationDigest) {
-          throw new Error('Expected exactly one matching governed invocation attestation');
+          throw governedAnswerFailure('native_event_grammar', 'live_envelope_session', 'attestation', null,
+            'invocation_attestation');
         }
-      } else if (attestationCount !== 1) throw new Error(`Expected exactly one governed runtime attestation; received ${attestationCount}`);
+      } else if (attestationCount !== 1) {
+        throw governedAnswerFailure('native_event_grammar', 'live_envelope_session', 'attestation', null,
+          'invocation_attestation');
+      }
       if (this.governedCodexProfile?.version === 'probe.governed-codex-profile/v2') {
         if (nativeToolBatchCount !== 1 || !Number.isSafeInteger(nativeToolBatch?.total) ||
           !Array.isArray(nativeToolBatch?.tools) || nativeToolBatch.total !== runtimeAttestation?.observed?.nativeTools?.total ||
           JSON.stringify(nativeToolBatch.tools) !== JSON.stringify(runtimeAttestation?.observed?.nativeTools?.tools)) {
-          throw new Error('Expected exactly one matching governed native capability aggregate');
+          throw governedAnswerFailure('native_event_grammar', 'live_envelope_session', 'attestation', null,
+            'native_capability_aggregate');
         }
         for (const toolEvent of nativeToolBatch.tools) this.events.emit('toolCall', toolEvent);
-      } else if (nativeToolBatchCount !== 0) throw new Error('Unexpected governed native capability aggregate');
+      } else if (nativeToolBatchCount !== 0) {
+        throw governedAnswerFailure('native_event_grammar', 'live_envelope_session', 'attestation', null,
+          'native_capability_aggregate');
+      }
       const validation = validateJsonResponse(candidateChunks.join(''), {debug:this.debug,schema});
       if (!validation.isValid) throw governedSchemaResultValidationFailure(validation);
       if (hasResultIdentity) {
@@ -3577,12 +3599,15 @@ Follow these instructions carefully:
       }
       return { data: validation.parsed, runtimeAttestation };
     } catch (error) {
-      answerFailure = normalizeGovernedAnswerFailure(error, 'unknown');
+      answerFailure = normalizeGovernedAnswerFailure(error, 'internal_contract');
       throw answerFailure;
     } finally {
       if (engine) {
         try { await engine.close(); }
-        catch { if (!answerFailure) throw governedAnswerFailure('unknown'); }
+        catch (error) {
+          if (!answerFailure) throw normalizeGovernedAnswerFailure(error, 'provider_engine', null, null, null,
+            null, null, 'close');
+        }
       }
     }
   }

--- a/npm/src/agent/engines/codex.js
+++ b/npm/src/agent/engines/codex.js
@@ -461,7 +461,11 @@ export async function createCodexEngine(options = {}) {
           try { collector.observe(event); } catch (error) { evidenceFailure ??= normalizeGovernedAnswerFailure(error, 'native_event_grammar'); }
         });
         if (opts.abortSignal) {
-          if (opts.abortSignal.aborted) throw new Error('Codex query cancelled');
+          if (opts.abortSignal.aborted) {
+            throw governedProfile
+              ? governedAnswerFailure('provider_engine', null, null, null, null, null, null, 'query')
+              : new Error('Codex query cancelled');
+          }
           abortHandler = () => { void cleanup(new Error('Codex query cancelled')).catch(() => {}); };
           opts.abortSignal.addEventListener('abort', abortHandler, { once: true });
         }
@@ -501,7 +505,8 @@ export async function createCodexEngine(options = {}) {
         try { result = await resultPromise; }
         catch (error) {
           throw governedProfile
-            ? governedAnswerFailure(evidenceFailure ? 'unknown' : 'provider_engine')
+            ? evidenceFailure || normalizeGovernedAnswerFailure(error, 'provider_engine', null, null, null,
+              null, null, 'query')
             : error;
         }
 
@@ -521,20 +526,31 @@ export async function createCodexEngine(options = {}) {
             internal = attestGovernedCodexSession({ profile: governedProfile,
               events: governedProfile.version === 'probe.governed-codex-profile/v2'
                 ? [collected.sessionEvent, collected.capabilities.nativeTools] : [collected.sessionEvent] });
+          } catch (error) {
+            throw normalizeGovernedAnswerFailure(error, 'native_event_grammar', 'live_envelope_session',
+              'attestation');
+          }
+          try {
             probeMcpCallCount = governedProfile.version === 'probe.governed-codex-profile/v2'
               ? governedProbeMcpCallCount(mcpServer?.getGovernedCallEvidence()) : 0;
           } catch (error) {
-            throw normalizeGovernedAnswerFailure(error, 'native_event_grammar', 'live_envelope_session', 'attestation');
+            throw normalizeGovernedAnswerFailure(error, 'native_event_grammar', 'live_envelope_session',
+              'attestation', null, null, null, null, 'native_capability_aggregate');
           }
-          attestation = hasInvocationDigest
-            ? externalBoundReceipt(internal, dispatch, invocationDigest, {
-              nativeCallCount: collected.capabilities.nativeTools.total,
-              probeMcpCallCount,
-            })
-            : externalReceipt(internal, {
-              nativeCallCount: collected.capabilities.nativeTools.total,
-              probeMcpCallCount,
-            });
+          try {
+            attestation = hasInvocationDigest
+              ? externalBoundReceipt(internal, dispatch, invocationDigest, {
+                nativeCallCount: collected.capabilities.nativeTools.total,
+                probeMcpCallCount,
+              })
+              : externalReceipt(internal, {
+                nativeCallCount: collected.capabilities.nativeTools.total,
+                probeMcpCallCount,
+              });
+          } catch (error) {
+            throw normalizeGovernedAnswerFailure(error, 'native_event_grammar', 'live_envelope_session',
+              'attestation', null, null, null, null, 'invocation_attestation');
+          }
           session.setConversationId(collected.sessionEvent.params.msg.session_id);
         }
 
@@ -576,7 +592,7 @@ export async function createCodexEngine(options = {}) {
         };
 
       } catch (error) {
-        if (governedProfile) error = normalizeGovernedAnswerFailure(error, 'unknown');
+        if (governedProfile) error = normalizeGovernedAnswerFailure(error, 'internal_contract');
         queryError = error;
         if (debug) {
           console.error('[DEBUG] Codex query error:', error);
@@ -589,7 +605,10 @@ export async function createCodexEngine(options = {}) {
         if (opts.abortSignal && abortHandler) opts.abortSignal.removeEventListener('abort', abortHandler);
         if (governedProfile) {
           try { await cleanup(); }
-          catch (cleanupError) { if (!queryError) throw cleanupError; }
+          catch (cleanupError) {
+            if (!queryError) throw normalizeGovernedAnswerFailure(cleanupError, 'provider_engine', null, null,
+              null, null, null, 'close');
+          }
         }
       }
     },

--- a/npm/src/agent/engines/governed-answer-failure.js
+++ b/npm/src/agent/engines/governed-answer-failure.js
@@ -1,6 +1,7 @@
 const GOVERNED_ANSWER_FAILURE_STAGES = new Set([
-  'native_event_grammar', 'provider_engine', 'schema_result_validation', 'unknown',
+  'native_event_grammar', 'provider_engine', 'schema_result_validation', 'internal_contract', 'unknown',
 ]);
+const GOVERNED_PROVIDER_ENGINE_FAILURE_BOUNDARIES = new Set(['acquire', 'query', 'close']);
 const GOVERNED_NATIVE_EVENT_FAILURE_BOUNDARIES = new Set([
   'raw_item_predicate', 'live_envelope_session',
 ]);
@@ -17,6 +18,7 @@ const GOVERNED_NATIVE_EVENT_FAILURE_ATTESTATION_PREDICATES = new Set([
   'network',
   'filesystem_shape', 'filesystem_type', 'entries', 'entry', 'access', 'path_shape',
   'path_type', 'value_shape', 'kind', 'native_tool_evidence', 'internal_contract',
+  'invocation_attestation', 'native_capability_aggregate',
 ]);
 const GOVERNED_SCHEMA_RESULT_VALIDATION_SUBREASONS = new Set([
   'response_json', 'schema_definition', 'schema_mismatch', 'result_identity',
@@ -73,13 +75,19 @@ function governedAttestationPredicate(error) {
 export class GovernedAnswerFailure extends Error {
   constructor(stage, nativeEventFailureBoundary = null, nativeEventFailureSubreason = null,
     nativeEventFailureCorrelationOperand = null, nativeEventFailureAttestationPredicate = null,
-    schemaResultValidationSubreason = null, schemaResultValidationKeyword = null) {
+    schemaResultValidationSubreason = null, schemaResultValidationKeyword = null,
+    providerEngineFailureBoundary = null) {
     super();
     delete this.stack;
     const answerFailureStage = GOVERNED_ANSWER_FAILURE_STAGES.has(stage) ? stage : 'unknown';
     Object.defineProperty(this, 'name', { value: 'GovernedAnswerFailure' });
     Object.defineProperty(this, 'answerFailureStage', {
       value: answerFailureStage,
+      enumerable: true,
+    });
+    if (answerFailureStage === 'provider_engine') Object.defineProperty(this, 'providerEngineFailureBoundary', {
+      value: GOVERNED_PROVIDER_ENGINE_FAILURE_BOUNDARIES.has(providerEngineFailureBoundary)
+        ? providerEngineFailureBoundary : null,
       enumerable: true,
     });
     if (answerFailureStage === 'native_event_grammar') Object.defineProperty(this, 'nativeEventFailureBoundary', {
@@ -134,19 +142,22 @@ export class GovernedAnswerFailure extends Error {
 
 export function governedAnswerFailure(stage, nativeEventFailureBoundary = null, nativeEventFailureSubreason = null,
   nativeEventFailureCorrelationOperand = null, nativeEventFailureAttestationPredicate = null,
-  schemaResultValidationSubreason = null, schemaResultValidationKeyword = null) {
+  schemaResultValidationSubreason = null, schemaResultValidationKeyword = null,
+  providerEngineFailureBoundary = null) {
   return new GovernedAnswerFailure(stage, nativeEventFailureBoundary, nativeEventFailureSubreason,
     nativeEventFailureCorrelationOperand, nativeEventFailureAttestationPredicate,
-    schemaResultValidationSubreason, schemaResultValidationKeyword);
+    schemaResultValidationSubreason, schemaResultValidationKeyword, providerEngineFailureBoundary);
 }
 
 export function normalizeGovernedAnswerFailure(error, fallback = 'unknown', nativeEventFailureBoundary = null,
   nativeEventFailureSubreason = null, nativeEventFailureCorrelationOperand = null,
-  schemaResultValidationSubreason = null, schemaResultValidationKeyword = null) {
+  schemaResultValidationSubreason = null, schemaResultValidationKeyword = null,
+  providerEngineFailureBoundary = null, nativeEventFailureAttestationPredicate = null) {
   return error instanceof GovernedAnswerFailure ? error
     : governedAnswerFailure(fallback, nativeEventFailureBoundary, nativeEventFailureSubreason,
       nativeEventFailureCorrelationOperand,
       fallback === 'native_event_grammar' && nativeEventFailureBoundary === 'live_envelope_session' &&
-        nativeEventFailureSubreason === 'attestation' ? governedAttestationPredicate(error) : null,
-      schemaResultValidationSubreason, schemaResultValidationKeyword);
+        nativeEventFailureSubreason === 'attestation'
+        ? nativeEventFailureAttestationPredicate ?? governedAttestationPredicate(error) : null,
+      schemaResultValidationSubreason, schemaResultValidationKeyword, providerEngineFailureBoundary);
 }

--- a/npm/tests/unit/governed-codex-native-capability.phase-a.test.mjs
+++ b/npm/tests/unit/governed-codex-native-capability.phase-a.test.mjs
@@ -31,7 +31,8 @@ const native = (index = 0, patch = {}) => ({ jsonrpc: '2.0', method: 'codex/even
     internal_chat_message_metadata_passthrough: { turn_id: 'raw-secret-turn' }, ...patch }
 }, id: '2' } });
 function assertFailure(result, stage, boundary = null, subreason = null, correlationOperand = null,
-  attestationPredicate = null, schemaSubreason = null, schemaKeyword = null) {
+  attestationPredicate = null, schemaSubreason = null, schemaKeyword = null,
+  providerEngineFailureBoundary = undefined) {
   assert.equal(result.result, undefined);
   assert.equal(result.error?.name, 'GovernedAnswerFailure');
   assert.equal(result.error?.message, '');
@@ -65,6 +66,15 @@ function assertFailure(result, stage, boundary = null, subreason = null, correla
   }
   assert.equal(result.error?.stack, undefined);
   assert.equal(Object.hasOwn(result.error ?? {}, 'cause'), false);
+  assert.equal(Object.isFrozen(result.error), true);
+  assert.deepEqual(Object.getOwnPropertySymbols(result.error), []);
+  for (const forbidden of ['raw', 'raw_output', 'prompt', 'output'])
+    assert.equal(Object.hasOwn(result.error ?? {}, forbidden), false);
+  if (stage === 'provider_engine') {
+    assert.equal(Object.hasOwn(result.error ?? {}, 'providerEngineFailureBoundary'), true);
+    if (providerEngineFailureBoundary !== undefined)
+      assert.equal(result.error?.providerEngineFailureBoundary, providerEngineFailureBoundary);
+  } else assert.equal(Object.hasOwn(result.error ?? {}, 'providerEngineFailureBoundary'), false);
   const serialized = JSON.stringify(result.error);
   for (const forbidden of ['SECRET_', 'raw-secret', 'Error:', 'at file:']) assert.equal(serialized.includes(forbidden), false);
 }
@@ -147,7 +157,7 @@ test('Phase A profile attests only a bounded disjoint native capability aggregat
     assert.equal((source.match(/governedLiveEnvelopeInvalid\('correlation'\)/g) ?? []).length, 1);
     assert.equal((source.match(/governedLiveEnvelopeInvalid\('correlation', 'thread_id'\)/g) ?? []).length, 1);
     assert.equal((source.match(/governedLiveEnvelopeInvalid\('correlation', 'response_id'\)/g) ?? []).length, 0);
-    assert.equal((source.match(/'attestation'/g) ?? []).length, 1);
+    assert.equal((source.match(/'attestation'/g) ?? []).length, 3);
     assert.equal((source.match(/governedLiveEnvelopeInvalid\(\)/g) ?? []).length, 0);
   } finally { await rm(cwd, { recursive: true, force: true }); }
 });
@@ -585,8 +595,8 @@ createInterface({ input: process.stdin }).on('line', async line => {
       '[DELTA-OUTPUT-DUP-ID]', '[COMMENTARY-ONLY]', '[DOUBLE-FINAL]', '[PHASE-UNKNOWN]', '[OVERFLOW-MESSAGES]'])
       assertFailure(await run(marker), 'native_event_grammar', 'raw_item_predicate');
 
-    assertFailure(await run('[PROVIDER-ERROR]'), 'provider_engine');
-    assertFailure(await run('[AMBIGUOUS]'), 'unknown');
+    assertFailure(await run('[PROVIDER-ERROR]'), 'provider_engine', null, null, null, null, null, null, 'query');
+    assertFailure(await run('[AMBIGUOUS]'), 'native_event_grammar', 'raw_item_predicate');
     assert.equal(governedAnswerFailure('native_event_grammar').nativeEventFailureBoundary, null);
     assert.equal(governedAnswerFailure('native_event_grammar', ['raw_item_predicate', 'live_envelope_session'])
       .nativeEventFailureBoundary, null);
@@ -806,12 +816,35 @@ createInterface({ input: process.stdin }).on('line', async line => {
     for (const subreason of ['response_json', 'schema_definition', 'result_identity'])
       assert.equal(governedAnswerFailure('schema_result_validation', null, null, null, null, subreason,
         'required').schemaResultValidationKeyword, null);
-    for (const stage of ['native_event_grammar', 'provider_engine', 'unknown']) {
+    for (const stage of ['native_event_grammar', 'provider_engine', 'internal_contract', 'unknown']) {
       assert.equal(Object.hasOwn(governedAnswerFailure(stage, null, null, null, null, 'response_json'),
         'schemaResultValidationSubreason'), false);
       assert.equal(Object.hasOwn(governedAnswerFailure(stage, null, null, null, null, 'schema_mismatch', 'required'),
         'schemaResultValidationKeyword'), false);
     }
+    for (const predicate of ['invocation_attestation', 'native_capability_aggregate']) {
+      const failure = governedAnswerFailure('native_event_grammar', 'live_envelope_session', 'attestation', null, predicate);
+      assert.equal(failure.answerFailureStage, 'native_event_grammar');
+      assert.equal(failure.nativeEventFailureAttestationPredicate, predicate);
+      assert.deepEqual(Object.keys(failure), ['answerFailureStage', 'nativeEventFailureBoundary',
+        'nativeEventFailureSubreason', 'nativeEventFailureAttestationPredicate']);
+      assert.equal(Object.isFrozen(failure), true);
+      assert.equal(failure.message, ''); assert.equal(failure.stack, undefined);
+      assert.equal(Object.hasOwn(failure, 'cause'), false);
+      assert.deepEqual(Object.getOwnPropertySymbols(failure), []);
+    }
+    for (const boundary of ['acquire', 'query', 'close']) {
+      const failure = governedAnswerFailure('provider_engine', null, null, null, null, null, null, boundary);
+      assert.equal(failure.providerEngineFailureBoundary, boundary);
+      assert.deepEqual(Object.keys(failure), ['answerFailureStage', 'providerEngineFailureBoundary']);
+    }
+    for (const boundary of [null, 'acquire|query', 'future-boundary', ['acquire'], 'SECRET_acquire']) {
+      const failure = governedAnswerFailure('provider_engine', null, null, null, null, null, null, boundary);
+      assert.equal(failure.providerEngineFailureBoundary, null);
+      assert.deepEqual(Object.keys(failure), ['answerFailureStage', 'providerEngineFailureBoundary']);
+    }
+    const nonProvider = governedAnswerFailure('native_event_grammar', 'acquire');
+    assert.equal(Object.hasOwn(nonProvider, 'providerEngineFailureBoundary'), false);
     const schemaFailureSource = await readFile(new URL('../../src/agent/engines/governed-answer-failure.js',
       import.meta.url), 'utf8');
     assert.equal((schemaFailureSource.match(/Object\.defineProperty\(this, 'schemaResultValidationSubreason'/g) ?? []).length, 1);
@@ -831,6 +864,11 @@ createInterface({ input: process.stdin }).on('line', async line => {
     assert.equal(normalizeGovernedAnswerFailure(new Error('SECRET_NORMALIZE_BODY'),
       'schema_result_validation').schemaResultValidationSubreason, null);
     const agentSource = await readFile(new URL('../../src/agent/ProbeAgent.js', import.meta.url), 'utf8');
+    const codexSource = await readFile(new URL('../../src/agent/engines/codex.js', import.meta.url), 'utf8');
+    for (const source of [agentSource, codexSource]) {
+      const normalizedCalls = [...source.matchAll(/normalizeGovernedAnswerFailure\(([^)]*)\)/gs)];
+      assert.equal(normalizedCalls.some(([, args]) => /['"]unknown['"]/.test(args)), false);
+    }
     const classifierStart = agentSource.indexOf('function classifyGovernedSchemaResultValidationKeyword');
     const classifierEnd = agentSource.indexOf('\n}\n\n// Maximum tool iterations', classifierStart) + 2;
     const classifierSource = agentSource.slice(classifierStart, classifierEnd);

--- a/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
+++ b/npm/tests/unit/governed-codex-runtime-binding.exp-0148.test.js
@@ -182,10 +182,18 @@ function expectedResultIdentity(canonical) {
 function assertDeepFrozen(value) {
   if (!value || typeof value !== 'object') return; assert.equal(Object.isFrozen(value), true); for (const child of Object.values(value)) assertDeepFrozen(child);
 }
-function assertFailureStage(error, answerFailureStage) {
+function assertFailureStage(error, answerFailureStage, nativeEventFailureBoundary = undefined,
+  nativeEventFailureSubreason = undefined, nativeEventFailureAttestationPredicate = undefined) {
   assert.equal(error?.name, 'GovernedAnswerFailure'); assert.equal(error?.message, '');
   assert.equal(error?.answerFailureStage, answerFailureStage); assert.equal(error?.stack, undefined); assert.equal(Object.hasOwn(error ?? {}, 'cause'), false);
+  assert.equal(Object.isFrozen(error), true); assert.deepEqual(Object.getOwnPropertySymbols(error), []);
+  for (const forbidden of ['raw', 'raw_output', 'prompt', 'output']) assert.equal(Object.hasOwn(error ?? {}, forbidden), false);
   assert.equal(Object.hasOwn(error ?? {}, 'nativeEventFailureCorrelationOperand'), false);
+  if (nativeEventFailureBoundary !== undefined) {
+    assert.equal(error.nativeEventFailureBoundary, nativeEventFailureBoundary);
+    assert.equal(error.nativeEventFailureSubreason, nativeEventFailureSubreason);
+    assert.equal(error.nativeEventFailureAttestationPredicate, nativeEventFailureAttestationPredicate);
+  }
 }
 
 test('EXP-0148 governed Codex runtime binding', async t => {
@@ -311,7 +319,8 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     for (const copies of [0, 2]) {
       const agent = governedAgent(root); let closeCount = 0; let queryCount = 0;
       agent.engine = { async *query() { queryCount++; yield { type: 'text', content: JSON.stringify(LINEAGE) }; for (let i = 0; i < copies; i++) yield { type: 'metadata', data: { attestation: governedValid.settled.value.runtimeAttestation } }; }, async close() { closeCount++; } };
-      const error = await agent.answerGoverned('[INJECTED]', { schema: LINEAGE_SCHEMA }).then(() => null, caught => caught); assertFailureStage(error, 'unknown');
+      const error = await agent.answerGoverned('[INJECTED]', { schema: LINEAGE_SCHEMA }).then(() => null, caught => caught); assertFailureStage(error,
+        'native_event_grammar', 'live_envelope_session', 'attestation', 'invocation_attestation');
       assert.equal(queryCount, 1); assert.equal(closeCount, 1);
     }
   });
@@ -432,6 +441,50 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     assert.deepEqual(receipt.evidence, { eventCount: 1 }); assert.deepEqual(receipt.usage, { status: 'unavailable' });
   });
 
+  await t.test('EXP-0210 closes acquire/query/close, contract, attestation, and aggregate boundaries', async () => {
+    const settle = (agent, options = { schema: LINEAGE_SCHEMA }) => agent.answerGoverned('[INJECTED]', options).then(value => ({ value }), error => ({ error }));
+    const queryEngine = (query, close = async () => {}) => ({ query, close });
+    const acquire = governedAgent(root); acquire.getEngine = async () => { throw new Error('SECRET_ACQUIRE'); };
+    const acquireFailure = (await settle(acquire)).error; assertFailureStage(acquireFailure, 'provider_engine');
+    assert.equal(acquireFailure.providerEngineFailureBoundary, 'acquire');
+
+    const query = governedAgent(root); query.engine = queryEngine(async function* () { throw new Error('SECRET_QUERY'); });
+    const queryFailure = (await settle(query)).error; assertFailureStage(queryFailure, 'provider_engine');
+    assert.equal(queryFailure.providerEngineFailureBoundary, 'query');
+
+    const closing = governedAgent(root); closing.engine = queryEngine(async function* () {
+      yield { type: 'text', content: JSON.stringify(LINEAGE) };
+      yield { type: 'metadata', data: { attestation: governedValid.settled.value.runtimeAttestation } };
+    }, async () => { throw new Error('SECRET_CLOSE'); });
+    const closeFailure = (await settle(closing)).error; assertFailureStage(closeFailure, 'provider_engine');
+    assert.equal(closeFailure.providerEngineFailureBoundary, 'close');
+
+    const contract = governedAgent(root); contract.engine = { close: async () => {} };
+    assertFailureStage((await settle(contract)).error, 'internal_contract');
+
+    const attestation = governedAgent(root); const wrongReceipt = structuredClone(boundValid.settled.value.runtimeAttestation);
+    wrongReceipt.executionContext.invocationDigest = DIGEST_B;
+    attestation.engine = queryEngine(async function* () {
+      yield { type: 'text', content: JSON.stringify(LINEAGE) };
+      yield { type: 'metadata', data: { attestation: wrongReceipt } };
+    });
+    assertFailureStage((await settle(attestation, { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A })).error,
+      'native_event_grammar', 'live_envelope_session', 'attestation', 'invocation_attestation');
+
+    const v2Profile = { ...profile(root), version: 'probe.governed-codex-profile/v2', profileId: 'luna-xhigh-readonly-native-exec-v1', probeMcpTools: [...TOOLS], codexNativeTools: ['exec'] };
+    delete v2Profile.probeTools;
+    const aggregateReceipt = attestGovernedCodexSession({ profile: v2Profile,
+      events: [configuredEvidence(777, 2, root), { total: 0, tools: [] }] });
+    const aggregate = new ProbeAgent({ provider: 'codex', path: root, cwd: root, allowedTools: [...TOOLS], governedCodexProfile: v2Profile, disableMermaidValidation: true });
+    aggregate.engine = queryEngine(async function* () {
+      yield { type: 'text', content: JSON.stringify(LINEAGE) };
+      yield { type: 'metadata', data: { attestation: aggregateReceipt } };
+      yield { type: 'toolBatch', total: 1, tools: [] };
+    });
+    assertFailureStage((await settle(aggregate)).error, 'native_event_grammar', 'live_envelope_session',
+      'attestation', 'native_capability_aggregate');
+  });
+
   await t.test('EXP-0151 O03 independently recomputes prompt digest and byte length', () => {
     assert.deepEqual(boundValid.settled.value.runtimeAttestation.dispatch, dispatchFor(boundValid.call.params.arguments.prompt));
   });
@@ -473,7 +526,8 @@ test('EXP-0148 governed Codex runtime binding', async t => {
     for (const receipts of cases) {
       const agent = governedAgent(root); let closeCount = 0;
       agent.engine = { async *query() { yield { type: 'text', content: JSON.stringify(LINEAGE) }; for (const attestation of receipts) yield { type: 'metadata', data: { attestation } }; }, async close() { closeCount++; } };
-      const error = await agent.answerGoverned('[INJECTED-V2]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }).then(() => null, caught => caught); assertFailureStage(error, 'unknown'); assert.equal(closeCount, 1);
+      const error = await agent.answerGoverned('[INJECTED-V2]', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A }).then(() => null, caught => caught); assertFailureStage(error,
+        'native_event_grammar', 'live_envelope_session', 'attestation', 'invocation_attestation'); assert.equal(closeCount, 1);
     }
   });
 
@@ -659,7 +713,8 @@ agent.answerGoverned('x', { schema, resultIdentity: 'probe.governed-result-ident
 
   await t.test('EXP-0152 T11 receipt and schema failures emit no identity and clean once', async () => {
     const mismatch = governedAgent(root); const wrong = structuredClone(boundValid.settled.value.runtimeAttestation); wrong.executionContext.invocationDigest = DIGEST_B; const mismatchState = installIdentifiedEngine(mismatch, wrong, '{');
-    const mismatchSettled = await mismatch.answerGoverned('mismatch', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }).then(value => ({ value }), error => ({ error })); assert.equal('value' in mismatchSettled, false); assertFailureStage(mismatchSettled.error, 'unknown'); assert.deepEqual([mismatchState.queries, mismatchState.closes], [1, 1]);
+    const mismatchSettled = await mismatch.answerGoverned('mismatch', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }).then(value => ({ value }), error => ({ error })); assert.equal('value' in mismatchSettled, false); assertFailureStage(mismatchSettled.error,
+      'native_event_grammar', 'live_envelope_session', 'attestation', 'invocation_attestation'); assert.deepEqual([mismatchState.queries, mismatchState.closes], [1, 1]);
     const invalid = governedAgent(root); const invalidState = installIdentifiedEngine(invalid, boundValid.settled.value.runtimeAttestation, '{'); const invalidSettled = await invalid.answerGoverned('invalid', { schema: LINEAGE_SCHEMA, invocationDigest: DIGEST_A, resultIdentity: RESULT_IDENTITY }).then(value => ({ value }), error => ({ error })); assert.equal('value' in invalidSettled, false); assertFailureStage(invalidSettled.error, 'schema_result_validation'); assert.deepEqual([invalidState.queries, invalidState.closes], [1, 1]);
   });
 
@@ -682,7 +737,7 @@ agent.answerGoverned('x', { schema, resultIdentity: 'probe.governed-result-ident
 
   await t.test('EXP-0152 T15 frozen files and legacy function/declaration regions remain exact', async () => {
     const sha = value => createHash('sha256').update(value).digest('hex'); const read = path => readFile(new URL(path, import.meta.url), 'utf8');
-    assert.equal(sha(await read('../../src/agent/engines/codex.js')), 'ffc0f977018cf8baa685265a4a1e5fdc12c8a5adbd4021ff7cb539cb622808ee'); assert.equal(sha(await read('../../src/agent/schemaUtils.js')), '24332877e019ef29311f03ce9b63e61925c25fd7f83f5dd442b22dc68c60f6e9'); assert.equal(sha(await read('../../src/agent/engines/governed-codex-profile.js')), '003cf97adbd0d9212e2d2fadaa14881d50fd1d25a51ae5deff6e927997440db9');
+    assert.equal(sha(await read('../../src/agent/engines/codex.js')), '46f495f5783f7e9e4e90481b25d12011a9429d9669777cad1eabff6e12048df9'); assert.equal(sha(await read('../../src/agent/schemaUtils.js')), '24332877e019ef29311f03ce9b63e61925c25fd7f83f5dd442b22dc68c60f6e9'); assert.equal(sha(await read('../../src/agent/engines/governed-codex-profile.js')), '003cf97adbd0d9212e2d2fadaa14881d50fd1d25a51ae5deff6e927997440db9');
     const source = await read('../../src/agent/ProbeAgent.js'); const answer = source.slice(source.indexOf('  async answer(message'), source.indexOf('  /**\n   * Get token usage information', source.indexOf('  async answer(message'))); assert.equal(sha(answer), '53ee9f207963f5b991aaf89e143211039ad632d9cc7535d91af66bcae95b135f');
     const governed = source.slice(source.indexOf('  async answerGoverned(message'), source.indexOf('\n  /**\n   * Answer a question', source.indexOf('  async answerGoverned(message'))); assert.equal((governed.match(/_prepareGovernedAnswerPrompt\(/g) || []).length, 1); assert.equal((governed.match(/options\.schema/g) || []).length, 0); assert.equal((governed.match(/options\.resultIdentity/g) || []).length, 1); assert.equal((governed.match(/validateJsonResponse\(/g) || []).length, 1); assert.match(governed, /return \{ data: validation\.parsed, runtimeAttestation \};/);
     const prepared = source.slice(source.indexOf('  _prepareGovernedAnswerPrompt'), source.indexOf('\n  /**\n   * Preview', source.indexOf('  _prepareGovernedAnswerPrompt'))); assert.equal((prepared.match(/options\.schema/g) || []).length, 1); assert.equal((prepared.match(/generateSchemaInstructions\(/g) || []).length, 1);


### PR DESCRIPTION
## Outcome

Governed answer failures now report a closed, privacy-safe diagnostic boundary instead of collapsing supported runtime failures to unknown.

## Contract

- provider_engine keeps its compatible top-level stage and adds acquire, query, or close
- native attestation preserves existing precise predicates and adds invocation_attestation and native_capability_aggregate
- schema validation taxonomy is unchanged
- remaining governed invariant fallthrough is internal_contract
- evidence failure wins over a simultaneous provider rejection
- prior primary failure wins over cleanup failure
- error projections remain frozen and omit raw messages, stacks, causes, prompts, and outputs

## Validation

- node syntax checks for all three production files
- focused governed Codex suites: 54/54 passed
- source census: no production governed normalization fallback to unknown
- git diff --check passed
- independent Sol xhigh review: ACCEPT

This PR is the smallest Probe-side fix required by the retained EXP-0210 onboarding diagnostic. It makes the next run actionable without making another model call merely to rediscover an opaque unknown failure.